### PR TITLE
Remove the flavor field and add the installation source

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 VERSION ?= $(shell ./hack/get_version_from_git.sh)
-FLAVOR ?= "Community"
+INSTALLATIONSOURCE ?= "Community"
 LDFLAGS = -X github.com/trento-project/agent/version.Version="$(VERSION)"
-LDFLAGS := $(LDFLAGS) -X github.com/trento-project/agent/version.Flavor="$(FLAVOR)"
+LDFLAGS := $(LDFLAGS) -X github.com/trento-project/agent/version.InstallationSource="$(INSTALLATIONSOURCE)"
 ARCHS ?= amd64 arm64 ppc64le s390x
 DEBUG ?= 0
 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -14,7 +14,7 @@ func NewVersionCmd() *cobra.Command {
 		Short: "Print the version number of Trento",
 		Long:  `All software has versions. This is Trento's`,
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Printf("Trento %s version %s\nbuilt with %s %s/%s\n", version.Flavor, version.Version, runtime.Version(), runtime.GOOS, runtime.GOARCH) //nolint
+			fmt.Printf("Trento installed from %s version %s\nbuilt with %s %s/%s\n", version.InstallationSource, version.Version, runtime.Version(), runtime.GOOS, runtime.GOARCH) //nolint
 		},
 	}
 

--- a/internal/discovery/host.go
+++ b/internal/discovery/host.go
@@ -54,14 +54,15 @@ func (d HostDiscovery) Discover() (string, error) {
 	}
 
 	host := hosts.DiscoveredHost{
-		SSHAddress:      d.sshAddress,
-		OSVersion:       getOSVersion(),
-		HostIPAddresses: ipAddresses,
-		HostName:        d.host,
-		CPUCount:        getLogicalCPUs(),
-		SocketCount:     getCPUSocketCount(),
-		TotalMemoryMB:   getTotalMemoryMB(),
-		AgentVersion:    version.Version,
+		SSHAddress:         d.sshAddress,
+		OSVersion:          getOSVersion(),
+		HostIPAddresses:    ipAddresses,
+		HostName:           d.host,
+		CPUCount:           getLogicalCPUs(),
+		SocketCount:        getCPUSocketCount(),
+		TotalMemoryMB:      getTotalMemoryMB(),
+		AgentVersion:       version.Version,
+		InstallationSource: version.InstallationSource,
 	}
 
 	err = d.collectorClient.Publish(d.id, host)

--- a/internal/discovery/mocks/discovered_host_mock.go
+++ b/internal/discovery/mocks/discovered_host_mock.go
@@ -4,13 +4,14 @@ import "github.com/trento-project/agent/internal/hosts"
 
 func NewDiscoveredHostMock() hosts.DiscoveredHost {
 	return hosts.DiscoveredHost{
-		SSHAddress:      "10.2.2.22",
-		OSVersion:       "15-SP2",
-		HostIPAddresses: []string{"10.1.1.4", "10.1.1.5", "10.1.1.6"},
-		HostName:        "thehostnamewherethediscoveryhappened",
-		CPUCount:        2,
-		SocketCount:     1,
-		TotalMemoryMB:   4096,
-		AgentVersion:    "trento-agent-version",
+		SSHAddress:         "10.2.2.22",
+		OSVersion:          "15-SP2",
+		HostIPAddresses:    []string{"10.1.1.4", "10.1.1.5", "10.1.1.6"},
+		HostName:           "thehostnamewherethediscoveryhappened",
+		CPUCount:           2,
+		SocketCount:        1,
+		TotalMemoryMB:      4096,
+		AgentVersion:       "trento-agent-version",
+		InstallationSource: "Community",
 	}
 }

--- a/internal/hosts/discovered_host.go
+++ b/internal/hosts/discovered_host.go
@@ -1,12 +1,13 @@
 package hosts
 
 type DiscoveredHost struct {
-	SSHAddress      string   `json:"ssh_address"`
-	OSVersion       string   `json:"os_version"`
-	HostIPAddresses []string `json:"ip_addresses"`
-	HostName        string   `json:"hostname"`
-	CPUCount        int      `json:"cpu_count"`
-	SocketCount     int      `json:"socket_count"`
-	TotalMemoryMB   int      `json:"total_memory_mb"`
-	AgentVersion    string   `json:"agent_version"`
+	SSHAddress         string   `json:"ssh_address"`
+	OSVersion          string   `json:"os_version"`
+	HostIPAddresses    []string `json:"ip_addresses"`
+	HostName           string   `json:"hostname"`
+	CPUCount           int      `json:"cpu_count"`
+	SocketCount        int      `json:"socket_count"`
+	TotalMemoryMB      int      `json:"total_memory_mb"`
+	AgentVersion       string   `json:"agent_version"`
+	InstallationSource string   `json:"installation_source"`
 }

--- a/packaging/suse/trento-agent.spec
+++ b/packaging/suse/trento-agent.spec
@@ -55,7 +55,7 @@ applications.
 %define shortname agent
 
 %build
-VERSION=%{version} make build
+VERSION=%{version} INSTALLATIONSOURCE=Suse make build
 
 %install
 

--- a/test/fixtures/discovery/host/expected_published_host_discovery.json
+++ b/test/fixtures/discovery/host/expected_published_host_discovery.json
@@ -13,6 +13,7 @@
         "cpu_count": 2,
         "socket_count": 1,
         "total_memory_mb": 4096,
-        "agent_version": "trento-agent-version"
+        "agent_version": "trento-agent-version",
+        "installation_source": "Community"
     }
 }

--- a/version/version.go
+++ b/version/version.go
@@ -3,5 +3,5 @@ package version
 // We exclude that variables from linting
 // because we explicitly use that
 // in the ldflags at build time
-var Version string //nolint
-var Flavor string  //nolint
+var Version string            //nolint
+var InstallationSource string //nolint


### PR DESCRIPTION
The `flavor` field is not used in the Agent since the web code was extracted, and there is not any "premium" capability.
For that reason it is removed.

And in order to have more information in our telemetry system, a new "installation source" metric is added, so we know how the agent was installed. The options are:

- `Community`: The agent was build after getting it from Github (whether downloading the code and building or getting the artficats)
- `Suse`: The agent is installed through a RPM package coming from OBS/IBS. There is not any distinctions between the source repository.