### PR TITLE
Add AgentID and CheckID fields to facts result

### DIFF
--- a/internal/factsengine/factsengine.go
+++ b/internal/factsengine/factsengine.go
@@ -113,7 +113,7 @@ func (c *FactsEngine) handleRequest(request []byte) error {
 		return err
 	}
 
-	gatheredFacts, err := gatherFacts(factsRequests, c.factGatherers)
+	gatheredFacts, err := gatherFacts(c.agentID, factsRequests, c.factGatherers)
 	if err != nil {
 		log.Errorf("Error gathering facts: %s", err)
 		return err
@@ -128,11 +128,13 @@ func (c *FactsEngine) handleRequest(request []byte) error {
 }
 
 func gatherFacts(
+	agentID string,
 	groupedFactsRequest *gatherers.GroupedFactsRequest,
 	factGatherers map[string]gatherers.FactGatherer,
 ) (gatherers.FactsResult, error) {
 	factsResults := gatherers.FactsResult{
 		ExecutionID: groupedFactsRequest.ExecutionID,
+		AgentID:     agentID,
 		Facts:       nil,
 	}
 	factsCh := make(chan []gatherers.Fact, len(groupedFactsRequest.Facts))

--- a/internal/factsengine/factsengine_test.go
+++ b/internal/factsengine/factsengine_test.go
@@ -27,8 +27,9 @@ func NewDummyGatherer1() *DummyGatherer1 {
 func (s *DummyGatherer1) Gather(_ []gatherers.FactRequest) ([]gatherers.Fact, error) {
 	return []gatherers.Fact{
 		{
-			Name:  "dummy1",
-			Value: "1",
+			Name:    "dummy1",
+			Value:   "1",
+			CheckID: "check1",
 		},
 	}, nil
 }
@@ -43,8 +44,9 @@ func NewDummyGatherer2() *DummyGatherer2 {
 func (s *DummyGatherer2) Gather(_ []gatherers.FactRequest) ([]gatherers.Fact, error) {
 	return []gatherers.Fact{
 		{
-			Name:  "dummy2",
-			Value: "2",
+			Name:    "dummy2",
+			Value:   "2",
+			CheckID: "check1",
 		},
 	}, nil
 }
@@ -61,7 +63,8 @@ func (s *ErrorGatherer) Gather(_ []gatherers.FactRequest) ([]gatherers.Fact, err
 }
 
 func (suite *FactsEngineTestSuite) TestCorosyncConfGatherFacts() {
-	someID := "someID" //nolint
+	someID := "someID"     //nolint
+	agentID := "someAgent" //nolint
 
 	groupedFactsRequest := &gatherers.GroupedFactsRequest{
 		ExecutionID: someID,
@@ -71,6 +74,7 @@ func (suite *FactsEngineTestSuite) TestCorosyncConfGatherFacts() {
 					Name:     "dummy1",
 					Gatherer: "dummyGatherer1",
 					Argument: "dummy1",
+					CheckID:  "check1",
 				},
 			},
 			"dummyGatherer2": {
@@ -78,6 +82,7 @@ func (suite *FactsEngineTestSuite) TestCorosyncConfGatherFacts() {
 					Name:     "dummy2",
 					Gatherer: "dummyGatherer2",
 					Argument: "dummy2",
+					CheckID:  "check1",
 				},
 			},
 		},
@@ -88,26 +93,30 @@ func (suite *FactsEngineTestSuite) TestCorosyncConfGatherFacts() {
 		"dummyGatherer2": NewDummyGatherer2(),
 	}
 
-	factResults, err := gatherFacts(groupedFactsRequest, factGatherers)
+	factResults, err := gatherFacts(agentID, groupedFactsRequest, factGatherers)
 
 	expectedFacts := []gatherers.Fact{
 		{
-			Name:  "dummy1",
-			Value: "1",
+			Name:    "dummy1",
+			Value:   "1",
+			CheckID: "check1",
 		},
 		{
-			Name:  "dummy2",
-			Value: "2",
+			Name:    "dummy2",
+			Value:   "2",
+			CheckID: "check1",
 		},
 	}
 
 	suite.NoError(err)
 	suite.Equal(someID, factResults.ExecutionID)
+	suite.Equal(agentID, factResults.AgentID)
 	suite.ElementsMatch(expectedFacts, factResults.Facts)
 }
 
 func (suite *FactsEngineTestSuite) TestCorosyncConfGatherFactsGathererNotFound() {
 	someID := "someID"
+	agentID := "someAgent"
 
 	groupedFactsRequest := &gatherers.GroupedFactsRequest{
 		ExecutionID: someID,
@@ -117,6 +126,7 @@ func (suite *FactsEngineTestSuite) TestCorosyncConfGatherFactsGathererNotFound()
 					Name:     "dummy1",
 					Gatherer: "dummyGatherer1",
 					Argument: "dummy1",
+					CheckID:  "check1",
 				},
 			},
 			"otherGatherer": {
@@ -124,6 +134,7 @@ func (suite *FactsEngineTestSuite) TestCorosyncConfGatherFactsGathererNotFound()
 					Name:     "other",
 					Gatherer: "otherGatherer",
 					Argument: "other",
+					CheckID:  "check1",
 				},
 			},
 		},
@@ -134,22 +145,25 @@ func (suite *FactsEngineTestSuite) TestCorosyncConfGatherFactsGathererNotFound()
 		"dummyGatherer2": NewDummyGatherer2(),
 	}
 
-	factResults, err := gatherFacts(groupedFactsRequest, factGatherers)
+	factResults, err := gatherFacts(agentID, groupedFactsRequest, factGatherers)
 
 	expectedFacts := []gatherers.Fact{
 		{
-			Name:  "dummy1",
-			Value: "1",
+			Name:    "dummy1",
+			Value:   "1",
+			CheckID: "check1",
 		},
 	}
 
 	suite.NoError(err)
 	suite.Equal(someID, factResults.ExecutionID)
+	suite.Equal(agentID, factResults.AgentID)
 	suite.ElementsMatch(expectedFacts, factResults.Facts)
 }
 
 func (suite *FactsEngineTestSuite) TestCorosyncConfGatherFactsErrorGathering() {
 	someID := "someID"
+	agentID := "someAgent"
 
 	groupedFactsRequest := &gatherers.GroupedFactsRequest{
 		ExecutionID: someID,
@@ -159,6 +173,7 @@ func (suite *FactsEngineTestSuite) TestCorosyncConfGatherFactsErrorGathering() {
 					Name:     "dummy1",
 					Gatherer: "dummyGatherer1",
 					Argument: "dummy1",
+					CheckID:  "check1",
 				},
 			},
 			"errorGatherer": {
@@ -166,6 +181,7 @@ func (suite *FactsEngineTestSuite) TestCorosyncConfGatherFactsErrorGathering() {
 					Name:     "error",
 					Gatherer: "errorGatherer",
 					Argument: "error",
+					CheckID:  "check1",
 				},
 			},
 		},
@@ -176,17 +192,19 @@ func (suite *FactsEngineTestSuite) TestCorosyncConfGatherFactsErrorGathering() {
 		"errorGatherer":  NewErrorGatherer(),
 	}
 
-	factResults, err := gatherFacts(groupedFactsRequest, factGatherers)
+	factResults, err := gatherFacts(agentID, groupedFactsRequest, factGatherers)
 
 	expectedFacts := []gatherers.Fact{
 		{
-			Name:  "dummy1",
-			Value: "1",
+			Name:    "dummy1",
+			Value:   "1",
+			CheckID: "check1",
 		},
 	}
 
 	suite.NoError(err)
 	suite.Equal(someID, factResults.ExecutionID)
+	suite.Equal(agentID, factResults.AgentID)
 	suite.ElementsMatch(expectedFacts, factResults.Facts)
 }
 
@@ -196,14 +214,14 @@ func (suite *FactsEngineTestSuite) TestCorosyncConfParseFactsRequest() {
 	{
 		"execution_id": "some-id",
 		"facts": [
-			{"name": "sbd_device", "gatherer": "sbd_config", "argument": "SBD_DEVICE"},
-			{"name": "sbd_timeout_actions", "gatherer": "sbd_config", "argument": "SBD_TIMEOUT_ACTION"},
-			{"name": "pacemaker_version", "gatherer": "package_version", "argument": "pacemaker"},
-			{"name": "corosync_version", "gatherer": "package_version", "argument": "corosync"},
-			{"name": "sbd_pcmk_delay_max", "gatherer": "cib", "argument": "//primitive[@type='external/sbd']/instance_attributes/nvpair[@name='pcmk_delay_max']/@value"},
-			{"name": "cib_sid", "gatherer": "cib", "argument": "//primitive[@type='SAPHana']/instance_attributes/nvpair[@name='SID']/@value"},
-			{"name": "corosync_token", "gatherer": "corosync.conf", "argument": "totem.token"},
-			{"name": "corosync_join", "gatherer": "corosync.conf", "argument": "totem.join"}
+			{"name": "sbd_device", "gatherer": "sbd_config", "argument": "SBD_DEVICE", "check_id": "check1"},
+			{"name": "sbd_timeout_actions", "gatherer": "sbd_config", "argument": "SBD_TIMEOUT_ACTION", "check_id": "check1"},
+			{"name": "pacemaker_version", "gatherer": "package_version", "argument": "pacemaker", "check_id": "check2"},
+			{"name": "corosync_version", "gatherer": "package_version", "argument": "corosync", "check_id": "check3"},
+			{"name": "sbd_pcmk_delay_max", "gatherer": "cib", "argument": "//primitive[@type='external/sbd']/instance_attributes/nvpair[@name='pcmk_delay_max']/@value", "check_id": "check4"},
+			{"name": "cib_sid", "gatherer": "cib", "argument": "//primitive[@type='SAPHana']/instance_attributes/nvpair[@name='SID']/@value", "check_id": "check5"},
+			{"name": "corosync_token", "gatherer": "corosync.conf", "argument": "totem.token", "check_id": "check6"},
+			{"name": "corosync_join", "gatherer": "corosync.conf", "argument": "totem.join", "check_id": "check6"}
 		]
 	}`
 
@@ -217,11 +235,13 @@ func (suite *FactsEngineTestSuite) TestCorosyncConfParseFactsRequest() {
 					Name:     "sbd_device",
 					Gatherer: "sbd_config",
 					Argument: "SBD_DEVICE",
+					CheckID:  "check1",
 				},
 				{
 					Name:     "sbd_timeout_actions",
 					Gatherer: "sbd_config",
 					Argument: "SBD_TIMEOUT_ACTION",
+					CheckID:  "check1",
 				},
 			},
 			"package_version": {
@@ -229,11 +249,13 @@ func (suite *FactsEngineTestSuite) TestCorosyncConfParseFactsRequest() {
 					Name:     "pacemaker_version",
 					Gatherer: "package_version",
 					Argument: "pacemaker",
+					CheckID:  "check2",
 				},
 				{
 					Name:     "corosync_version",
 					Gatherer: "package_version",
 					Argument: "corosync",
+					CheckID:  "check3",
 				},
 			},
 			"cib": {
@@ -241,11 +263,13 @@ func (suite *FactsEngineTestSuite) TestCorosyncConfParseFactsRequest() {
 					Name:     "sbd_pcmk_delay_max",
 					Gatherer: "cib",
 					Argument: "//primitive[@type='external/sbd']/instance_attributes/nvpair[@name='pcmk_delay_max']/@value",
+					CheckID:  "check4",
 				},
 				{
 					Name:     "cib_sid",
 					Gatherer: "cib",
 					Argument: "//primitive[@type='SAPHana']/instance_attributes/nvpair[@name='SID']/@value",
+					CheckID:  "check5",
 				},
 			},
 			"corosync.conf": {
@@ -253,11 +277,13 @@ func (suite *FactsEngineTestSuite) TestCorosyncConfParseFactsRequest() {
 					Name:     "corosync_token",
 					Gatherer: "corosync.conf",
 					Argument: "totem.token",
+					CheckID:  "check6",
 				},
 				{
 					Name:     "corosync_join",
 					Gatherer: "corosync.conf",
 					Argument: "totem.join",
+					CheckID:  "check6",
 				},
 			},
 		},
@@ -270,21 +296,24 @@ func (suite *FactsEngineTestSuite) TestCorosyncConfParseFactsRequest() {
 func (suite *FactsEngineTestSuite) TestCorosyncConfBuildResponse() {
 	facts := gatherers.FactsResult{
 		ExecutionID: "some-id",
+		AgentID:     "some-agent",
 		Facts: []gatherers.Fact{
 			{
-				Name:  "fact1",
-				Value: "1",
+				Name:    "fact1",
+				Value:   "1",
+				CheckID: "check1",
 			},
 			{
-				Name:  "fact2",
-				Value: "2",
+				Name:    "fact2",
+				Value:   "2",
+				CheckID: "check2",
 			},
 		},
 	}
 
 	response, err := buildResponse(facts)
 
-	expectedResponse := `{"execution_id":"some-id","facts":[{"name":"fact1","value":"1"},{"name":"fact2","value":"2"}]}`
+	expectedResponse := `{"execution_id":"some-id","agent_id":"some-agent","facts":[{"name":"fact1","value":"1","check_id":"check1"},{"name":"fact2","value":"2","check_id":"check2"}]}`
 
 	suite.NoError(err)
 	suite.Equal(expectedResponse, string(response))
@@ -325,13 +354,14 @@ func (suite *FactsEngineTestSuite) TestCorosyncConfGetGatherersList() {
 
 func (suite *FactsEngineTestSuite) TestCorosyncConfPrettifyFactResult() {
 	fact := gatherers.Fact{
-		Name:  "some-fact",
-		Value: 1,
+		Name:    "some-fact",
+		Value:   1,
+		CheckID: "check1",
 	}
 
 	prettifiedFact, err := PrettifyFactResult(fact)
 
-	expectedResponse := "{\n  \"name\": \"some-fact\",\n  \"value\": 1\n}"
+	expectedResponse := "{\n  \"name\": \"some-fact\",\n  \"value\": 1,\n  \"check_id\": \"check1\"\n}"
 
 	suite.NoError(err)
 	suite.Equal(expectedResponse, prettifiedFact)

--- a/internal/factsengine/gatherers/corosyncconf.go
+++ b/internal/factsengine/gatherers/corosyncconf.go
@@ -48,11 +48,7 @@ func (s *CorosyncConfGatherer) Gather(factsRequests []FactRequest) ([]Fact, erro
 	}
 
 	for _, factReq := range factsRequests {
-		fact := Fact{
-			Name:  factReq.Name,
-			Value: getValue(corosycnMap, strings.Split(factReq.Argument, ".")),
-		}
-
+		fact := NewFactWithRequest(factReq, getValue(corosycnMap, strings.Split(factReq.Argument, ".")))
 		facts = append(facts, fact)
 	}
 

--- a/internal/factsengine/gatherers/facts.go
+++ b/internal/factsengine/gatherers/facts.go
@@ -2,12 +2,14 @@ package gatherers
 
 type FactsResult struct {
 	ExecutionID string `json:"execution_id"`
+	AgentID     string `json:"agent_id"`
 	Facts       []Fact `json:"facts"`
 }
 
 type Fact struct {
-	Name  string      `json:"name"`
-	Value interface{} `json:"value"`
+	Name    string      `json:"name"`
+	Value   interface{} `json:"value"`
+	CheckID string      `json:"check_id"`
 }
 
 type FactsRequest struct {
@@ -24,4 +26,13 @@ type FactRequest struct {
 	Name     string `json:"name"`
 	Gatherer string `json:"gatherer"`
 	Argument string `json:"argument"`
+	CheckID  string `json:"check_id"`
+}
+
+func NewFactWithRequest(req FactRequest, value interface{}) Fact {
+	return Fact{
+		Name:    req.Name,
+		CheckID: req.CheckID,
+		Value:   value,
+	}
 }


### PR DESCRIPTION
Add AgentID and CheckID fields to facts request and result, on order to provide Wanda all the required data.

@CDimonaco I have created the new `CreateFactWithRequest` function in order to make the creation easier and more standardized. It is used in the `Gather` function of the `corosyncconf.go` file. I was thinking if we could enforce the usage of this method somehow in the `Gather` functions, so new gatherers don't miss all the fields. Do you know any trick we could have to enforce this? Maybe there isn't hehe, and we would need to validate later on all the fields are populated.