### PR TITLE
Package version gatherer

### DIFF
--- a/internal/factsengine/factsengine.go
+++ b/internal/factsengine/factsengine.go
@@ -26,8 +26,9 @@ func NewFactsEngine(agentID, factsEngineService string) *FactsEngine {
 		factsEngineService:  factsEngineService,
 		factsServiceAdapter: nil,
 		factGatherers: map[string]gatherers.FactGatherer{
-			gatherers.CorosyncFactKey:        gatherers.NewCorosyncConfGatherer(),
-			gatherers.CorosyncCmapCtlFactKey: gatherers.NewCorosyncCmapctlGatherer(),
+			gatherers.CorosyncFactKey:            gatherers.NewCorosyncConfGatherer(),
+			gatherers.CorosyncCmapCtlFactKey:     gatherers.NewCorosyncCmapctlGatherer(),
+			gatherers.PackageVersionGathererName: gatherers.NewPackageVersionGatherer(),
 		},
 		pluginLoaders: NewPluginLoaders(),
 	}

--- a/internal/factsengine/factsengine_test.go
+++ b/internal/factsengine/factsengine_test.go
@@ -64,7 +64,7 @@ func (s *ErrorGatherer) Gather(_ []gatherers.FactRequest) ([]gatherers.Fact, err
 	return []gatherers.Fact{}, fmt.Errorf("kabum!") //nolint
 }
 
-func (suite *FactsEngineTestSuite) TestCorosyncConfGatherFacts() {
+func (suite *FactsEngineTestSuite) TestFactsEngineGatherFacts() {
 	someID := "someID"     //nolint
 	agentID := "someAgent" //nolint
 
@@ -350,6 +350,16 @@ func (suite *FactsEngineTestSuite) TestFactsEngineGetGatherersList() {
 	gatherers := engine.GetGatherersList()
 
 	expectedGatherers := []string{"dummyGatherer1", "dummyGatherer2", "errorGatherer"}
+
+	suite.ElementsMatch(expectedGatherers, gatherers)
+}
+
+func (suite *FactsEngineTestSuite) TestFactsEngineGetGatherersListNative() {
+	engine := NewFactsEngine("", "")
+
+	gatherers := engine.GetGatherersList()
+
+	expectedGatherers := []string{"corosync.conf", "corosync-cmapctl", "package_version"}
 
 	suite.ElementsMatch(expectedGatherers, gatherers)
 }

--- a/internal/factsengine/gatherers/packageversion.go
+++ b/internal/factsengine/gatherers/packageversion.go
@@ -1,0 +1,38 @@
+package gatherers
+
+import (
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	PackageVersionGathererName = "package_version"
+)
+
+type PackageVersionGatherer struct {
+	executor CommandExecutor
+}
+
+func NewPackageVersionGatherer() *PackageVersionGatherer {
+	return &PackageVersionGatherer{
+		executor: Executor{},
+	}
+}
+
+func (g *PackageVersionGatherer) Gather(factsRequests []FactRequest) ([]Fact, error) {
+	facts := []Fact{}
+	log.Infof("Starting Package versions facts gathering process")
+
+	for _, factReq := range factsRequests {
+		version, err := g.executor.Exec(
+			"rpm", "-q", "--qf", "%{VERSION}", factReq.Argument)
+		if err != nil {
+			// TODO: Decide together with Wanda how to deal with errors. `err` field in the fact result?
+			log.Errorf("Error getting version of package: %s", factReq.Argument)
+		}
+		fact := NewFactWithRequest(factReq, string(version))
+		facts = append(facts, fact)
+	}
+
+	log.Infof("Requested Package versions facts gathered")
+	return facts, nil
+}

--- a/internal/factsengine/gatherers/packageversion_test.go
+++ b/internal/factsengine/gatherers/packageversion_test.go
@@ -1,0 +1,109 @@
+package gatherers
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	mocks "github.com/trento-project/agent/internal/factsengine/gatherers/mocks"
+)
+
+type PackageVersionTestSuite struct {
+	suite.Suite
+}
+
+func TestPackageVersionTestSuite(t *testing.T) {
+	suite.Run(t, new(PackageVersionTestSuite))
+}
+
+func (suite *PackageVersionTestSuite) TestPackageVersionGather() {
+	mockExecutor := new(mocks.CommandExecutor)
+
+	mockExecutor.On("Exec", "rpm", "-q", "--qf", "%{VERSION}", "corosync").Return(
+		[]byte("2.4.5"), nil)
+	mockExecutor.On("Exec", "rpm", "-q", "--qf", "%{VERSION}", "pacemaker").Return(
+		[]byte("2.0.5+20201202.ba59be712"), nil)
+
+	p := &PackageVersionGatherer{
+		executor: mockExecutor,
+	}
+
+	factRequests := []FactRequest{
+		{
+			Name:     "corosync",
+			Gatherer: "package_version",
+			Argument: "corosync",
+			CheckID:  "check1",
+		},
+		{
+			Name:     "pacemaker",
+			Gatherer: "package_version",
+			Argument: "pacemaker",
+			CheckID:  "check2",
+		},
+	}
+
+	factResults, err := p.Gather(factRequests)
+
+	expectedResults := []Fact{
+		{
+			Name:    "corosync",
+			Value:   "2.4.5",
+			CheckID: "check1",
+		},
+		{
+			Name:    "pacemaker",
+			Value:   "2.0.5+20201202.ba59be712",
+			CheckID: "check2",
+		},
+	}
+
+	suite.NoError(err)
+	suite.ElementsMatch(expectedResults, factResults)
+}
+
+func (suite *PackageVersionTestSuite) TestPackageVersionGatherError() {
+	mockExecutor := new(mocks.CommandExecutor)
+
+	mockExecutor.On("Exec", "rpm", "-q", "--qf", "%{VERSION}", "corosync").Return(
+		[]byte("2.4.5"), nil)
+	mockExecutor.On("Exec", "rpm", "-q", "--qf", "%{VERSION}", "pacemake").Return(
+		[]byte("package pacemake is not installed\n"), errors.New("some error"))
+
+	p := &PackageVersionGatherer{
+		executor: mockExecutor,
+	}
+
+	factRequests := []FactRequest{
+		{
+			Name:     "corosync",
+			Gatherer: "package_version",
+			Argument: "corosync",
+			CheckID:  "check1",
+		},
+		{
+			Name:     "pacemaker",
+			Gatherer: "package_version",
+			Argument: "pacemake",
+			CheckID:  "check2",
+		},
+	}
+
+	factResults, err := p.Gather(factRequests)
+
+	expectedResults := []Fact{
+		{
+			Name:    "corosync",
+			Value:   "2.4.5",
+			CheckID: "check1",
+		},
+		{
+			Name:    "pacemaker",
+			Value:   "package pacemake is not installed\n",
+			CheckID: "check2",
+		},
+	}
+
+	suite.NoError(err)
+	suite.ElementsMatch(expectedResults, factResults)
+}


### PR DESCRIPTION
Implement the package_version gatherer.

It depends on: https://github.com/trento-project/agent/pull/65

Some examples:

```
#> ./trento-agent facts gather --gatherer package_version --argument pacemaker
INFO[2022-08-02 15:20:21] Starting Package versions facts gathering process 
INFO[2022-08-02 15:20:21] Requested Package versions facts gathered    
INFO[2022-08-02 15:20:21] Gathered fact for "package_version" with argument "pacemaker": 
INFO[2022-08-02 15:20:21] {
  "name": "pacemaker",
  "value": "2.0.5+20201202.ba59be712",
  "check_id": ""
} 
```

```
> ./trento-agent facts gather --gatherer package_version --argument corosync
INFO[2022-08-02 15:20:42] Starting Package versions facts gathering process 
INFO[2022-08-02 15:20:42] Requested Package versions facts gathered    
INFO[2022-08-02 15:20:42] Gathered fact for "package_version" with argument "corosync": 
INFO[2022-08-02 15:20:42] {
  "name": "corosync",
  "value": "2.4.5",
  "check_id": ""
} 
```

```
#> ./trento-agent facts gather --gatherer package_version --argument other
INFO[2022-08-02 15:20:58] Starting Package versions facts gathering process 
ERRO[2022-08-02 15:20:58] Error getting version of package: other      
INFO[2022-08-02 15:20:58] Requested Package versions facts gathered    
INFO[2022-08-02 15:20:58] Gathered fact for "package_version" with argument "other": 
INFO[2022-08-02 15:20:58] {
  "name": "other",
  "value": "package other is not installed\n",
  "check_id": ""
} 

```