### PR TITLE
Change trento-premium to be obsolete in the spec

### DIFF
--- a/packaging/suse/trento-agent.spec
+++ b/packaging/suse/trento-agent.spec
@@ -33,7 +33,9 @@ BuildRequires:  golang(API) = 1.16
 Requires:       golang-github-prometheus-node_exporter
 Provides:       %{name} = %{version}-%{release}
 Provides:       trento = %{version}-%{release}
+Provides:       trento-premium = %{version}-%{release}
 Obsoletes:      trento < %{version}-%{release}
+Obsoletes:      trento-premium < 0.9.1-0
 
 %{go_nostrip}
 


### PR DESCRIPTION
This PR simply changes the relationship in the spec file with the old `trento-premium` package so that it's now marked as Obsolete. This should reduce the possibility of users installing the older package without noticing that it has been obsoleted.