### PR TITLE
Instruct the specfile to only create the RPM package for the agent binary

### DIFF
--- a/packaging/suse/_service
+++ b/packaging/suse/_service
@@ -5,9 +5,6 @@
         <param name="revision">%%REVISION%%</param>
         <param name="exclude">.git</param>
         <param name="exclude">.github</param>
-        <param name="extract">web/frontend/package.json</param>
-        <param name="extract">web/frontend/package-lock.json</param>
-        <param name="exclude">web/frontend/package-lock.json</param>
         <param name="versionformat">%%VERSION%%</param>
         <param name="filename">trento</param>
     </service>
@@ -17,11 +14,6 @@
     <service name="recompress" mode="disabled">
         <param name="file">*.tar</param>
         <param name="compression">gz</param>
-    </service>
-    <service name="node_modules" mode="disabled">
-        <param name="cpio">node_modules.obscpio</param>
-        <param name="output">node_modules.spec.inc</param>
-        <param name="source-offset">10000</param>
     </service>
     <service name="go_modules" mode="disabled" />
 </services>

--- a/packaging/suse/trento.spec
+++ b/packaging/suse/trento.spec
@@ -26,15 +26,10 @@ Group:          System/Monitoring
 URL:            https://github.com/trento-project/trento
 Source:         %{name}-%{version}.tar.gz
 Source1:        vendor.tar.gz
-Source2:        node_modules.spec.inc
-Source3:        package.json
-%include        %_sourcedir/node_modules.spec.inc
 ExclusiveArch:  aarch64 x86_64 ppc64le s390x
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildRequires:  golang-packaging
 BuildRequires:  golang(API) = 1.16
-BuildRequires:  npm
-BuildRequires:  local-npm-registry
 Requires:       golang-github-prometheus-node_exporter
 Provides:       %{name} = %{version}-%{release}
 
@@ -52,20 +47,16 @@ applications.
 %setup -q            # unpack project sources
 %setup -q -T -D -a 1 # unpack go dependencies in vendor.tar.gz, which was prepared by the source services
 
-cp %SOURCE3 .
-local-npm-registry %{_sourcedir} install --with=dev
-
-%define shortname trento
+%define binaryname trento-agent
+%define shortname agent
 
 %build
-
-mv node_modules web/frontend/
 VERSION=%{version} make build
 
 %install
 
 # Install the binary.
-install -D -m 0755 %{shortname} "%{buildroot}%{_bindir}/%{shortname}"
+install -D -m 0755 %{shortname} "%{buildroot}%{_bindir}/%{binaryname}"
 
 # Install the systemd unit
 install -D -m 0644 packaging/systemd/trento-agent.service %{buildroot}%{_unitdir}/trento-agent.service
@@ -94,8 +85,8 @@ install -D -m 0640 packaging/config/agent.yaml %{buildroot}%{_sysconfdir}/trento
 %doc *.md
 %doc docs/*.md
 %license LICENSE
-%{_bindir}/%{shortname}
-%{_unitdir}/trento-agent.service
+%{_bindir}/%{binaryname}
+%{_unitdir}/%{binaryname}.service
 
 %if 0%{?suse_version} > 1500
 %dir %_distconfdir/trento

--- a/packaging/suse/trento.spec
+++ b/packaging/suse/trento.spec
@@ -32,6 +32,8 @@ BuildRequires:  golang-packaging
 BuildRequires:  golang(API) = 1.16
 Requires:       golang-github-prometheus-node_exporter
 Provides:       %{name} = %{version}-%{release}
+Provides:       trento = %{version}-%{release}
+Obsoletes:      trento < %{version}-%{release}
 
 %{go_nostrip}
 

--- a/packaging/systemd/trento-agent.service
+++ b/packaging/systemd/trento-agent.service
@@ -4,7 +4,7 @@ Requires=prometheus-node_exporter.service
 After=prometheus-node_exporter.service
 
 [Service]
-ExecStart=/usr/bin/trento agent start
+ExecStart=/usr/bin/trento-agent start
 Type=simple
 User=root
 Restart=on-failure


### PR DESCRIPTION
As above, we are just shipping the binary inside the RPM now, therefore we need less and less stuff. 

No node_modules needed anymore.