### PR TITLE
Detect AWS based on dmidecode system-manufacturer

### DIFF
--- a/internal/cloud/metadata.go
+++ b/internal/cloud/metadata.go
@@ -44,15 +44,30 @@ func identifyAzure() (bool, error) {
 
 func identifyAws() (bool, error) {
 	log.Debug("Checking if the VM is running on Aws...")
-	output, err := customExecCommand("dmidecode", "-s", "system-version").Output()
+	systemVersion, err := customExecCommand("dmidecode", "-s", "system-version").Output()
 	if err != nil {
 		return false, err
 	}
 
-	provider := strings.TrimSpace(string(output))
-	log.Debugf("dmidecode output: %s", provider)
+	systemVersionTrim := strings.ToLower(strings.TrimSpace(string(systemVersion)))
+	log.Debugf("dmidecode system-version output: %s", systemVersionTrim)
 
-	return regexp.MatchString(".*amazon.*", provider)
+	result, _ := regexp.MatchString(".*amazon.*", string(systemVersionTrim))
+	if result {
+		return result, nil
+	}
+
+	systemManufacturer, err := customExecCommand("dmidecode", "-s", "system-manufacturer").Output()
+	if err != nil {
+		return false, err
+	}
+
+	systemManufacturerTrim := strings.ToLower(strings.TrimSpace(string(systemManufacturer)))
+	log.Debugf("dmidecode system-manufacturer output: %s", systemManufacturerTrim)
+
+	result, _ = regexp.MatchString(".*amazon.*", systemManufacturerTrim)
+
+	return result, nil
 }
 
 func identifyGcp() (bool, error) {

--- a/internal/cloud/metadata_test.go
+++ b/internal/cloud/metadata_test.go
@@ -50,11 +50,15 @@ func TestIdentifyCloudProviderAzure(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func mockDmidecodeAws() *exec.Cmd {
+func mockDmidecodeAwsSystem() *exec.Cmd {
 	return exec.Command("echo", "4.11.amazon")
 }
 
-func TestIdentifyCloudProviderAws(t *testing.T) {
+func mockDmidecodeAwsManufacturer() *exec.Cmd {
+	return exec.Command("echo", "Amazon EC2")
+}
+
+func TestIdentifyCloudProviderAwsUsingSystemVersion(t *testing.T) {
 	mockCommand := new(mocks.CustomCommand)
 
 	customExecCommand = mockCommand.Execute
@@ -64,7 +68,30 @@ func TestIdentifyCloudProviderAws(t *testing.T) {
 	)
 
 	mockCommand.On("Execute", "dmidecode", "-s", "system-version").Return(
-		mockDmidecodeAws(),
+		mockDmidecodeAwsSystem(),
+	)
+
+	provider, err := IdentifyCloudProvider()
+
+	assert.Equal(t, "aws", provider)
+	assert.NoError(t, err)
+}
+
+func TestIdentifyCloudProviderAwsUsingManufacturer(t *testing.T) {
+	mockCommand := new(mocks.CustomCommand)
+
+	customExecCommand = mockCommand.Execute
+
+	mockCommand.On("Execute", "dmidecode", "-s", "chassis-asset-tag").Return(
+		mockDmidecodeNoCloud(),
+	)
+
+	mockCommand.On("Execute", "dmidecode", "-s", "system-version").Return(
+		mockDmidecodeNoCloud(),
+	)
+
+	mockCommand.On("Execute", "dmidecode", "-s", "system-manufacturer").Return(
+		mockDmidecodeAwsManufacturer(),
 	)
 
 	provider, err := IdentifyCloudProvider()
@@ -87,6 +114,10 @@ func TestIdentifyCloudProviderGcp(t *testing.T) {
 	)
 
 	mockCommand.On("Execute", "dmidecode", "-s", "system-version").Return(
+		mockDmidecodeNoCloud(),
+	)
+
+	mockCommand.On("Execute", "dmidecode", "-s", "system-manufacturer").Return(
 		mockDmidecodeNoCloud(),
 	)
 
@@ -114,6 +145,10 @@ func TestIdentifyCloudProviderNoCloud(t *testing.T) {
 	)
 
 	mockCommand.On("Execute", "dmidecode", "-s", "system-version").Return(
+		mockDmidecodeNoCloud(),
+	)
+
+	mockCommand.On("Execute", "dmidecode", "-s", "system-manufacturer").Return(
 		mockDmidecodeNoCloud(),
 	)
 
@@ -169,6 +204,10 @@ func TestNewCloudInstanceNoCloud(t *testing.T) {
 	)
 
 	mockCommand.On("Execute", "dmidecode", "-s", "system-version").Return(
+		mockDmidecodeNoCloud(),
+	)
+
+	mockCommand.On("Execute", "dmidecode", "-s", "system-manufacturer").Return(
 		mockDmidecodeNoCloud(),
 	)
 


### PR DESCRIPTION
This PR allows the cloud discovery to identify AWS as cloud provider using `dmidecode -s system-manufacturer` in addition to the already existing `dmidecode -s system-version` call.

