### PR TITLE
Add a debug trace to know why the cluster data is not built

### DIFF
--- a/internal/discovery/cluster.go
+++ b/internal/discovery/cluster.go
@@ -40,6 +40,7 @@ func (d ClusterDiscovery) GetInterval() time.Duration {
 func (d ClusterDiscovery) Discover() (string, error) {
 	cluster, err := cluster.NewCluster()
 	if err != nil {
+		log.Debugf("Error creating the cluster data object: %s", err)
 		return "No HA cluster discovered on this host", nil
 	}
 


### PR DESCRIPTION
For debugging purposes, add a new logging entry to print why the a cluster is not discovered in the host.
In the last case, it was not discovered because the `authkey` file was not there.

Adding it as an debug, because not having cluster might be normal in many nodes, so I don't want to spam errors if the logging is not set as debug.