### PR TITLE
Flat map sap systems payload lists

### DIFF
--- a/internal/sapsystem/sapsystem_test.go
+++ b/internal/sapsystem/sapsystem_test.go
@@ -113,8 +113,8 @@ func TestNewSAPSystem(t *testing.T) {
 	system, err := NewSAPSystem(appFS, "/usr/sap/DEV")
 
 	assert.Equal(t, Application, system.Type)
-	assert.Contains(t, system.Instances, "ASCS01")
-	assert.Contains(t, system.Instances, "ERS02")
+	assert.Contains(t, system.Instances[0].Name, "ASCS01")
+	assert.Contains(t, system.Instances[1].Name, "ERS02")
 	assert.Equal(t, system.Profile, expectedProfile)
 	assert.NoError(t, err)
 }
@@ -358,8 +358,8 @@ func TestNewSAPInstanceDatabase(t *testing.T) {
 		Host: host,
 		SAPControl: &SAPControl{
 			webService: mockWebService,
-			Processes: map[string]*sapcontrol.OSProcess{
-				"enserver": &sapcontrol.OSProcess{
+			Processes: []*sapcontrol.OSProcess{
+				&sapcontrol.OSProcess{
 					Name:        "enserver",
 					Description: "foobar",
 					Dispstatus:  sapcontrol.STATECOLOR_GREEN,
@@ -368,7 +368,7 @@ func TestNewSAPInstanceDatabase(t *testing.T) {
 					Elapsedtime: "",
 					Pid:         30787,
 				},
-				"msg_server": &sapcontrol.OSProcess{
+				&sapcontrol.OSProcess{
 					Name:        "msg_server",
 					Description: "foobar2",
 					Dispstatus:  sapcontrol.STATECOLOR_YELLOW,
@@ -378,30 +378,30 @@ func TestNewSAPInstanceDatabase(t *testing.T) {
 					Pid:         30786,
 				},
 			},
-			Properties: map[string]*sapcontrol.InstanceProperty{
-				"prop1": &sapcontrol.InstanceProperty{
+			Properties: []*sapcontrol.InstanceProperty{
+				&sapcontrol.InstanceProperty{
 					Property:     "prop1",
 					Propertytype: "type1",
 					Value:        "value1",
 				},
-				"SAPSYSTEMNAME": &sapcontrol.InstanceProperty{
+				&sapcontrol.InstanceProperty{
 					Property:     "SAPSYSTEMNAME",
 					Propertytype: "string",
 					Value:        "PRD",
 				},
-				"INSTANCE_NAME": &sapcontrol.InstanceProperty{
-					Property:     "INSTANCE_NAME",
-					Propertytype: "string",
-					Value:        "HDB00",
-				},
-				"HANA Roles": &sapcontrol.InstanceProperty{
+				&sapcontrol.InstanceProperty{
 					Property:     "HANA Roles",
 					Propertytype: "type3",
 					Value:        "some hana value",
 				},
+				&sapcontrol.InstanceProperty{
+					Property:     "INSTANCE_NAME",
+					Propertytype: "string",
+					Value:        "HDB00",
+				},
 			},
-			Instances: map[string]*sapcontrol.SAPInstance{
-				"host1": &sapcontrol.SAPInstance{
+			Instances: []*sapcontrol.SAPInstance{
+				&sapcontrol.SAPInstance{
 					Hostname:      "host1",
 					InstanceNr:    0,
 					HttpPort:      50013,
@@ -410,7 +410,7 @@ func TestNewSAPInstanceDatabase(t *testing.T) {
 					Features:      "some features",
 					Dispstatus:    sapcontrol.STATECOLOR_GREEN,
 				},
-				"host2": &sapcontrol.SAPInstance{
+				&sapcontrol.SAPInstance{
 					Hostname:      "host2",
 					InstanceNr:    1,
 					HttpPort:      50113,
@@ -590,8 +590,8 @@ func TestNewSAPInstanceApp(t *testing.T) {
 		Host: host,
 		SAPControl: &SAPControl{
 			webService: mockWebService,
-			Processes: map[string]*sapcontrol.OSProcess{
-				"enserver": &sapcontrol.OSProcess{
+			Processes: []*sapcontrol.OSProcess{
+				&sapcontrol.OSProcess{
 					Name:        "enserver",
 					Description: "foobar",
 					Dispstatus:  sapcontrol.STATECOLOR_GREEN,
@@ -600,7 +600,7 @@ func TestNewSAPInstanceApp(t *testing.T) {
 					Elapsedtime: "",
 					Pid:         30787,
 				},
-				"msg_server": &sapcontrol.OSProcess{
+				&sapcontrol.OSProcess{
 					Name:        "msg_server",
 					Description: "foobar2",
 					Dispstatus:  sapcontrol.STATECOLOR_YELLOW,
@@ -610,25 +610,25 @@ func TestNewSAPInstanceApp(t *testing.T) {
 					Pid:         30786,
 				},
 			},
-			Properties: map[string]*sapcontrol.InstanceProperty{
-				"prop1": &sapcontrol.InstanceProperty{
+			Properties: []*sapcontrol.InstanceProperty{
+				&sapcontrol.InstanceProperty{
 					Property:     "prop1",
 					Propertytype: "type1",
 					Value:        "value1",
 				},
-				"SAPSYSTEMNAME": &sapcontrol.InstanceProperty{
+				&sapcontrol.InstanceProperty{
 					Property:     "SAPSYSTEMNAME",
 					Propertytype: "string",
 					Value:        "PRD",
 				},
-				"INSTANCE_NAME": &sapcontrol.InstanceProperty{
+				&sapcontrol.InstanceProperty{
 					Property:     "INSTANCE_NAME",
 					Propertytype: "string",
 					Value:        "HDB00",
 				},
 			},
-			Instances: map[string]*sapcontrol.SAPInstance{
-				"host1": &sapcontrol.SAPInstance{
+			Instances: []*sapcontrol.SAPInstance{
+				&sapcontrol.SAPInstance{
 					Hostname:      "host1",
 					InstanceNr:    0,
 					HttpPort:      50013,
@@ -637,7 +637,7 @@ func TestNewSAPInstanceApp(t *testing.T) {
 					Features:      "some features",
 					Dispstatus:    sapcontrol.STATECOLOR_GREEN,
 				},
-				"host2": &sapcontrol.SAPInstance{
+				&sapcontrol.SAPInstance{
 					Hostname:      "host2",
 					InstanceNr:    1,
 					HttpPort:      50113,

--- a/test/fixtures/discovery/sap_system/expected_published_sap_system_discovery_application.json
+++ b/test/fixtures/discovery/sap_system/expected_published_sap_system_discovery_application.json
@@ -41,14 +41,14 @@
         "icm/HTTP/ASJava/disable_url_session_tracking": "TRUE"
       },
       "Databases": null,
-      "Instances": {
-        "D02": {
+      "Instances": [
+        {
           "Host": "vmnetweaver04",
           "Name": "D02",
           "Type": 2,
           "SAPControl": {
-            "Instances": {
-              "sapha1as": {
+            "Instances": [
+              {
                 "features": "MESSAGESERVER|ENQUE",
                 "hostname": "sapha1as",
                 "httpPort": 50013,
@@ -57,7 +57,7 @@
                 "instanceNr": 0,
                 "startPriority": "1"
               },
-              "sapha1er": {
+              {
                 "features": "ENQREP",
                 "hostname": "sapha1er",
                 "httpPort": 51013,
@@ -66,7 +66,7 @@
                 "instanceNr": 10,
                 "startPriority": "0.5"
               },
-              "sapha1pas": {
+              {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
                 "hostname": "sapha1pas",
                 "httpPort": 50113,
@@ -75,7 +75,7 @@
                 "instanceNr": 1,
                 "startPriority": "3"
               },
-              "sapha1aas1": {
+            {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
                 "hostname": "sapha1aas1",
                 "httpPort": 50213,
@@ -84,9 +84,9 @@
                 "instanceNr": 2,
                 "startPriority": "3"
               }
-            },
-            "Processes": {
-              "gwrd": {
+            ],
+            "Processes": [
+              {
                 "pid": 17444,
                 "name": "gwrd",
                 "starttime": "2021 09 28 16:58:24",
@@ -95,7 +95,7 @@
                 "description": "Gateway",
                 "elapsedtime": "1557:46:59"
               },
-              "icman": {
+              {
                 "pid": 17445,
                 "name": "icman",
                 "starttime": "2021 09 28 16:58:24",
@@ -104,7 +104,7 @@
                 "description": "ICM",
                 "elapsedtime": "1557:46:59"
               },
-              "igswd_mt": {
+              {
                 "pid": 17440,
                 "name": "igswd_mt",
                 "starttime": "2021 09 28 16:58:23",
@@ -113,7 +113,7 @@
                 "description": "IGS Watchdog",
                 "elapsedtime": "1557:47:00"
               },
-              "disp+work": {
+            {
                 "pid": 17439,
                 "name": "disp+work",
                 "starttime": "2021 09 28 16:58:23",
@@ -122,125 +122,125 @@
                 "description": "Dispatcher",
                 "elapsedtime": "1557:47:00"
               }
-            },
-            "Properties": {
-              "ICM": {
+            ],
+            "Properties": [
+              {
                 "value": "HTTP://sapha1aas1:0/sap/admin/public/index.html",
                 "property": "ICM",
                 "propertytype": "NodeURL"
               },
-              "IGS": {
+              {
                 "value": "http://sapha1aas1:40280",
                 "property": "IGS",
                 "propertytype": "NodeURL"
               },
-              "Syslog": {
+              {
                 "value": "ABAPReadSyslog",
                 "property": "Syslog",
                 "propertytype": "NodeWebmethod"
               },
-              "ICM Cache": {
+              {
                 "value": "ICMGetCacheEntries",
                 "property": "ICM Cache",
                 "propertytype": "NodeWebmethod"
               },
-              "SAPSYSTEM": {
+              {
                 "value": "02",
                 "property": "SAPSYSTEM",
                 "propertytype": "Attribute"
               },
-              "Webmethods": {
+              {
                 "value": "Start,InstanceStart,StartBypassHA,Bootstrap,Stop,InstanceStop,StopBypassHA,Shutdown,ParameterValue,GetProcessList,GetStartProfile,GetTraceFile,GetAlertTree,GetAlerts,RestartService,StopService,GetEnvironment,ListDeveloperTraces,ReadDeveloperTrace,RestartInstance,SendSignal,GetVersionInfo,GetQueueStatistic,GetInstanceProperties,OSExecute,ReadLogFile,AnalyseLogFiles,ListLogFiles,GetAccessPointList,GetSystemInstanceList,GetSystemUpdateList,StartSystem,StopSystem,RestartSystem,UpdateSystem,UpdateSCSInstance,CheckUpdateSystem,AccessCheck,GetProcessParameter,SetProcessParameter,SetProcessParameter2,ShmDetach,GetNetworkId,GetSecNetworkId,RequestLogonFile,CreateSnapshot,ReadSnapshot,ListSnapshots,DeleteSnapshots,GetCallstack,ABAPReadSyslog,ABAPReadRawSyslog,ABAPGetWPTable,ABAPAcknowledgeAlerts,ABAPGetComponentList,ABAPCheckRFCDestinations,ABAPGetSystemWPTable,J2EEGetProcessList,J2EEGetProcessList2,J2EEControlProcess,J2EEGetThreadList,J2EEGetThreadList2,J2EEGetThreadCallStack,J2EEGetThreadTaskStack,J2EEGetSessionList,J2EEGetWebSessionList,J2EEGetWebSessionList2,J2EEGetCacheStatistic,J2EEGetCacheStatistic2,J2EEGetApplicationAliasList,J2EEGetVMGCHistory,J2EEGetVMGCHistory2,J2EEGetVMHeapInfo,J2EEGetEJBSessionList,J2EEGetRemoteObjectList,J2EEGetClusterMsgList,J2EEGetSharedTableInfo,J2EEGetComponentList,J2EEControlComponents,ICMGetThreadList,ICMGetConnectionList,ICMGetCacheEntries,ICMGetProxyConnectionList,WebDispGetServerList,EnqGetLockTable,EnqRemoveLocks,EnqGetStatistic,UpdateSystemPKI,UpdateInstancePSE,HACheckConfig,HACheckFailoverConfig,HAGetFailoverConfig,HAFailoverToNode",
                 "property": "Webmethods",
                 "propertytype": "Attribute"
               },
-              "ICM Threads": {
+              {
                 "value": "ICMGetThreadList",
                 "property": "ICM Threads",
                 "propertytype": "NodeWebmethod"
               },
-              "Open Alerts": {
+              {
                 "value": "GetAlertTree",
                 "property": "Open Alerts",
                 "propertytype": "NodeWebmethod"
               },
-              "Process List": {
+              {
                 "value": "GetProcessList",
                 "property": "Process List",
                 "propertytype": "NodeWebmethod"
               },
-              "SAPLOCALHOST": {
+              {
                 "value": "sapha1aas1",
                 "property": "SAPLOCALHOST",
                 "propertytype": "Attribute"
               },
-              "ABAP WP Table": {
+              {
                 "value": "ABAPGetWPTable",
                 "property": "ABAP WP Table",
                 "propertytype": "NodeWebmethod"
               },
-              "Access Points": {
+              {
                 "value": "GetAccessPointList",
                 "property": "Access Points",
                 "propertytype": "NodeWebmethod"
               },
-              "INSTANCE_NAME": {
+              {
                 "value": "D02",
                 "property": "INSTANCE_NAME",
                 "propertytype": "Attribute"
               },
-              "Kernel Update": {
+              {
                 "value": "https://launchpad.support.sap.com/#/softwarecenter/template/products/_APP=00200682500000001943&_EVENT=DISPHIER&HEADER=Y&FUNCTIONBAR=N&EVENT=TREE&NE=NAVIGATE&ENR=73554900100200001710&V=MAINT",
                 "property": "Kernel Update",
                 "propertytype": "NodeURL"
               },
-              "SAPSYSTEMNAME": {
+              {
                 "value": "HA1",
                 "property": "SAPSYSTEMNAME",
                 "propertytype": "Attribute"
               },
-              "StartPriority": {
+              {
                 "value": "3",
                 "property": "StartPriority",
                 "propertytype": "Attribute"
               },
-              "Current Status": {
+              {
                 "value": "GetAlertTree",
                 "property": "Current Status",
                 "propertytype": "NodeWebmethod"
               },
-              "ICM Connections": {
+              {
                 "value": "ICMGetConnectionList",
                 "property": "ICM Connections",
                 "propertytype": "NodeWebmethod"
               },
-              "Queue Statistic": {
+              {
                 "value": "GetQueueStatistic",
                 "property": "Queue Statistic",
                 "propertytype": "NodeWebmethod"
               },
-              "Protected Webmethods": {
+              {
                 "value": "ABAPAcknowledgeAlerts,ABAPCheckRFCDestinations,ABAPGetComponentList,ABAPGetSystemWPTable,ABAPGetWPTable,ABAPReadRawSyslog,ABAPReadSyslog,AnalyseLogFiles,Bootstrap,CheckUpdateSystem,ConfigureLogFileList,CreateSnapshot,DeleteSnapshots,EnqGetLockTable,EnqGetStatistic,EnqRemoveLocks,GetAccessPointList,GetAlerts,GetAlertTree,GetCallstack,GetEnvironment,GetLogFileList,GetProcessParameter,GetQueueStatistic,GetStartProfile,GetSystemUpdateList,GetTraceFile,GetVersionInfo,HACheckConfig,HACheckFailoverConfig,HAFailoverToNode,HAGetFailoverConfig,ICMGetCacheEntries,ICMGetConnectionList,ICMGetProxyConnectionList,ICMGetThreadList,InstanceStart,InstanceStop,J2EEControlCluster,J2EEControlComponents,J2EEControlProcess,J2EEDisableDbgSession,J2EEEnableDbgSession,J2EEGetApplicationAliasList,J2EEGetCacheStatistic,J2EEGetCacheStatistic2,J2EEGetClusterMsgList,J2EEGetComponentList,J2EEGetEJBSessionList,J2EEGetProcessList,J2EEGetProcessList2,J2EEGetRemoteObjectList,J2EEGetSessionList,J2EEGetSharedTableInfo,J2EEGetThreadCallStack,J2EEGetThreadList,J2EEGetThreadList2,J2EEGetThreadTaskStack,J2EEGetVMGCHistory,J2EEGetVMGCHistory2,J2EEGetVMHeapInfo,J2EEGetWebSessionList,J2EEGetWebSessionList2,ListDeveloperTraces,ListLogFiles,ListSnapshots,OSExecute,ParameterValue,ReadDeveloperTrace,ReadLogFile,ReadSnapshot,RestartInstance,RestartService,RestartSystem,SendSignal,SetProcessParameter,SetProcessParameter2,ShmDetach,Shutdown,Start,StartBypassHA,StartSystem,Stop,StopBypassHA,StopService,StopSystem,UpdateInstancePSE,UpdateSCSInstance,UpdateSystem,UpdateSystemPKI,WebDispGetServerList,GetAgentConfig,MtChangeStatus,MtCustomizeWrite,MtDbsetToWpsetByTid,MtDestroyMarkNTry,MtReset,PerfCustomizeWrite,ReadDirectory,ReadFile,ReadProfileParameters,Register,SnglmgsCustomizeWrite,SystemObjectSetValue,ToolSet,ToolSetRuntimeStatus,TriggerDataCollection,Unregister,UtilAlChangeStatus",
                 "property": "Protected Webmethods",
                 "propertytype": "Attribute"
               },
-              "ICM Proxy Connections": {
+              {
                 "value": "ICMGetProxyConnectionList",
                 "property": "ICM Proxy Connections",
                 "propertytype": "NodeWebmethod"
               },
-              "Parameter Documentation": {
+              {
                 "value": "http://sapha1aas1:50213/sapparamEN.html",
                 "property": "Parameter Documentation",
                 "propertytype": "NodeURL"
               }
-            }
+            ]
           },
           "HdbnsutilSRstate": null,
           "HostConfiguration": null,
           "SystemReplication": null
         }
-      }
+      ]
     }
   ]
 }

--- a/test/fixtures/discovery/sap_system/expected_published_sap_system_discovery_database.json
+++ b/test/fixtures/discovery/sap_system/expected_published_sap_system_discovery_database.json
@@ -27,14 +27,14 @@
           "Container": ""
         }
       ],
-      "Instances": {
-        "HDB00": {
+      "Instances": [
+        {
           "Host": "vmhana01",
           "Name": "HDB00",
           "Type": 1,
           "SAPControl": {
-            "Instances": {
-              "vmhana01": {
+            "Instances": [
+              {
                 "features": "HDB|HDB_WORKER",
                 "hostname": "vmhana01",
                 "httpPort": 50013,
@@ -43,9 +43,9 @@
                 "instanceNr": 0,
                 "startPriority": "0.3"
               }
-            },
-            "Processes": {
-              "hdbdaemon": {
+            ],
+            "Processes": [
+              {
                 "pid": 16386,
                 "name": "hdbdaemon",
                 "starttime": "2021 09 28 15:52:57",
@@ -54,7 +54,7 @@
                 "description": "HDB Daemon",
                 "elapsedtime": "689:20:39"
               },
-              "hdbxsengine": {
+              {
                 "pid": 16621,
                 "name": "hdbxsengine",
                 "starttime": "2021 09 28 15:53:06",
@@ -63,7 +63,7 @@
                 "description": "HDB XSEngine-PRD",
                 "elapsedtime": "689:20:30"
               },
-              "hdbnameserver": {
+              {
                 "pid": 16402,
                 "name": "hdbnameserver",
                 "starttime": "2021 09 28 15:52:58",
@@ -72,7 +72,7 @@
                 "description": "HDB Nameserver",
                 "elapsedtime": "689:20:38"
               },
-              "hdbindexserver": {
+              {
                 "pid": 16619,
                 "name": "hdbindexserver",
                 "starttime": "2021 09 28 15:53:06",
@@ -81,7 +81,7 @@
                 "description": "HDB Indexserver-PRD",
                 "elapsedtime": "689:20:30"
               },
-              "hdbpreprocessor": {
+              {
                 "pid": 16581,
                 "name": "hdbpreprocessor",
                 "starttime": "2021 09 28 15:53:04",
@@ -90,7 +90,7 @@
                 "description": "HDB Preprocessor",
                 "elapsedtime": "689:20:32"
               },
-              "hdbcompileserver": {
+              {
                 "pid": 16579,
                 "name": "hdbcompileserver",
                 "starttime": "2021 09 28 15:53:04",
@@ -99,7 +99,7 @@
                 "description": "HDB Compileserver",
                 "elapsedtime": "689:20:32"
               },
-              "hdbwebdispatcher": {
+              {
                 "pid": 16977,
                 "name": "hdbwebdispatcher",
                 "starttime": "2021 09 28 15:53:33",
@@ -108,69 +108,69 @@
                 "description": "HDB Web Dispatcher",
                 "elapsedtime": "689:20:03"
               }
-            },
-            "Properties": {
-              "SAPSYSTEM": {
+            ],
+            "Properties": [
+              {
                 "value": "00",
                 "property": "SAPSYSTEM",
                 "propertytype": "Attribute"
               },
-              "DBServices": {
+              {
                 "value": "YES",
                 "property": "DBServices",
                 "propertytype": "Attribute"
               },
-              "HANA Roles": {
+              {
                 "value": "worker",
                 "property": "HANA Roles",
                 "propertytype": "Attribute"
               },
-              "Webmethods": {
+              {
                 "value": "Start,InstanceStart,StartBypassHA,Bootstrap,Stop,InstanceStop,StopBypassHA,Shutdown,ParameterValue,GetProcessList,GetStartProfile,GetTraceFile,GetAlertTree,GetAlerts,RestartService,StopService,GetEnvironment,ListDeveloperTraces,ReadDeveloperTrace,RestartInstance,SendSignal,GetVersionInfo,GetQueueStatistic,GetInstanceProperties,OSExecute,ReadLogFile,AnalyseLogFiles,ListLogFiles,GetAccessPointList,GetSystemInstanceList,GetSystemUpdateList,StartSystem,StopSystem,RestartSystem,UpdateSystem,UpdateSCSInstance,CheckUpdateSystem,AccessCheck,GetProcessParameter,SetProcessParameter,SetProcessParameter2,CheckParameter,ShmDetach,GetNetworkId,GetSecNetworkId,RequestLogonFile,CreateSnapshot,ReadSnapshot,ListSnapshots,DeleteSnapshots,GetCallstack,ABAPReadSyslog,ABAPReadRawSyslog,ABAPGetWPTable,ABAPAcknowledgeAlerts,ABAPGetComponentList,ABAPCheckRFCDestinations,ABAPGetSystemWPTable,J2EEGetProcessList,J2EEGetProcessList2,J2EEControlProcess,J2EEGetThreadList,J2EEGetThreadList2,J2EEGetThreadCallStack,J2EEGetThreadTaskStack,J2EEGetSessionList,J2EEGetWebSessionList,J2EEGetWebSessionList2,J2EEGetCacheStatistic,J2EEGetCacheStatistic2,J2EEGetApplicationAliasList,J2EEGetVMGCHistory,J2EEGetVMGCHistory2,J2EEGetVMHeapInfo,J2EEGetEJBSessionList,J2EEGetRemoteObjectList,J2EEGetClusterMsgList,J2EEGetSharedTableInfo,J2EEGetComponentList,J2EEControlComponents,ICMGetThreadList,ICMGetConnectionList,ICMGetCacheEntries,ICMGetProxyConnectionList,WebDispGetServerList,WebDispGetGroupList,WebDispGetVirtHostList,WebDispGetUrlPrefixList,EnqGetLockTable,EnqRemoveLocks,EnqRemoveUserLocks,EnqGetStatistic,UpdateSystemPKI,UpdateInstancePSE,StorePSE,DeletePSE,CheckPSE,HACheckConfig,HACheckFailoverConfig,HAGetFailoverConfig,HAFailoverToNode,HASetMaintenanceMode,HACheckMaintenanceMode",
                 "property": "Webmethods",
                 "propertytype": "Attribute"
               },
-              "Process List": {
+              {
                 "value": "GetProcessList",
                 "property": "Process List",
                 "propertytype": "NodeWebmethod"
               },
-              "SAPLOCALHOST": {
+              {
                 "value": "vmhana01",
                 "property": "SAPLOCALHOST",
                 "propertytype": "Attribute"
               },
-              "Access Points": {
+              {
                 "value": "GetAccessPointList",
                 "property": "Access Points",
                 "propertytype": "NodeWebmethod"
               },
-              "INSTANCE_NAME": {
+              {
                 "value": "HDB00",
                 "property": "INSTANCE_NAME",
                 "propertytype": "Attribute"
               },
-              "SAPSYSTEMNAME": {
+              {
                 "value": "PRD",
                 "property": "SAPSYSTEMNAME",
                 "propertytype": "Attribute"
               },
-              "StartPriority": {
+              {
                 "value": "0.3",
                 "property": "StartPriority",
                 "propertytype": "Attribute"
               },
-              "Protected Webmethods": {
+              {
                 "value": "ABAPAcknowledgeAlerts,ABAPCheckRFCDestinations,ABAPGetComponentList,ABAPGetSystemWPTable,ABAPGetWPTable,ABAPReadRawSyslog,ABAPReadSyslog,AnalyseLogFiles,Bootstrap,CheckParameter,CheckPSE,CheckUpdateSystem,ConfigureLogFileList,CreatePSECredential,CreateSnapshot,DeletePSE,DeleteSnapshots,EnqGetLockTable,EnqGetStatistic,EnqRemoveLocks,EnqRemoveUserLocks,GetAccessPointList,GetAlerts,GetAlertTree,GetCallstack,GetEnvironment,GetLogFileList,GetProcessParameter,GetQueueStatistic,GetStartProfile,GetSystemUpdateList,GetTraceFile,GetVersionInfo,HACheckConfig,HACheckFailoverConfig,HACheckMaintenanceMode,HAFailoverToNode,HAGetFailoverConfig,HASetMaintenanceMode,ICMGetCacheEntries,ICMGetConnectionList,ICMGetProxyConnectionList,ICMGetThreadList,InstanceStart,InstanceStop,J2EEControlCluster,J2EEControlComponents,J2EEControlProcess,J2EEDisableDbgSession,J2EEEnableDbgSession,J2EEGetApplicationAliasList,J2EEGetCacheStatistic,J2EEGetCacheStatistic2,J2EEGetClusterMsgList,J2EEGetComponentList,J2EEGetEJBSessionList,J2EEGetProcessList,J2EEGetProcessList2,J2EEGetRemoteObjectList,J2EEGetSessionList,J2EEGetSharedTableInfo,J2EEGetThreadCallStack,J2EEGetThreadList,J2EEGetThreadList2,J2EEGetThreadTaskStack,J2EEGetVMGCHistory,J2EEGetVMGCHistory2,J2EEGetVMHeapInfo,J2EEGetWebSessionList,J2EEGetWebSessionList2,ListDeveloperTraces,ListLogFiles,ListSnapshots,OSExecute,ParameterValue,ReadDeveloperTrace,ReadLogFile,ReadSnapshot,RestartInstance,RestartService,RestartSystem,SendSignal,SetProcessParameter,SetProcessParameter2,ShmDetach,Shutdown,Start,StartBypassHA,StartSystem,Stop,StopBypassHA,StopService,StopSystem,StorePSE,UpdateInstancePSE,UpdateSCSInstance,UpdateSystem,UpdateSystemPKI,WebDispGetServerList,WebDispGetGroupList,WebDispGetVirtHostList,WebDispGetUrlPrefixList,GetAgentConfig,GetListOfMaByCusGrp,GetMcInLocalMs,GetMtesByRequestTable,GetMtListByMtclass,InfoGetTree,MscCustomizeWrite,MscDeleteLines,MscReadCache,MsGetLocalMsInfo,MsGetMteclsInLocalMs,MtChangeStatus,MtCustomizeWrite,MtDbsetToWpsetByTid,MtDestroyMarkNTry,MteGetByToolRunstatus,MtGetAllToCust,MtGetAllToolsToSet,MtGetMteinfo,MtGetTidByName,MtRead,MtReset,PerfCustomizeWrite,PerfRead,PerfReadSmoothData,ReadDirectory,ReadFile,ReadProfileParameters,ReferenceRead,Register,RequestLogonFile,SnglmgsCustomizeWrite,SystemObjectSetValue,TextAttrRead,ToolGetEffective,ToolSet,ToolSetRuntimeStatus,TriggerDataCollection,Unregister,UtilAlChangeStatus,UtilMtGetAidByTid,UtilMtGetTreeLocal,UtilMtReadAll,UtilReadRawalertByAid,UtilSnglmsgReadRawdata",
                 "property": "Protected Webmethods",
                 "propertytype": "Attribute"
               },
-              "Parameter Documentation": {
+              {
                 "value": "http://vmhana01:50013/sapparamEN.html",
                 "property": "Parameter Documentation",
                 "propertytype": "NodeURL"
               }
-            }
+            ]
           },
           "HdbnsutilSRstate": {
             "mode": "primary",
@@ -372,7 +372,7 @@
             "service/vmhana01/30007/SHIPPED_LAST_DELTA_REPLICA_START_TIME": "-"
           }
         }
-      }
+      ]
     }
   ]
 }

--- a/test/fixtures/discovery/sap_system/sap_system_discovery_application.json
+++ b/test/fixtures/discovery/sap_system/sap_system_discovery_application.json
@@ -38,14 +38,14 @@
       "icm/HTTP/ASJava/disable_url_session_tracking": "TRUE"
     },
     "Databases": null,
-    "Instances": {
-      "D02": {
+    "Instances": [
+      {
         "Host": "vmnetweaver04",
         "Name": "D02",
         "Type": 2,
         "SAPControl": {
-          "Instances": {
-            "sapha1as": {
+          "Instances": [
+            {
               "features": "MESSAGESERVER|ENQUE",
               "hostname": "sapha1as",
               "httpPort": 50013,
@@ -54,7 +54,7 @@
               "instanceNr": 0,
               "startPriority": "1"
             },
-            "sapha1er": {
+            {
               "features": "ENQREP",
               "hostname": "sapha1er",
               "httpPort": 51013,
@@ -63,7 +63,7 @@
               "instanceNr": 10,
               "startPriority": "0.5"
             },
-            "sapha1pas": {
+            {
               "features": "ABAP|GATEWAY|ICMAN|IGS",
               "hostname": "sapha1pas",
               "httpPort": 50113,
@@ -72,7 +72,7 @@
               "instanceNr": 1,
               "startPriority": "3"
             },
-            "sapha1aas1": {
+            {
               "features": "ABAP|GATEWAY|ICMAN|IGS",
               "hostname": "sapha1aas1",
               "httpPort": 50213,
@@ -81,9 +81,9 @@
               "instanceNr": 2,
               "startPriority": "3"
             }
-          },
-          "Processes": {
-            "gwrd": {
+          ],
+          "Processes": [
+            {
               "pid": 17444,
               "name": "gwrd",
               "starttime": "2021 09 28 16:58:24",
@@ -92,7 +92,7 @@
               "description": "Gateway",
               "elapsedtime": "1557:46:59"
             },
-            "icman": {
+            {
               "pid": 17445,
               "name": "icman",
               "starttime": "2021 09 28 16:58:24",
@@ -101,7 +101,7 @@
               "description": "ICM",
               "elapsedtime": "1557:46:59"
             },
-            "igswd_mt": {
+            {
               "pid": 17440,
               "name": "igswd_mt",
               "starttime": "2021 09 28 16:58:23",
@@ -110,7 +110,7 @@
               "description": "IGS Watchdog",
               "elapsedtime": "1557:47:00"
             },
-            "disp+work": {
+            {
               "pid": 17439,
               "name": "disp+work",
               "starttime": "2021 09 28 16:58:23",
@@ -119,124 +119,124 @@
               "description": "Dispatcher",
               "elapsedtime": "1557:47:00"
             }
-          },
-          "Properties": {
-            "ICM": {
+          ],
+          "Properties": [
+            {
               "value": "HTTP://sapha1aas1:0/sap/admin/public/index.html",
               "property": "ICM",
               "propertytype": "NodeURL"
             },
-            "IGS": {
+            {
               "value": "http://sapha1aas1:40280",
               "property": "IGS",
               "propertytype": "NodeURL"
             },
-            "Syslog": {
+            {
               "value": "ABAPReadSyslog",
               "property": "Syslog",
               "propertytype": "NodeWebmethod"
             },
-            "ICM Cache": {
+            {
               "value": "ICMGetCacheEntries",
               "property": "ICM Cache",
               "propertytype": "NodeWebmethod"
             },
-            "SAPSYSTEM": {
+            {
               "value": "02",
               "property": "SAPSYSTEM",
               "propertytype": "Attribute"
             },
-            "Webmethods": {
+            {
               "value": "Start,InstanceStart,StartBypassHA,Bootstrap,Stop,InstanceStop,StopBypassHA,Shutdown,ParameterValue,GetProcessList,GetStartProfile,GetTraceFile,GetAlertTree,GetAlerts,RestartService,StopService,GetEnvironment,ListDeveloperTraces,ReadDeveloperTrace,RestartInstance,SendSignal,GetVersionInfo,GetQueueStatistic,GetInstanceProperties,OSExecute,ReadLogFile,AnalyseLogFiles,ListLogFiles,GetAccessPointList,GetSystemInstanceList,GetSystemUpdateList,StartSystem,StopSystem,RestartSystem,UpdateSystem,UpdateSCSInstance,CheckUpdateSystem,AccessCheck,GetProcessParameter,SetProcessParameter,SetProcessParameter2,ShmDetach,GetNetworkId,GetSecNetworkId,RequestLogonFile,CreateSnapshot,ReadSnapshot,ListSnapshots,DeleteSnapshots,GetCallstack,ABAPReadSyslog,ABAPReadRawSyslog,ABAPGetWPTable,ABAPAcknowledgeAlerts,ABAPGetComponentList,ABAPCheckRFCDestinations,ABAPGetSystemWPTable,J2EEGetProcessList,J2EEGetProcessList2,J2EEControlProcess,J2EEGetThreadList,J2EEGetThreadList2,J2EEGetThreadCallStack,J2EEGetThreadTaskStack,J2EEGetSessionList,J2EEGetWebSessionList,J2EEGetWebSessionList2,J2EEGetCacheStatistic,J2EEGetCacheStatistic2,J2EEGetApplicationAliasList,J2EEGetVMGCHistory,J2EEGetVMGCHistory2,J2EEGetVMHeapInfo,J2EEGetEJBSessionList,J2EEGetRemoteObjectList,J2EEGetClusterMsgList,J2EEGetSharedTableInfo,J2EEGetComponentList,J2EEControlComponents,ICMGetThreadList,ICMGetConnectionList,ICMGetCacheEntries,ICMGetProxyConnectionList,WebDispGetServerList,EnqGetLockTable,EnqRemoveLocks,EnqGetStatistic,UpdateSystemPKI,UpdateInstancePSE,HACheckConfig,HACheckFailoverConfig,HAGetFailoverConfig,HAFailoverToNode",
               "property": "Webmethods",
               "propertytype": "Attribute"
             },
-            "ICM Threads": {
+            {
               "value": "ICMGetThreadList",
               "property": "ICM Threads",
               "propertytype": "NodeWebmethod"
             },
-            "Open Alerts": {
+            {
               "value": "GetAlertTree",
               "property": "Open Alerts",
               "propertytype": "NodeWebmethod"
             },
-            "Process List": {
+            {
               "value": "GetProcessList",
               "property": "Process List",
               "propertytype": "NodeWebmethod"
             },
-            "SAPLOCALHOST": {
+            {
               "value": "sapha1aas1",
               "property": "SAPLOCALHOST",
               "propertytype": "Attribute"
             },
-            "ABAP WP Table": {
+            {
               "value": "ABAPGetWPTable",
               "property": "ABAP WP Table",
               "propertytype": "NodeWebmethod"
             },
-            "Access Points": {
+            {
               "value": "GetAccessPointList",
               "property": "Access Points",
               "propertytype": "NodeWebmethod"
             },
-            "INSTANCE_NAME": {
+            {
               "value": "D02",
               "property": "INSTANCE_NAME",
               "propertytype": "Attribute"
             },
-            "Kernel Update": {
+            {
               "value": "https://launchpad.support.sap.com/#/softwarecenter/template/products/_APP=00200682500000001943&_EVENT=DISPHIER&HEADER=Y&FUNCTIONBAR=N&EVENT=TREE&NE=NAVIGATE&ENR=73554900100200001710&V=MAINT",
               "property": "Kernel Update",
               "propertytype": "NodeURL"
             },
-            "SAPSYSTEMNAME": {
+            {
               "value": "HA1",
               "property": "SAPSYSTEMNAME",
               "propertytype": "Attribute"
             },
-            "StartPriority": {
+            {
               "value": "3",
               "property": "StartPriority",
               "propertytype": "Attribute"
             },
-            "Current Status": {
+            {
               "value": "GetAlertTree",
               "property": "Current Status",
               "propertytype": "NodeWebmethod"
             },
-            "ICM Connections": {
+            {
               "value": "ICMGetConnectionList",
               "property": "ICM Connections",
               "propertytype": "NodeWebmethod"
             },
-            "Queue Statistic": {
+            {
               "value": "GetQueueStatistic",
               "property": "Queue Statistic",
               "propertytype": "NodeWebmethod"
             },
-            "Protected Webmethods": {
+            {
               "value": "ABAPAcknowledgeAlerts,ABAPCheckRFCDestinations,ABAPGetComponentList,ABAPGetSystemWPTable,ABAPGetWPTable,ABAPReadRawSyslog,ABAPReadSyslog,AnalyseLogFiles,Bootstrap,CheckUpdateSystem,ConfigureLogFileList,CreateSnapshot,DeleteSnapshots,EnqGetLockTable,EnqGetStatistic,EnqRemoveLocks,GetAccessPointList,GetAlerts,GetAlertTree,GetCallstack,GetEnvironment,GetLogFileList,GetProcessParameter,GetQueueStatistic,GetStartProfile,GetSystemUpdateList,GetTraceFile,GetVersionInfo,HACheckConfig,HACheckFailoverConfig,HAFailoverToNode,HAGetFailoverConfig,ICMGetCacheEntries,ICMGetConnectionList,ICMGetProxyConnectionList,ICMGetThreadList,InstanceStart,InstanceStop,J2EEControlCluster,J2EEControlComponents,J2EEControlProcess,J2EEDisableDbgSession,J2EEEnableDbgSession,J2EEGetApplicationAliasList,J2EEGetCacheStatistic,J2EEGetCacheStatistic2,J2EEGetClusterMsgList,J2EEGetComponentList,J2EEGetEJBSessionList,J2EEGetProcessList,J2EEGetProcessList2,J2EEGetRemoteObjectList,J2EEGetSessionList,J2EEGetSharedTableInfo,J2EEGetThreadCallStack,J2EEGetThreadList,J2EEGetThreadList2,J2EEGetThreadTaskStack,J2EEGetVMGCHistory,J2EEGetVMGCHistory2,J2EEGetVMHeapInfo,J2EEGetWebSessionList,J2EEGetWebSessionList2,ListDeveloperTraces,ListLogFiles,ListSnapshots,OSExecute,ParameterValue,ReadDeveloperTrace,ReadLogFile,ReadSnapshot,RestartInstance,RestartService,RestartSystem,SendSignal,SetProcessParameter,SetProcessParameter2,ShmDetach,Shutdown,Start,StartBypassHA,StartSystem,Stop,StopBypassHA,StopService,StopSystem,UpdateInstancePSE,UpdateSCSInstance,UpdateSystem,UpdateSystemPKI,WebDispGetServerList,GetAgentConfig,MtChangeStatus,MtCustomizeWrite,MtDbsetToWpsetByTid,MtDestroyMarkNTry,MtReset,PerfCustomizeWrite,ReadDirectory,ReadFile,ReadProfileParameters,Register,SnglmgsCustomizeWrite,SystemObjectSetValue,ToolSet,ToolSetRuntimeStatus,TriggerDataCollection,Unregister,UtilAlChangeStatus",
               "property": "Protected Webmethods",
               "propertytype": "Attribute"
             },
-            "ICM Proxy Connections": {
+            {
               "value": "ICMGetProxyConnectionList",
               "property": "ICM Proxy Connections",
               "propertytype": "NodeWebmethod"
             },
-            "Parameter Documentation": {
+            {
               "value": "http://sapha1aas1:50213/sapparamEN.html",
               "property": "Parameter Documentation",
               "propertytype": "NodeURL"
             }
-          }
+          ]
         },
         "HdbnsutilSRstate": null,
         "HostConfiguration": null,
         "SystemReplication": null
       }
-    }
+    ]
   }
 ]

--- a/test/fixtures/discovery/sap_system/sap_system_discovery_database.json
+++ b/test/fixtures/discovery/sap_system/sap_system_discovery_database.json
@@ -24,14 +24,14 @@
         "Container": ""
       }
     ],
-    "Instances": {
-      "HDB00": {
+    "Instances": [
+      {
         "Host": "vmhana01",
         "Name": "HDB00",
         "Type": 1,
         "SAPControl": {
-          "Instances": {
-            "vmhana01": {
+          "Instances": [
+            {
               "features": "HDB|HDB_WORKER",
               "hostname": "vmhana01",
               "httpPort": 50013,
@@ -40,9 +40,9 @@
               "instanceNr": 0,
               "startPriority": "0.3"
             }
-          },
-          "Processes": {
-            "hdbdaemon": {
+          ],
+          "Processes": [
+            {
               "pid": 16386,
               "name": "hdbdaemon",
               "starttime": "2021 09 28 15:52:57",
@@ -51,7 +51,7 @@
               "description": "HDB Daemon",
               "elapsedtime": "689:20:39"
             },
-            "hdbxsengine": {
+            {
               "pid": 16621,
               "name": "hdbxsengine",
               "starttime": "2021 09 28 15:53:06",
@@ -60,7 +60,7 @@
               "description": "HDB XSEngine-PRD",
               "elapsedtime": "689:20:30"
             },
-            "hdbnameserver": {
+            {
               "pid": 16402,
               "name": "hdbnameserver",
               "starttime": "2021 09 28 15:52:58",
@@ -69,7 +69,7 @@
               "description": "HDB Nameserver",
               "elapsedtime": "689:20:38"
             },
-            "hdbindexserver": {
+            {
               "pid": 16619,
               "name": "hdbindexserver",
               "starttime": "2021 09 28 15:53:06",
@@ -78,7 +78,7 @@
               "description": "HDB Indexserver-PRD",
               "elapsedtime": "689:20:30"
             },
-            "hdbpreprocessor": {
+            {
               "pid": 16581,
               "name": "hdbpreprocessor",
               "starttime": "2021 09 28 15:53:04",
@@ -87,7 +87,7 @@
               "description": "HDB Preprocessor",
               "elapsedtime": "689:20:32"
             },
-            "hdbcompileserver": {
+            {
               "pid": 16579,
               "name": "hdbcompileserver",
               "starttime": "2021 09 28 15:53:04",
@@ -96,7 +96,7 @@
               "description": "HDB Compileserver",
               "elapsedtime": "689:20:32"
             },
-            "hdbwebdispatcher": {
+            {
               "pid": 16977,
               "name": "hdbwebdispatcher",
               "starttime": "2021 09 28 15:53:33",
@@ -105,69 +105,69 @@
               "description": "HDB Web Dispatcher",
               "elapsedtime": "689:20:03"
             }
-          },
-          "Properties": {
-            "SAPSYSTEM": {
+          ],
+          "Properties": [
+            {
               "value": "00",
               "property": "SAPSYSTEM",
               "propertytype": "Attribute"
             },
-            "DBServices": {
+            {
               "value": "YES",
               "property": "DBServices",
               "propertytype": "Attribute"
             },
-            "HANA Roles": {
+            {
               "value": "worker",
               "property": "HANA Roles",
               "propertytype": "Attribute"
             },
-            "Webmethods": {
+            {
               "value": "Start,InstanceStart,StartBypassHA,Bootstrap,Stop,InstanceStop,StopBypassHA,Shutdown,ParameterValue,GetProcessList,GetStartProfile,GetTraceFile,GetAlertTree,GetAlerts,RestartService,StopService,GetEnvironment,ListDeveloperTraces,ReadDeveloperTrace,RestartInstance,SendSignal,GetVersionInfo,GetQueueStatistic,GetInstanceProperties,OSExecute,ReadLogFile,AnalyseLogFiles,ListLogFiles,GetAccessPointList,GetSystemInstanceList,GetSystemUpdateList,StartSystem,StopSystem,RestartSystem,UpdateSystem,UpdateSCSInstance,CheckUpdateSystem,AccessCheck,GetProcessParameter,SetProcessParameter,SetProcessParameter2,CheckParameter,ShmDetach,GetNetworkId,GetSecNetworkId,RequestLogonFile,CreateSnapshot,ReadSnapshot,ListSnapshots,DeleteSnapshots,GetCallstack,ABAPReadSyslog,ABAPReadRawSyslog,ABAPGetWPTable,ABAPAcknowledgeAlerts,ABAPGetComponentList,ABAPCheckRFCDestinations,ABAPGetSystemWPTable,J2EEGetProcessList,J2EEGetProcessList2,J2EEControlProcess,J2EEGetThreadList,J2EEGetThreadList2,J2EEGetThreadCallStack,J2EEGetThreadTaskStack,J2EEGetSessionList,J2EEGetWebSessionList,J2EEGetWebSessionList2,J2EEGetCacheStatistic,J2EEGetCacheStatistic2,J2EEGetApplicationAliasList,J2EEGetVMGCHistory,J2EEGetVMGCHistory2,J2EEGetVMHeapInfo,J2EEGetEJBSessionList,J2EEGetRemoteObjectList,J2EEGetClusterMsgList,J2EEGetSharedTableInfo,J2EEGetComponentList,J2EEControlComponents,ICMGetThreadList,ICMGetConnectionList,ICMGetCacheEntries,ICMGetProxyConnectionList,WebDispGetServerList,WebDispGetGroupList,WebDispGetVirtHostList,WebDispGetUrlPrefixList,EnqGetLockTable,EnqRemoveLocks,EnqRemoveUserLocks,EnqGetStatistic,UpdateSystemPKI,UpdateInstancePSE,StorePSE,DeletePSE,CheckPSE,HACheckConfig,HACheckFailoverConfig,HAGetFailoverConfig,HAFailoverToNode,HASetMaintenanceMode,HACheckMaintenanceMode",
               "property": "Webmethods",
               "propertytype": "Attribute"
             },
-            "Process List": {
+            {
               "value": "GetProcessList",
               "property": "Process List",
               "propertytype": "NodeWebmethod"
             },
-            "SAPLOCALHOST": {
+            {
               "value": "vmhana01",
               "property": "SAPLOCALHOST",
               "propertytype": "Attribute"
             },
-            "Access Points": {
+            {
               "value": "GetAccessPointList",
               "property": "Access Points",
               "propertytype": "NodeWebmethod"
             },
-            "INSTANCE_NAME": {
+            {
               "value": "HDB00",
               "property": "INSTANCE_NAME",
               "propertytype": "Attribute"
             },
-            "SAPSYSTEMNAME": {
+            {
               "value": "PRD",
               "property": "SAPSYSTEMNAME",
               "propertytype": "Attribute"
             },
-            "StartPriority": {
+            {
               "value": "0.3",
               "property": "StartPriority",
               "propertytype": "Attribute"
             },
-            "Protected Webmethods": {
+            {
               "value": "ABAPAcknowledgeAlerts,ABAPCheckRFCDestinations,ABAPGetComponentList,ABAPGetSystemWPTable,ABAPGetWPTable,ABAPReadRawSyslog,ABAPReadSyslog,AnalyseLogFiles,Bootstrap,CheckParameter,CheckPSE,CheckUpdateSystem,ConfigureLogFileList,CreatePSECredential,CreateSnapshot,DeletePSE,DeleteSnapshots,EnqGetLockTable,EnqGetStatistic,EnqRemoveLocks,EnqRemoveUserLocks,GetAccessPointList,GetAlerts,GetAlertTree,GetCallstack,GetEnvironment,GetLogFileList,GetProcessParameter,GetQueueStatistic,GetStartProfile,GetSystemUpdateList,GetTraceFile,GetVersionInfo,HACheckConfig,HACheckFailoverConfig,HACheckMaintenanceMode,HAFailoverToNode,HAGetFailoverConfig,HASetMaintenanceMode,ICMGetCacheEntries,ICMGetConnectionList,ICMGetProxyConnectionList,ICMGetThreadList,InstanceStart,InstanceStop,J2EEControlCluster,J2EEControlComponents,J2EEControlProcess,J2EEDisableDbgSession,J2EEEnableDbgSession,J2EEGetApplicationAliasList,J2EEGetCacheStatistic,J2EEGetCacheStatistic2,J2EEGetClusterMsgList,J2EEGetComponentList,J2EEGetEJBSessionList,J2EEGetProcessList,J2EEGetProcessList2,J2EEGetRemoteObjectList,J2EEGetSessionList,J2EEGetSharedTableInfo,J2EEGetThreadCallStack,J2EEGetThreadList,J2EEGetThreadList2,J2EEGetThreadTaskStack,J2EEGetVMGCHistory,J2EEGetVMGCHistory2,J2EEGetVMHeapInfo,J2EEGetWebSessionList,J2EEGetWebSessionList2,ListDeveloperTraces,ListLogFiles,ListSnapshots,OSExecute,ParameterValue,ReadDeveloperTrace,ReadLogFile,ReadSnapshot,RestartInstance,RestartService,RestartSystem,SendSignal,SetProcessParameter,SetProcessParameter2,ShmDetach,Shutdown,Start,StartBypassHA,StartSystem,Stop,StopBypassHA,StopService,StopSystem,StorePSE,UpdateInstancePSE,UpdateSCSInstance,UpdateSystem,UpdateSystemPKI,WebDispGetServerList,WebDispGetGroupList,WebDispGetVirtHostList,WebDispGetUrlPrefixList,GetAgentConfig,GetListOfMaByCusGrp,GetMcInLocalMs,GetMtesByRequestTable,GetMtListByMtclass,InfoGetTree,MscCustomizeWrite,MscDeleteLines,MscReadCache,MsGetLocalMsInfo,MsGetMteclsInLocalMs,MtChangeStatus,MtCustomizeWrite,MtDbsetToWpsetByTid,MtDestroyMarkNTry,MteGetByToolRunstatus,MtGetAllToCust,MtGetAllToolsToSet,MtGetMteinfo,MtGetTidByName,MtRead,MtReset,PerfCustomizeWrite,PerfRead,PerfReadSmoothData,ReadDirectory,ReadFile,ReadProfileParameters,ReferenceRead,Register,RequestLogonFile,SnglmgsCustomizeWrite,SystemObjectSetValue,TextAttrRead,ToolGetEffective,ToolSet,ToolSetRuntimeStatus,TriggerDataCollection,Unregister,UtilAlChangeStatus,UtilMtGetAidByTid,UtilMtGetTreeLocal,UtilMtReadAll,UtilReadRawalertByAid,UtilSnglmsgReadRawdata",
               "property": "Protected Webmethods",
               "propertytype": "Attribute"
             },
-            "Parameter Documentation": {
+            {
               "value": "http://vmhana01:50013/sapparamEN.html",
               "property": "Parameter Documentation",
               "propertytype": "NodeURL"
             }
-          }
+          ]
         },
         "HdbnsutilSRstate": {
           "mode": "primary",
@@ -369,6 +369,6 @@
           "service/vmhana01/30007/SHIPPED_LAST_DELTA_REPLICA_START_TIME": "-"
         }
       }
-    }
+    ]
   }
 ]


### PR DESCRIPTION
Flat map SAP systems payload some lists.
- `Instances` list
- `SAP control Instances` list
- `SAP control processes` list
- `SAP properties` list
The key of those maps was redundant in fact.

Using a map was causing issues, as for example, the instances names (used as key) might not be unique, so the data was being overidden. This scenario is present when 2 instances of the same system are installed in the same host (we already have some user with this scenario).

I think this format of payload has more advantages, and matches better with the current backend system (as we don't have anymore big limitations to filter by fields, as we had at the beginning when consul was used as data storage).

PD: Backend changes coming soon!
