### PR TITLE
Publish csp information of a discovered pacemaker cluster

### DIFF
--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/trento-project/agent/internal/cloud"
 	// These packages were originally imported from github.com/ClusterLabs/ha_cluster_exporter/collector/pacemaker
 	// Now we mantain our own fork
 	"github.com/trento-project/agent/internal/cluster/cib"
@@ -35,12 +36,13 @@ type DiscoveryTools struct {
 }
 
 type Cluster struct {
-	Cib    cib.Root    `mapstructure:"cib,omitempty"`
-	Crmmon crmmon.Root `mapstructure:"crmmon,omitempty"`
-	SBD    SBD         `mapstructure:"sbd,omitempty"`
-	Id     string      `mapstructure:"id"`
-	Name   string      `mapstructure:"name"`
-	DC     bool        `mapstructure:"dc"`
+	Cib           cib.Root    `mapstructure:"cib,omitempty"`
+	Crmmon        crmmon.Root `mapstructure:"crmmon,omitempty"`
+	SBD           SBD         `mapstructure:"sbd,omitempty"`
+	Id            string      `mapstructure:"id"`
+	Name          string      `mapstructure:"name"`
+	DC            bool        `mapstructure:"dc"`
+	CloudProvider string      `mapstructure:"cloud_provider"`
 }
 
 func Md5sumFile(filePath string) (string, error) {
@@ -106,6 +108,9 @@ func NewClusterWithDiscoveryTools(discoveryTools *DiscoveryTools) (Cluster, erro
 	}
 
 	cluster.DC = isDC(&cluster)
+
+	csp, _ := cloud.IdentifyCloudProvider()
+	cluster.CloudProvider = csp
 
 	return cluster, nil
 }

--- a/internal/discovery/mocks/discovered_cluster_mock.go
+++ b/internal/discovery/mocks/discovered_cluster_mock.go
@@ -1,6 +1,9 @@
 package mocks
 
-import "github.com/trento-project/agent/internal/cluster"
+import (
+	"github.com/trento-project/agent/internal/cloud"
+	"github.com/trento-project/agent/internal/cluster"
+)
 
 func NewDiscoveredClusterMock() cluster.Cluster {
 	cluster, _ := cluster.NewClusterWithDiscoveryTools(&cluster.DiscoveryTools{
@@ -10,6 +13,8 @@ func NewDiscoveredClusterMock() cluster.Cluster {
 		SBDPath:         "./test/fake_sbd.sh",
 		SBDConfigPath:   "./test/sbd_config",
 	})
+
+	cluster.CloudProvider = cloud.Azure
 
 	return cluster
 }

--- a/test/fixtures/discovery/cluster/expected_published_cluster_discovery.json
+++ b/test/fixtures/discovery/cluster/expected_published_cluster_discovery.json
@@ -1032,6 +1032,7 @@
     },
     "Id": "47d1190ffb4f781974c8356d7f863b03",
     "Name": "hana_cluster",
-    "DC": false
+    "DC": false,
+    "CloudProvider": "azure"
   }
 }


### PR DESCRIPTION
This PR determines the CSP of a cluster.

Extracts the information the same way we do for the cloud discovery of a host.

Clearly the information published by the Designated Controller will be the truth.

Question: what if no CSP was provided? No big issue from agent side, as just an empty string will be published.
What about the checks engine?
Gonna check on this later on the control plane