### PR TITLE
Gather facts command

### DIFF
--- a/cmd/facts.go
+++ b/cmd/facts.go
@@ -1,0 +1,77 @@
+package cmd
+
+import (
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+
+	"github.com/trento-project/agent/internal"
+	"github.com/trento-project/agent/internal/factsengine"
+	"github.com/trento-project/agent/internal/factsengine/gatherers"
+)
+
+func NewFactsCmd() *cobra.Command {
+	factsCmd := &cobra.Command{
+		Use:   "facts",
+		Short: "Run facts related operations",
+	}
+
+	factsCmd.AddCommand(NewFactsGatherCmd())
+
+	return factsCmd
+}
+
+func NewFactsGatherCmd() *cobra.Command {
+	gatherCmd := &cobra.Command{
+		Use:   "gather",
+		Short: "Gather the requested fact",
+		Run:   gather,
+		PersistentPreRunE: func(agentCmd *cobra.Command, _ []string) error {
+			agentCmd.Flags().VisitAll(func(f *pflag.Flag) {
+				viper.BindPFlag(f.Name, f)
+			})
+
+			return internal.InitConfig("agent")
+		},
+	}
+
+	gatherCmd.Flags().String("gatherer", "", "The gatherer to use")
+	gatherCmd.Flags().String("argument", "", "The used gatherer argument")
+	gatherCmd.MarkFlagRequired("gatherer")
+	gatherCmd.MarkFlagRequired("argument")
+
+	return gatherCmd
+}
+
+func gather(*cobra.Command, []string) {
+	var gatherer = viper.GetString("gatherer")
+	var argument = viper.GetString("argument")
+
+	engine := factsengine.NewFactsEngine("", "")
+
+	g, err := engine.GetGatherer(gatherer)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	factRequest := []gatherers.FactRequest{
+		{
+			Name:     argument,
+			Argument: argument,
+		},
+	}
+
+	value, err := g.Gather(factRequest)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	result, err := factsengine.PrettifyFactResult(value[0])
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	log.Printf("Gathererd fact for \"%s\" with argument \"%s\":", gatherer, argument)
+	log.Printf("%s", result)
+}

--- a/cmd/facts.go
+++ b/cmd/facts.go
@@ -18,6 +18,7 @@ func NewFactsCmd() *cobra.Command {
 	}
 
 	factsCmd.AddCommand(NewFactsGatherCmd())
+	factsCmd.AddCommand(NewFactsListCmd())
 
 	return factsCmd
 }
@@ -40,6 +41,23 @@ func NewFactsGatherCmd() *cobra.Command {
 	gatherCmd.Flags().String("argument", "", "The used gatherer argument")
 	gatherCmd.MarkFlagRequired("gatherer")
 	gatherCmd.MarkFlagRequired("argument")
+
+	return gatherCmd
+}
+
+func NewFactsListCmd() *cobra.Command {
+	gatherCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List the available gatherers",
+		Run:   list,
+		PersistentPreRunE: func(agentCmd *cobra.Command, _ []string) error {
+			agentCmd.Flags().VisitAll(func(f *pflag.Flag) {
+				viper.BindPFlag(f.Name, f)
+			})
+
+			return internal.InitConfig("agent")
+		},
+	}
 
 	return gatherCmd
 }
@@ -72,6 +90,17 @@ func gather(*cobra.Command, []string) {
 		log.Fatal(err)
 	}
 
-	log.Printf("Gathererd fact for \"%s\" with argument \"%s\":", gatherer, argument)
+	log.Printf("Gathered fact for \"%s\" with argument \"%s\":", gatherer, argument)
 	log.Printf("%s", result)
+}
+
+func list(*cobra.Command, []string) {
+	engine := factsengine.NewFactsEngine("", "")
+	gatherers := engine.GetGatherersList()
+
+	log.Printf("Available gatherers:")
+
+	for _, g := range gatherers {
+		log.Printf(g)
+	}
 }

--- a/cmd/facts.go
+++ b/cmd/facts.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -12,7 +13,7 @@ import (
 )
 
 func NewFactsCmd() *cobra.Command {
-	factsCmd := &cobra.Command{
+	factsCmd := &cobra.Command{ //nolint
 		Use:   "facts",
 		Short: "Run facts related operations",
 	}
@@ -24,13 +25,16 @@ func NewFactsCmd() *cobra.Command {
 }
 
 func NewFactsGatherCmd() *cobra.Command {
-	gatherCmd := &cobra.Command{
+	gatherCmd := &cobra.Command{ //nolint
 		Use:   "gather",
 		Short: "Gather the requested fact",
 		Run:   gather,
 		PersistentPreRunE: func(agentCmd *cobra.Command, _ []string) error {
 			agentCmd.Flags().VisitAll(func(f *pflag.Flag) {
-				viper.BindPFlag(f.Name, f)
+				err := viper.BindPFlag(f.Name, f)
+				if err != nil {
+					panic(errors.Wrap(err, "error during cli init"))
+				}
 			})
 
 			return internal.InitConfig("agent")
@@ -39,20 +43,29 @@ func NewFactsGatherCmd() *cobra.Command {
 
 	gatherCmd.Flags().String("gatherer", "", "The gatherer to use")
 	gatherCmd.Flags().String("argument", "", "The used gatherer argument")
-	gatherCmd.MarkFlagRequired("gatherer")
-	gatherCmd.MarkFlagRequired("argument")
+	err := gatherCmd.MarkFlagRequired("gatherer")
+	if err != nil {
+		panic(err)
+	}
+	err = gatherCmd.MarkFlagRequired("argument")
+	if err != nil {
+		panic(err)
+	}
 
 	return gatherCmd
 }
 
 func NewFactsListCmd() *cobra.Command {
-	gatherCmd := &cobra.Command{
+	gatherCmd := &cobra.Command{ //nolint
 		Use:   "list",
 		Short: "List the available gatherers",
 		Run:   list,
 		PersistentPreRunE: func(agentCmd *cobra.Command, _ []string) error {
 			agentCmd.Flags().VisitAll(func(f *pflag.Flag) {
-				viper.BindPFlag(f.Name, f)
+				err := viper.BindPFlag(f.Name, f)
+				if err != nil {
+					panic(errors.Wrap(err, "error during cli init"))
+				}
 			})
 
 			return internal.InitConfig("agent")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,18 +1,10 @@
 package cmd
 
 import (
-	"context"
-	"log"
-	"os"
-	"os/signal"
-	"syscall"
-
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
-
-	"github.com/trento-project/agent/internal"
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -49,37 +41,4 @@ that can help you deploy, provision and operate infrastructure for SAP Applicati
 	rootCmd.AddCommand(NewVersionCmd())
 
 	return rootCmd
-}
-
-func start(*cobra.Command, []string) {
-	var err error
-
-	ctx, ctxCancel := context.WithCancel(context.Background())
-
-	signals := make(chan os.Signal, 1)
-	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM)
-
-	config, err := LoadConfig()
-	if err != nil {
-		log.Fatal("Failed to create the agent configuration: ", err)
-	}
-
-	a, err := internal.NewAgent(config)
-	if err != nil {
-		log.Fatal("Failed to create the agent: ", err)
-	}
-
-	go func() {
-		quit := <-signals
-		log.Printf("Caught %s signal!", quit)
-
-		log.Println("Stopping the agent...")
-		a.Stop(ctxCancel)
-	}()
-
-	log.Println("Starting the Console Agent...")
-	err = a.Start(ctx)
-	if err != nil {
-		log.Fatal("Failed to start the agent: ", err)
-	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -38,6 +38,7 @@ that can help you deploy, provision and operate infrastructure for SAP Applicati
 	})
 
 	rootCmd.AddCommand(NewStartCmd())
+	rootCmd.AddCommand(NewFactsCmd())
 	rootCmd.AddCommand(NewVersionCmd())
 
 	return rootCmd

--- a/internal/factsengine/factsengine.go
+++ b/internal/factsengine/factsengine.go
@@ -34,7 +34,7 @@ func (c *FactsEngine) GetGatherer(gatherer string) (gatherers.FactGatherer, erro
 	if g, found := c.factGatherers[gatherer]; found {
 		return g, nil
 	}
-	return nil, fmt.Errorf("gatherer %s not found", gatherer)
+	return nil, errors.Errorf("gatherer %s not found", gatherer)
 }
 
 func (c *FactsEngine) GetGatherersList() []string {
@@ -95,12 +95,12 @@ func (c *FactsEngine) Listen(ctx context.Context) error {
 func PrettifyFactResult(fact gatherers.Fact) (string, error) {
 	jsonResult, err := json.Marshal(fact)
 	if err != nil {
-		return "", fmt.Errorf("Error building the response: %s", err)
+		return "", errors.Wrap(err, "Error building the response")
 	}
 
 	result, err := prettyString(jsonResult)
 	if err != nil {
-		return "", fmt.Errorf("Error prettifying the results: %s", err)
+		return "", errors.Wrap(err, "Error prettifying the results")
 	}
 
 	return result, nil

--- a/internal/factsengine/factsengine.go
+++ b/internal/factsengine/factsengine.go
@@ -37,6 +37,16 @@ func (c *FactsEngine) GetGatherer(gatherer string) (gatherers.FactGatherer, erro
 	return nil, fmt.Errorf("gatherer %s not found", gatherer)
 }
 
+func (c *FactsEngine) GetGatherersList() []string {
+	gatherersList := []string{}
+
+	for gatherer := range c.factGatherers {
+		gatherersList = append(gatherersList, gatherer)
+	}
+
+	return gatherersList
+}
+
 func (c *FactsEngine) Subscribe() error {
 	log.Infof("Subscribing agent %s to the facts gathering reception service on %s", c.agentID, c.factsEngineService)
 	// RabbitMQ adapter exists only by now

--- a/internal/factsengine/factsengine_test.go
+++ b/internal/factsengine/factsengine_test.go
@@ -289,3 +289,34 @@ func (suite *FactsEngineTestSuite) TestCorosyncConfBuildResponse() {
 	suite.NoError(err)
 	suite.Equal(expectedResponse, string(response))
 }
+
+func (suite *FactsEngineTestSuite) TestCorosyncConf_GetGatherer() {
+	engine := NewFactsEngine("", "")
+	g, err := engine.GetGatherer("corosync.conf")
+
+	expectedGatherer := &gatherers.CorosyncConfGatherer{}
+
+	suite.NoError(err)
+	suite.Equal(expectedGatherer, g)
+}
+
+func (suite *FactsEngineTestSuite) TestCorosyncConf_GetGatherer_NotFound() {
+	engine := NewFactsEngine("", "")
+	_, err := engine.GetGatherer("other")
+
+	suite.EqualError(err, "gatherer other not found")
+}
+
+func (suite *FactsEngineTestSuite) TestCorosyncConf_PrettifyFactResult() {
+	fact := gatherers.Fact{
+		Name:  "some-fact",
+		Value: 1,
+	}
+
+	prettifiedFact, err := PrettifyFactResult(fact)
+
+	expectedResponse := "{\n  \"name\": \"some-fact\",\n  \"value\": 1\n}"
+
+	suite.NoError(err)
+	suite.Equal(expectedResponse, prettifiedFact)
+}

--- a/internal/factsengine/factsengine_test.go
+++ b/internal/factsengine/factsengine_test.go
@@ -307,6 +307,22 @@ func (suite *FactsEngineTestSuite) TestCorosyncConf_GetGatherer_NotFound() {
 	suite.EqualError(err, "gatherer other not found")
 }
 
+func (suite *FactsEngineTestSuite) TestCorosyncConf_GetGatherersList() {
+	engine := &FactsEngine{
+		factGatherers: map[string]gatherers.FactGatherer{
+			"dummyGatherer1": NewDummyGatherer1(),
+			"dummyGatherer2": NewDummyGatherer2(),
+			"errorGatherer":  NewErrorGatherer(),
+		},
+	}
+
+	gatherers := engine.GetGatherersList()
+
+	expectedGatherers := []string{"dummyGatherer1", "dummyGatherer2", "errorGatherer"}
+
+	suite.ElementsMatch(expectedGatherers, gatherers)
+}
+
 func (suite *FactsEngineTestSuite) TestCorosyncConf_PrettifyFactResult() {
 	fact := gatherers.Fact{
 		Name:  "some-fact",

--- a/internal/factsengine/factsengine_test.go
+++ b/internal/factsengine/factsengine_test.go
@@ -290,7 +290,7 @@ func (suite *FactsEngineTestSuite) TestCorosyncConfBuildResponse() {
 	suite.Equal(expectedResponse, string(response))
 }
 
-func (suite *FactsEngineTestSuite) TestCorosyncConf_GetGatherer() {
+func (suite *FactsEngineTestSuite) TestCorosyncConfGetGatherer() {
 	engine := NewFactsEngine("", "")
 	g, err := engine.GetGatherer("corosync.conf")
 
@@ -300,15 +300,15 @@ func (suite *FactsEngineTestSuite) TestCorosyncConf_GetGatherer() {
 	suite.Equal(expectedGatherer, g)
 }
 
-func (suite *FactsEngineTestSuite) TestCorosyncConf_GetGatherer_NotFound() {
+func (suite *FactsEngineTestSuite) TestCorosyncConfGetGathererNotFound() {
 	engine := NewFactsEngine("", "")
 	_, err := engine.GetGatherer("other")
 
 	suite.EqualError(err, "gatherer other not found")
 }
 
-func (suite *FactsEngineTestSuite) TestCorosyncConf_GetGatherersList() {
-	engine := &FactsEngine{
+func (suite *FactsEngineTestSuite) TestCorosyncConfGetGatherersList() {
+	engine := &FactsEngine{ // nolint
 		factGatherers: map[string]gatherers.FactGatherer{
 			"dummyGatherer1": NewDummyGatherer1(),
 			"dummyGatherer2": NewDummyGatherer2(),
@@ -323,7 +323,7 @@ func (suite *FactsEngineTestSuite) TestCorosyncConf_GetGatherersList() {
 	suite.ElementsMatch(expectedGatherers, gatherers)
 }
 
-func (suite *FactsEngineTestSuite) TestCorosyncConf_PrettifyFactResult() {
+func (suite *FactsEngineTestSuite) TestCorosyncConfPrettifyFactResult() {
 	fact := gatherers.Fact{
 		Name:  "some-fact",
 		Value: 1,


### PR DESCRIPTION
Some helper utilities for the agent to run and test the fact gathering. They help to the developers (and any user) to run and test the fact gathering options through the command line.

Gather a fact:
```
$> ./trento-agent facts gather --gatherer corosync.conf --argument totem.token
INFO[2022-07-22 13:48:31] Starting corosync.conf file facts gathering process 
INFO[2022-07-22 13:48:31] Requested corosync.conf file facts gathered  
INFO[2022-07-22 13:48:31] Gathered fact for "corosync.conf" with argument "totem.token": 
INFO[2022-07-22 13:48:31] {
  "name": "totem.token",
  "value": "30000"
} 
```

List available gatherers:
```
$> ./trento-agent facts list
INFO[2022-07-22 13:48:42] Available gatherers:                         
INFO[2022-07-22 13:48:42] corosync.conf
```