### PR TITLE
Get the agent ID in the main agent code package

### DIFF
--- a/internal/agent.go
+++ b/internal/agent.go
@@ -3,17 +3,25 @@ package internal
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
+	"github.com/spf13/afero"
 
 	"github.com/trento-project/agent/internal/discovery"
 	"github.com/trento-project/agent/internal/discovery/collector"
 )
 
-const trentoAgentCheckId = "trentoAgent"
+const machineIdPath = "/etc/machine-id"
+
+var (
+	fileSystem      = afero.NewOsFs()
+	trentoNamespace = uuid.Must(uuid.Parse("fb92284e-aa5e-47f6-a883-bf9469e7a0dc"))
+)
 
 type Agent struct {
 	config          *Config
@@ -30,10 +38,14 @@ type Config struct {
 
 // NewAgent returns a new instance of Agent with the given configuration
 func NewAgent(config *Config) (*Agent, error) {
-	collectorClient, err := collector.NewCollectorClient(config.DiscoveriesConfig.CollectorConfig)
+	agentID, err := getAgentID()
 	if err != nil {
-		return nil, errors.Wrap(err, "could not create a collector client")
+		return nil, errors.Wrap(err, "could not get the agent ID")
 	}
+
+	config.DiscoveriesConfig.CollectorConfig.AgentID = agentID
+
+	collectorClient := collector.NewCollectorClient(config.DiscoveriesConfig.CollectorConfig)
 
 	discoveries := []discovery.Discovery{
 		discovery.NewClusterDiscovery(collectorClient, *config.DiscoveriesConfig),
@@ -53,6 +65,18 @@ func NewAgent(config *Config) (*Agent, error) {
 		discoveries:     discoveries,
 	}
 	return agent, nil
+}
+
+func getAgentID() (string, error) {
+	machineIDBytes, err := afero.ReadFile(fileSystem, machineIdPath)
+	if err != nil {
+		return "", err
+	}
+
+	machineID := strings.TrimSpace(string(machineIDBytes))
+	agentID := uuid.NewSHA1(trentoNamespace, []byte(machineID))
+
+	return agentID.String(), nil
 }
 
 // Start the Agent. This will start the discovery ticker and the heartbeat ticker

--- a/internal/agent_test.go
+++ b/internal/agent_test.go
@@ -1,0 +1,35 @@
+package internal
+
+import (
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/suite"
+	_ "github.com/trento-project/agent/test"
+)
+
+const (
+	DummyMachineID = "dummy-machine-id"
+	DummyAgentID   = "779cdd70-e9e2-58ca-b18a-bf3eb3f71244"
+)
+
+type AgentTestSuite struct {
+	suite.Suite
+}
+
+func TestAgentTestSuite(t *testing.T) {
+	suite.Run(t, new(AgentTestSuite))
+}
+
+func (suite *AgentTestSuite) SetupSuite() {
+	fileSystem = afero.NewMemMapFs()
+
+	afero.WriteFile(fileSystem, machineIdPath, []byte(DummyMachineID), 0644)
+}
+
+func (suite *AgentTestSuite) TestAgent_getAgentID() {
+	agentID, err := getAgentID()
+
+	suite.NoError(err)
+	suite.Equal(DummyAgentID, agentID)
+}

--- a/internal/discovery/collector/client_test.go
+++ b/internal/discovery/collector/client_test.go
@@ -7,15 +7,13 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/spf13/afero"
 	"github.com/stretchr/testify/suite"
 	_ "github.com/trento-project/agent/test"
 	"github.com/trento-project/agent/test/helpers"
 )
 
 const (
-	DummyMachineID = "dummy-machine-id"
-	DummyAgentID   = "779cdd70-e9e2-58ca-b18a-bf3eb3f71244"
+	DummyAgentID = "779cdd70-e9e2-58ca-b18a-bf3eb3f71244"
 )
 
 type CollectorClientTestSuite struct {
@@ -26,28 +24,13 @@ func TestCollectorClientTestSuite(t *testing.T) {
 	suite.Run(t, new(CollectorClientTestSuite))
 }
 
-func (suite *CollectorClientTestSuite) SetupSuite() {
-	fileSystem = afero.NewMemMapFs()
-
-	afero.WriteFile(fileSystem, machineIdPath, []byte(DummyMachineID), 0644)
-}
-
-func (suite *CollectorClientTestSuite) TestCollectorClient_NewClientWithoutTLS() {
-	_, err := NewCollectorClient(&Config{
-		ServerUrl: "http://localhost",
-		ApiKey:    "some-api-key",
-	})
-
-	suite.NoError(err)
-}
-
 func (suite *CollectorClientTestSuite) TestCollectorClient_PublishingSuccess() {
-	collectorClient, err := NewCollectorClient(&Config{
-		ServerUrl: "https://localhost",
-		ApiKey:    "some-api-key",
-	})
-
-	suite.NoError(err)
+	collectorClient := NewCollectorClient(
+		&Config{
+			AgentID:   DummyAgentID,
+			ServerUrl: "https://localhost",
+			ApiKey:    "some-api-key",
+		})
 
 	discoveredDataPayload := struct {
 		FieldA string
@@ -74,18 +57,18 @@ func (suite *CollectorClientTestSuite) TestCollectorClient_PublishingSuccess() {
 		}
 	})
 
-	err = collectorClient.Publish(discoveryType, discoveredDataPayload)
+	err := collectorClient.Publish(discoveryType, discoveredDataPayload)
 
 	suite.NoError(err)
 }
 
 func (suite *CollectorClientTestSuite) TestCollectorClient_PublishingFailure() {
-	collectorClient, err := NewCollectorClient(&Config{
-		ServerUrl: "http://localhost",
-		ApiKey:    "some-api-key",
-	})
-
-	suite.NoError(err)
+	collectorClient := NewCollectorClient(
+		&Config{
+			AgentID:   DummyAgentID,
+			ServerUrl: "http://localhost",
+			ApiKey:    "some-api-key",
+		})
 
 	collectorClient.httpClient.Transport = helpers.RoundTripFunc(func(req *http.Request) *http.Response {
 		suite.Equal(req.URL.String(), "http://localhost/api/collect")
@@ -94,18 +77,18 @@ func (suite *CollectorClientTestSuite) TestCollectorClient_PublishingFailure() {
 		}
 	})
 
-	err = collectorClient.Publish("some_discovery_type", struct{}{})
+	err := collectorClient.Publish("some_discovery_type", struct{}{})
 
 	suite.Error(err)
 }
 
 func (suite *CollectorClientTestSuite) TestCollectorClient_Heartbeat() {
-	collectorClient, err := NewCollectorClient(&Config{
-		ServerUrl: "https://localhost",
-		ApiKey:    "some-api-key",
-	})
-
-	suite.NoError(err)
+	collectorClient := NewCollectorClient(
+		&Config{
+			AgentID:   DummyAgentID,
+			ServerUrl: "https://localhost",
+			ApiKey:    "some-api-key",
+		})
 
 	collectorClient.httpClient.Transport = helpers.RoundTripFunc(func(req *http.Request) *http.Response {
 		suite.Equal(req.URL.String(), fmt.Sprintf("https://localhost/api/hosts/%s/heartbeat", DummyAgentID))
@@ -113,7 +96,7 @@ func (suite *CollectorClientTestSuite) TestCollectorClient_Heartbeat() {
 			StatusCode: 204,
 		}
 	})
-	err = collectorClient.Heartbeat()
+	err := collectorClient.Heartbeat()
 
 	suite.NoError(err)
 }

--- a/internal/discovery/collector/publishing_test.go
+++ b/internal/discovery/collector/publishing_test.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/spf13/afero"
 	"github.com/stretchr/testify/suite"
 	"github.com/trento-project/agent/internal/discovery/mocks"
 	_ "github.com/trento-project/agent/test"
@@ -24,15 +23,12 @@ func TestPublishingTestSuite(t *testing.T) {
 }
 
 func (suite *PublishingTestSuite) SetupSuite() {
-	fileSystem = afero.NewMemMapFs()
-
-	afero.WriteFile(fileSystem, machineIdPath, []byte(DummyMachineID), 0644)
-
-	collectorClient, err := NewCollectorClient(&Config{
-		ServerUrl: "https://localhost",
-		ApiKey:    "some-api-key",
-	})
-	suite.NoError(err)
+	collectorClient := NewCollectorClient(
+		&Config{
+			AgentID:   DummyAgentID,
+			ServerUrl: "https://localhost",
+			ApiKey:    "some-api-key",
+		})
 
 	suite.configuredClient = collectorClient
 }

--- a/internal/discovery/collector/uuid.go
+++ b/internal/discovery/collector/uuid.go
@@ -1,5 +1,0 @@
-package collector
-
-import "github.com/google/uuid"
-
-var TrentoNamespace = uuid.Must(uuid.Parse("fb92284e-aa5e-47f6-a883-bf9469e7a0dc"))


### PR DESCRIPTION
In order to start introducing fact gathering in the Agent side, we need to know the Agent ID beforehand, so we can do more operations (like start consuming from rabbitmq in a queue with the AgentID name).

Now, the Agent ID is attached to the discovery publishing, and this limits its usage. 
The PR aims to make the Agent ID more broadly available in the agent code.