### PR TITLE
Implement saphostctrl gatherer

### DIFF
--- a/internal/factsengine/gatherers/gatherer.go
+++ b/internal/factsengine/gatherers/gatherer.go
@@ -18,5 +18,6 @@ func StandardGatherers() map[string]FactGatherer {
 		PackageVersionGathererName:  NewDefaultPackageVersionGatherer(),
 		SBDConfigGathererName:       NewDefaultSBDGatherer(),
 		SBDDumpGathererName:         NewDefaultSBDDumpGatherer(),
+		SapHostCtrlGathererName:     NewDefaultSapHostCtrlGatherer(),
 	}
 }

--- a/internal/factsengine/gatherers/saphostctrl.go
+++ b/internal/factsengine/gatherers/saphostctrl.go
@@ -2,42 +2,56 @@ package gatherers
 
 import (
 	log "github.com/sirupsen/logrus"
+	"github.com/trento-project/agent/pkg/factsengine/entities"
+	"github.com/trento-project/agent/pkg/utils"
 )
 
 const (
 	SapHostCtrlGathererName = "saphostctrl"
 )
 
+// nolint:gochecknoglobals
+var (
+	SapHostCtrlCommandError = entities.FactGatheringError{
+		Type:    "saphostctrl-cmd-error",
+		Message: "error executing saphostctrl command",
+	}
+)
+
 type SapHostCtrlGatherer struct {
-	executor CommandExecutor
+	executor utils.CommandExecutor
 }
 
 func NewDefaultSapHostCtrlGatherer() *SapHostCtrlGatherer {
-	return NewSapHostCtrlGatherer(Executor{})
+	return NewSapHostCtrlGatherer(utils.Executor{})
 }
 
-func NewSapHostCtrlGatherer(executor CommandExecutor) *SapHostCtrlGatherer {
+func NewSapHostCtrlGatherer(executor utils.CommandExecutor) *SapHostCtrlGatherer {
 	return &SapHostCtrlGatherer{
 		executor: executor,
 	}
 }
 
-func (g *SapHostCtrlGatherer) Gather(factsRequests []FactRequest) ([]Fact, error) {
-	facts := []Fact{}
+func (g *SapHostCtrlGatherer) Gather(factsRequests []entities.FactRequest) ([]entities.Fact, error) {
+	facts := []entities.Fact{}
 	log.Infof("Starting saphostctrl facts gathering process")
 
 	for _, factReq := range factsRequests {
+		var fact entities.Fact
 		// TODO: The instance number "00" could be an additional argument in the future
 		version, err := g.executor.Exec(
 			"/usr/sap/hostctrl/exe/saphostctrl", "-nr", "00", "-function", factReq.Argument)
 		if err != nil {
-			// TODO: Decide together with Wanda how to deal with errors. `err` field in the fact result?
-			log.Errorf("Error running saphostctrl: %s", err)
+			gatheringError := SapHostCtrlCommandError.Wrap(factReq.Argument)
+			log.Error(gatheringError)
+			fact = entities.NewFactGatheredWithError(factReq, gatheringError)
+		} else {
+			fact = entities.NewFactGatheredWithRequest(factReq, &entities.FactValueString{Value: (string(version))})
 		}
-		fact := NewFactWithRequest(factReq, string(version))
+
 		facts = append(facts, fact)
 	}
 
-	log.Infof("Requested saphostctrl facts gathered")
+	log.Infof("Requested %s facts gathered", SapHostCtrlGathererName)
 	return facts, nil
 }

--- a/internal/factsengine/gatherers/saphostctrl.go
+++ b/internal/factsengine/gatherers/saphostctrl.go
@@ -1,0 +1,43 @@
+package gatherers
+
+import (
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	SapHostCtrlGathererName = "saphostctrl"
+)
+
+type SapHostCtrlGatherer struct {
+	executor CommandExecutor
+}
+
+func NewDefaultSapHostCtrlGatherer() *SapHostCtrlGatherer {
+	return NewSapHostCtrlGatherer(Executor{})
+}
+
+func NewSapHostCtrlGatherer(executor CommandExecutor) *SapHostCtrlGatherer {
+	return &SapHostCtrlGatherer{
+		executor: executor,
+	}
+}
+
+func (g *SapHostCtrlGatherer) Gather(factsRequests []FactRequest) ([]Fact, error) {
+	facts := []Fact{}
+	log.Infof("Starting saphostctrl facts gathering process")
+
+	for _, factReq := range factsRequests {
+		// TODO: The instance number "00" could be an additional argument in the future
+		version, err := g.executor.Exec(
+			"/usr/sap/hostctrl/exe/saphostctrl", "-nr", "00", "-function", factReq.Argument)
+		if err != nil {
+			// TODO: Decide together with Wanda how to deal with errors. `err` field in the fact result?
+			log.Errorf("Error running saphostctrl: %s", err)
+		}
+		fact := NewFactWithRequest(factReq, string(version))
+		facts = append(facts, fact)
+	}
+
+	log.Infof("Requested saphostctrl facts gathered")
+	return facts, nil
+}

--- a/internal/factsengine/gatherers/saphostctrl.go
+++ b/internal/factsengine/gatherers/saphostctrl.go
@@ -1,13 +1,18 @@
 package gatherers
 
 import (
+	"regexp"
+	"strings"
+
 	log "github.com/sirupsen/logrus"
 	"github.com/trento-project/agent/pkg/factsengine/entities"
 	"github.com/trento-project/agent/pkg/utils"
 )
 
 const (
-	SapHostCtrlGathererName = "saphostctrl"
+	SapHostCtrlGathererName               = "saphostctrl"
+	saphostCtrlListInstancesParsingRegexp = `^\s+Inst Info\s*:\s*([^-]+?)\s*-\s*(\d+)\s*-\s*([^,]+?)\s*-\s*(\d+),\s*patch\s*(\d+),\s*changelist\s*(\d+)$`
+	saphostCtrlPingParsingRegexp          = `(SUCCESS|FAILURE) \( *(\d+) usec\)`
 )
 
 // nolint:gochecknoglobals
@@ -15,6 +20,14 @@ var (
 	SapHostCtrlCommandError = entities.FactGatheringError{
 		Type:    "saphostctrl-cmd-error",
 		Message: "error executing saphostctrl command",
+	}
+	SapHostCtrlUnsupportedFunction = entities.FactGatheringError{
+		Type:    "saphostctrl-func-error",
+		Message: "unsupported saphostctrl function",
+	}
+	SapHostCtrlParseError = entities.FactGatheringError{
+		Type:    "saphostctrl-parse-error",
+		Message: "error while parsing saphostctrl output",
 	}
 )
 
@@ -38,20 +51,92 @@ func (g *SapHostCtrlGatherer) Gather(factsRequests []entities.FactRequest) ([]en
 
 	for _, factReq := range factsRequests {
 		var fact entities.Fact
-		// TODO: The instance number "00" could be an additional argument in the future
-		version, err := g.executor.Exec(
-			"/usr/sap/hostctrl/exe/saphostctrl", "-nr", "00", "-function", factReq.Argument)
-		if err != nil {
-			gatheringError := SapHostCtrlCommandError.Wrap(factReq.Argument)
+
+		if !whitelisted()[factReq.Argument] {
+			gatheringError := SapHostCtrlUnsupportedFunction.Wrap(factReq.Argument)
 			log.Error(gatheringError)
 			fact = entities.NewFactGatheredWithError(factReq, gatheringError)
 		} else {
-			fact = entities.NewFactGatheredWithRequest(factReq, &entities.FactValueString{Value: (string(version))})
-		}
+			saphostctlOutput, err := g.executor.Exec("/usr/sap/hostctrl/exe/saphostctrl", "-function", factReq.Argument)
+			if err != nil {
+				gatheringError := SapHostCtrlCommandError.Wrap(factReq.Argument)
+				log.Error(gatheringError)
+				fact = entities.NewFactGatheredWithError(factReq, gatheringError)
+				facts = append(facts, fact)
+				continue
+			}
+			switch factReq.Argument {
+			case "Ping":
+				parsedOutput, err := parsePing(string(saphostctlOutput))
+				if err != nil {
+					fact = entities.NewFactGatheredWithError(factReq, err)
+					facts = append(facts, fact)
+					continue
+				}
+				fact = entities.NewFactGatheredWithRequest(factReq, parsedOutput)
 
+			case "ListInstances":
+				parsedOutput, err := parseInstances(string(saphostctlOutput))
+				if err != nil {
+					fact = entities.NewFactGatheredWithError(factReq, err)
+					facts = append(facts, fact)
+					continue
+				}
+				fact = entities.NewFactGatheredWithRequest(factReq, parsedOutput)
+			}
+		}
 		facts = append(facts, fact)
 	}
 
 	log.Infof("Requested %s facts gathered", SapHostCtrlGathererName)
 	return facts, nil
+}
+
+func whitelisted() map[string]bool {
+	whitelist := map[string]bool{"Ping": true, "ListInstances": true}
+
+	return whitelist
+}
+
+func parsePing(commandOutput string) (*entities.FactValueMap, *entities.FactGatheringError) {
+	re := regexp.MustCompile(saphostCtrlPingParsingRegexp)
+	pingData := map[string]entities.FactValue{}
+
+	matches := re.FindStringSubmatch(commandOutput)
+	if len(matches) < 2 {
+		return nil, SapHostCtrlParseError.Wrap(commandOutput)
+	}
+
+	pingData["status"] = &entities.FactValueString{Value: matches[1]}
+	pingData["elapsed"] = &entities.FactValueString{Value: matches[2]}
+
+	result := &entities.FactValueMap{Value: pingData}
+
+	return result, nil
+}
+
+func parseInstances(commandOutput string) (*entities.FactValueMap, *entities.FactGatheringError) {
+	r, _ := regexp.Compile(saphostCtrlListInstancesParsingRegexp)
+	lines := strings.Split(commandOutput, "\n")
+	instances := map[string]entities.FactValue{}
+
+	for _, line := range lines {
+		if r.MatchString(line) {
+			fields := r.FindStringSubmatch(line)
+			if len(fields) < 6 {
+				return nil, SapHostCtrlParseError.Wrap(commandOutput)
+			}
+
+			instances["system"] = &entities.FactValueString{Value: fields[1]}
+			instances["instance"] = &entities.FactValueString{Value: fields[2]}
+			instances["hostname"] = &entities.FactValueString{Value: fields[3]}
+			instances["revision"] = &entities.FactValueString{Value: fields[4]}
+			instances["patch"] = &entities.FactValueString{Value: fields[5]}
+			instances["changelist"] = &entities.FactValueString{Value: fields[6]}
+		}
+	}
+
+	result := &entities.FactValueMap{Value: instances}
+
+	return result, nil
 }

--- a/internal/factsengine/gatherers/saphostctrl.go
+++ b/internal/factsengine/gatherers/saphostctrl.go
@@ -12,7 +12,7 @@ import (
 const (
 	SapHostCtrlGathererName               = "saphostctrl"
 	saphostCtrlListInstancesParsingRegexp = `^\s+Inst Info\s*:\s*([^-]+?)\s*-\s*(\d+)\s*-\s*([^,]+?)\s*-\s*(\d+),\s*patch\s*(\d+),\s*changelist\s*(\d+)$`
-	saphostCtrlPingParsingRegexp          = `(SUCCESS) \( *(\d+) usec\)`
+	saphostCtrlPingParsingRegexp          = `(SUCCESS|FAILED) \( *(\d+) usec\)`
 )
 
 var whitelistedWebmethods = map[string]func(utils.CommandExecutor) (entities.FactValue, *entities.FactGatheringError){

--- a/internal/factsengine/gatherers/saphostctrl_test.go
+++ b/internal/factsengine/gatherers/saphostctrl_test.go
@@ -1,10 +1,11 @@
-package gatherers // nolint:dupl
+package gatherers_test // nolint:dupl
 
 import (
 	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
+	"github.com/trento-project/agent/internal/factsengine/gatherers"
 	"github.com/trento-project/agent/pkg/factsengine/entities"
 	utilsMocks "github.com/trento-project/agent/pkg/utils/mocks"
 )
@@ -26,9 +27,9 @@ func (suite *SapHostCtrlTestSuite) TestSapHostCtrlGather() {
 	suite.mockExecutor.On("Exec", "/usr/sap/hostctrl/exe/saphostctrl", "-function", "Ping").Return(
 		[]byte("SUCCESS (  543341 usec)\n"), nil)
 	suite.mockExecutor.On("Exec", "/usr/sap/hostctrl/exe/saphostctrl", "-function", "ListInstances").Return(
-		[]byte(" Inst Info : PRD - 00 - myhost-vmhana02 - 753, patch 410, changelist 1908545\n"), nil)
+		[]byte(" Inst Info : PRD - 00 - myhost-vmhana02 - 753, patch 410, changelist 1908545\n Inst Info : PRD - 01 - anotherhost-vmhana01 - 753, patch 410, changelist 1908545\n"), nil)
 
-	p := NewSapHostCtrlGatherer(suite.mockExecutor)
+	p := gatherers.NewSapHostCtrlGatherer(suite.mockExecutor)
 
 	factRequests := []entities.FactRequest{
 		{
@@ -49,28 +50,36 @@ func (suite *SapHostCtrlTestSuite) TestSapHostCtrlGather() {
 
 	expectedResults := []entities.Fact{
 		{
-			Name: "ping",
+			Name:    "ping",
+			CheckID: "check1",
 			Value: &entities.FactValueMap{
 				Value: map[string]entities.FactValue{
 					"status":  &entities.FactValueString{Value: "SUCCESS"},
 					"elapsed": &entities.FactValueString{Value: "543341"},
 				},
 			},
-			CheckID: "check1",
 		},
 		{
-			Name: "listinstances",
-			Value: &entities.FactValueMap{
-				Value: map[string]entities.FactValue{
-					"system":     &entities.FactValueString{Value: "PRD"},
-					"instance":   &entities.FactValueString{Value: "00"},
-					"hostname":   &entities.FactValueString{Value: "myhost-vmhana02"},
-					"revision":   &entities.FactValueString{Value: "753"},
-					"patch":      &entities.FactValueString{Value: "410"},
-					"changelist": &entities.FactValueString{Value: "1908545"},
-				},
-			},
+			Name:    "listinstances",
 			CheckID: "check2",
+			Value: &entities.FactValueList{Value: []entities.FactValue{
+				&entities.FactValueMap{Value: map[string]entities.FactValue{
+					"changelist": &entities.FactValueString{Value: "1908545"},
+					"hostname":   &entities.FactValueString{Value: "myhost-vmhana02"},
+					"instance":   &entities.FactValueString{Value: "00"},
+					"patch":      &entities.FactValueString{Value: "410"},
+					"revision":   &entities.FactValueString{Value: "753"},
+					"system":     &entities.FactValueString{Value: "PRD"},
+				}},
+				&entities.FactValueMap{Value: map[string]entities.FactValue{
+					"changelist": &entities.FactValueString{Value: "1908545"},
+					"hostname":   &entities.FactValueString{Value: "anotherhost-vmhana01"},
+					"instance":   &entities.FactValueString{Value: "01"},
+					"patch":      &entities.FactValueString{Value: "410"},
+					"revision":   &entities.FactValueString{Value: "753"},
+					"system":     &entities.FactValueString{Value: "PRD"},
+				}},
+			}},
 		},
 	}
 
@@ -80,11 +89,11 @@ func (suite *SapHostCtrlTestSuite) TestSapHostCtrlGather() {
 
 func (suite *SapHostCtrlTestSuite) TestSapHostCtrlGatherError() {
 	suite.mockExecutor.On("Exec", "/usr/sap/hostctrl/exe/saphostctrl", "-function", "Ping").Return(
-		[]byte("SUCCESS (  543341 usec)\n"), nil)
+		[]byte("FAILURE\n"), nil)
 	suite.mockExecutor.On("Exec", "/usr/sap/hostctrl/exe/saphostctrl", "-function", "Pong").Return(
 		[]byte("some error"), errors.New("some error"))
 
-	p := NewSapHostCtrlGatherer(suite.mockExecutor)
+	p := gatherers.NewSapHostCtrlGatherer(suite.mockExecutor)
 
 	factRequests := []entities.FactRequest{
 		{
@@ -94,9 +103,9 @@ func (suite *SapHostCtrlTestSuite) TestSapHostCtrlGatherError() {
 			CheckID:  "check1",
 		},
 		{
-			Name:     "pong",
+			Name:     "start_instance",
 			Gatherer: "saphostctrl",
-			Argument: "Pong",
+			Argument: "StartInstance",
 			CheckID:  "check2",
 		},
 	}
@@ -105,21 +114,20 @@ func (suite *SapHostCtrlTestSuite) TestSapHostCtrlGatherError() {
 
 	expectedResults := []entities.Fact{
 		{
-			Name: "ping",
-			Value: &entities.FactValueMap{
-				Value: map[string]entities.FactValue{
-					"status":  &entities.FactValueString{Value: "SUCCESS"},
-					"elapsed": &entities.FactValueString{Value: "543341"},
-				},
+			Name:  "ping",
+			Value: nil,
+			Error: &entities.FactGatheringError{
+				Message: "error while parsing saphostctrl output: FAILURE\n",
+				Type:    "saphostctrl-parse-error",
 			},
 			CheckID: "check1",
 		},
 		{
-			Name:  "pong",
+			Name:  "start_instance",
 			Value: nil,
 			Error: &entities.FactGatheringError{
-				Message: "unsupported saphostctrl function: Pong",
-				Type:    "saphostctrl-func-error",
+				Message: "requested webmethod not whitelisted: StartInstance",
+				Type:    "saphostctrl-webmethod-error",
 			},
 			CheckID: "check2",
 		},

--- a/internal/factsengine/gatherers/saphostctrl_test.go
+++ b/internal/factsengine/gatherers/saphostctrl_test.go
@@ -1,4 +1,4 @@
-package gatherers_test // nolint:dupl
+package gatherers_test
 
 import (
 	"errors"
@@ -48,27 +48,27 @@ func (suite *SapHostCtrlTestSuite) TestSapHostCtrlGatherListInstances() {
 			CheckID: "check2",
 			Value: &entities.FactValueList{Value: []entities.FactValue{
 				&entities.FactValueMap{Value: map[string]entities.FactValue{
-					"changelist": &entities.FactValueString{Value: "2091708"},
+					"changelist": &entities.FactValueInt{Value: 2091708},
 					"hostname":   &entities.FactValueString{Value: "s41app"},
 					"instance":   &entities.FactValueString{Value: "41"},
-					"patch":      &entities.FactValueString{Value: "50"},
-					"revision":   &entities.FactValueString{Value: "785"},
+					"patch":      &entities.FactValueInt{Value: 50},
+					"sapkernel":  &entities.FactValueInt{Value: 785},
 					"system":     &entities.FactValueString{Value: "S41"},
 				}},
 				&entities.FactValueMap{Value: map[string]entities.FactValue{
-					"changelist": &entities.FactValueString{Value: "2091708"},
+					"changelist": &entities.FactValueInt{Value: 2091708},
 					"hostname":   &entities.FactValueString{Value: "s41app"},
 					"instance":   &entities.FactValueString{Value: "40"},
-					"patch":      &entities.FactValueString{Value: "50"},
-					"revision":   &entities.FactValueString{Value: "785"},
+					"patch":      &entities.FactValueInt{Value: 50},
+					"sapkernel":  &entities.FactValueInt{Value: 785},
 					"system":     &entities.FactValueString{Value: "S41"},
 				}},
 				&entities.FactValueMap{Value: map[string]entities.FactValue{
-					"changelist": &entities.FactValueString{Value: "2069355"},
+					"changelist": &entities.FactValueInt{Value: 2069355},
 					"hostname":   &entities.FactValueString{Value: "s41db"},
 					"instance":   &entities.FactValueString{Value: "11"},
-					"patch":      &entities.FactValueString{Value: "819"},
-					"revision":   &entities.FactValueString{Value: "753"},
+					"patch":      &entities.FactValueInt{Value: 819},
+					"sapkernel":  &entities.FactValueInt{Value: 753},
 					"system":     &entities.FactValueString{Value: "HS1"},
 				}},
 			}},
@@ -103,7 +103,7 @@ func (suite *SapHostCtrlTestSuite) TestSapHostCtrlGatherPingSuccess() {
 			Value: &entities.FactValueMap{
 				Value: map[string]entities.FactValue{
 					"status":  &entities.FactValueString{Value: "SUCCESS"},
-					"elapsed": &entities.FactValueString{Value: "543341"},
+					"elapsed": &entities.FactValueInt{Value: 543341},
 				},
 			},
 		},
@@ -137,7 +137,7 @@ func (suite *SapHostCtrlTestSuite) TestSapHostCtrlGatherPingFailed() {
 			Value: &entities.FactValueMap{
 				Value: map[string]entities.FactValue{
 					"status":  &entities.FactValueString{Value: "FAILED"},
-					"elapsed": &entities.FactValueString{Value: "497"},
+					"elapsed": &entities.FactValueInt{Value: 497},
 				},
 			},
 		},
@@ -149,9 +149,9 @@ func (suite *SapHostCtrlTestSuite) TestSapHostCtrlGatherPingFailed() {
 
 func (suite *SapHostCtrlTestSuite) TestSapHostCtrlGatherError() {
 	suite.mockExecutor.On("Exec", "/usr/sap/hostctrl/exe/saphostctrl", "-function", "Ping").Return(
-		[]byte("FAILURE\n"), nil)
-	suite.mockExecutor.On("Exec", "/usr/sap/hostctrl/exe/saphostctrl", "-function", "Pong").Return(
-		[]byte("some error"), errors.New("some error"))
+		[]byte("Unexpected output\n"), nil)
+	suite.mockExecutor.On("Exec", "/usr/sap/hostctrl/exe/saphostctrl", "-function", "ListInstances").Return(
+		nil, errors.New("some error"))
 
 	p := gatherers.NewSapHostCtrlGatherer(suite.mockExecutor)
 
@@ -168,6 +168,12 @@ func (suite *SapHostCtrlTestSuite) TestSapHostCtrlGatherError() {
 			Argument: "StartInstance",
 			CheckID:  "check2",
 		},
+		{
+			Name:     "list_instances",
+			Gatherer: "saphostctrl",
+			Argument: "ListInstances",
+			CheckID:  "check3",
+		},
 	}
 
 	factResults, err := p.Gather(factRequests)
@@ -177,7 +183,7 @@ func (suite *SapHostCtrlTestSuite) TestSapHostCtrlGatherError() {
 			Name:  "ping",
 			Value: nil,
 			Error: &entities.FactGatheringError{
-				Message: "error while parsing saphostctrl output: FAILURE\n",
+				Message: "error while parsing saphostctrl output: Unexpected output\n",
 				Type:    "saphostctrl-parse-error",
 			},
 			CheckID: "check1",
@@ -186,10 +192,19 @@ func (suite *SapHostCtrlTestSuite) TestSapHostCtrlGatherError() {
 			Name:  "start_instance",
 			Value: nil,
 			Error: &entities.FactGatheringError{
-				Message: "requested webmethod not whitelisted: StartInstance",
+				Message: "requested webmethod not supported: StartInstance",
 				Type:    "saphostctrl-webmethod-error",
 			},
 			CheckID: "check2",
+		},
+		{
+			Name:  "list_instances",
+			Value: nil,
+			Error: &entities.FactGatheringError{
+				Message: "error executing saphostctrl command: some error",
+				Type:    "saphostctrl-cmd-error",
+			},
+			CheckID: "check3",
 		},
 	}
 

--- a/internal/factsengine/gatherers/saphostctrl_test.go
+++ b/internal/factsengine/gatherers/saphostctrl_test.go
@@ -5,12 +5,13 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/suite"
-	mocks "github.com/trento-project/agent/internal/factsengine/gatherers/mocks"
+	"github.com/trento-project/agent/pkg/factsengine/entities"
+	utilsMocks "github.com/trento-project/agent/pkg/utils/mocks"
 )
 
 type SapHostCtrlTestSuite struct {
 	suite.Suite
-	mockExecutor *mocks.CommandExecutor
+	mockExecutor *utilsMocks.CommandExecutor
 }
 
 func TestSapHostCtrlTestSuite(t *testing.T) {
@@ -18,7 +19,7 @@ func TestSapHostCtrlTestSuite(t *testing.T) {
 }
 
 func (suite *SapHostCtrlTestSuite) SetupTest() {
-	suite.mockExecutor = new(mocks.CommandExecutor)
+	suite.mockExecutor = new(utilsMocks.CommandExecutor)
 }
 
 func (suite *SapHostCtrlTestSuite) TestSapHostCtrlGather() {
@@ -29,7 +30,7 @@ func (suite *SapHostCtrlTestSuite) TestSapHostCtrlGather() {
 
 	p := NewSapHostCtrlGatherer(suite.mockExecutor)
 
-	factRequests := []FactRequest{
+	factRequests := []entities.FactRequest{
 		{
 			Name:     "ping",
 			Gatherer: "saphostctrl",
@@ -46,15 +47,15 @@ func (suite *SapHostCtrlTestSuite) TestSapHostCtrlGather() {
 
 	factResults, err := p.Gather(factRequests)
 
-	expectedResults := []Fact{
+	expectedResults := []entities.Fact{
 		{
 			Name:    "ping",
-			Value:   "SUCCESS (  543341 usec)\n",
+			Value:   &entities.FactValueString{Value: "SUCCESS (  543341 usec)\n"},
 			CheckID: "check1",
 		},
 		{
 			Name:    "pong",
-			Value:   "ERROR",
+			Value:   &entities.FactValueString{Value: "ERROR"},
 			CheckID: "check2",
 		},
 	}
@@ -71,7 +72,7 @@ func (suite *SapHostCtrlTestSuite) TestSapHostCtrlGatherError() {
 
 	p := NewSapHostCtrlGatherer(suite.mockExecutor)
 
-	factRequests := []FactRequest{
+	factRequests := []entities.FactRequest{
 		{
 			Name:     "ping",
 			Gatherer: "saphostctrl",
@@ -88,15 +89,19 @@ func (suite *SapHostCtrlTestSuite) TestSapHostCtrlGatherError() {
 
 	factResults, err := p.Gather(factRequests)
 
-	expectedResults := []Fact{
+	expectedResults := []entities.Fact{
 		{
 			Name:    "ping",
-			Value:   "SUCCESS (  543341 usec)\n",
+			Value:   &entities.FactValueString{Value: "SUCCESS (  543341 usec)\n"},
 			CheckID: "check1",
 		},
 		{
-			Name:    "pong",
-			Value:   "some error",
+			Name:  "pong",
+			Value: nil,
+			Error: &entities.FactGatheringError{
+				Message: "error executing saphostctrl command: Pong",
+				Type:    "saphostctrl-cmd-error",
+			},
 			CheckID: "check2",
 		},
 	}

--- a/internal/factsengine/gatherers/saphostctrl_test.go
+++ b/internal/factsengine/gatherers/saphostctrl_test.go
@@ -1,0 +1,106 @@
+package gatherers // nolint:dupl
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	mocks "github.com/trento-project/agent/internal/factsengine/gatherers/mocks"
+)
+
+type SapHostCtrlTestSuite struct {
+	suite.Suite
+	mockExecutor *mocks.CommandExecutor
+}
+
+func TestSapHostCtrlTestSuite(t *testing.T) {
+	suite.Run(t, new(SapHostCtrlTestSuite))
+}
+
+func (suite *SapHostCtrlTestSuite) SetupTest() {
+	suite.mockExecutor = new(mocks.CommandExecutor)
+}
+
+func (suite *SapHostCtrlTestSuite) TestSapHostCtrlGather() {
+	suite.mockExecutor.On("Exec", "/usr/sap/hostctrl/exe/saphostctrl", "-nr", "00", "-function", "Ping").Return(
+		[]byte("SUCCESS (  543341 usec)\n"), nil)
+	suite.mockExecutor.On("Exec", "/usr/sap/hostctrl/exe/saphostctrl", "-nr", "00", "-function", "Pong").Return(
+		[]byte("ERROR"), nil)
+
+	p := NewSapHostCtrlGatherer(suite.mockExecutor)
+
+	factRequests := []FactRequest{
+		{
+			Name:     "ping",
+			Gatherer: "saphostctrl",
+			Argument: "Ping",
+			CheckID:  "check1",
+		},
+		{
+			Name:     "pong",
+			Gatherer: "saphostctrl",
+			Argument: "Pong",
+			CheckID:  "check2",
+		},
+	}
+
+	factResults, err := p.Gather(factRequests)
+
+	expectedResults := []Fact{
+		{
+			Name:    "ping",
+			Value:   "SUCCESS (  543341 usec)\n",
+			CheckID: "check1",
+		},
+		{
+			Name:    "pong",
+			Value:   "ERROR",
+			CheckID: "check2",
+		},
+	}
+
+	suite.NoError(err)
+	suite.ElementsMatch(expectedResults, factResults)
+}
+
+func (suite *SapHostCtrlTestSuite) TestSapHostCtrlGatherError() {
+	suite.mockExecutor.On("Exec", "/usr/sap/hostctrl/exe/saphostctrl", "-nr", "00", "-function", "Ping").Return(
+		[]byte("SUCCESS (  543341 usec)\n"), nil)
+	suite.mockExecutor.On("Exec", "/usr/sap/hostctrl/exe/saphostctrl", "-nr", "00", "-function", "Pong").Return(
+		[]byte("some error"), errors.New("some error"))
+
+	p := NewSapHostCtrlGatherer(suite.mockExecutor)
+
+	factRequests := []FactRequest{
+		{
+			Name:     "ping",
+			Gatherer: "saphostctrl",
+			Argument: "Ping",
+			CheckID:  "check1",
+		},
+		{
+			Name:     "pong",
+			Gatherer: "saphostctrl",
+			Argument: "Pong",
+			CheckID:  "check2",
+		},
+	}
+
+	factResults, err := p.Gather(factRequests)
+
+	expectedResults := []Fact{
+		{
+			Name:    "ping",
+			Value:   "SUCCESS (  543341 usec)\n",
+			CheckID: "check1",
+		},
+		{
+			Name:    "pong",
+			Value:   "some error",
+			CheckID: "check2",
+		},
+	}
+
+	suite.NoError(err)
+	suite.ElementsMatch(expectedResults, factResults)
+}


### PR DESCRIPTION
saphostctrl gatherer. Simply returns the output of this commands.

Example: 
```
./trento-agent facts gather --gatherer saphostctrl --argument Ping
INFO[2022-08-05 09:12:00] Starting saphostctrl facts gathering process 
INFO[2022-08-05 09:12:00] Requested saphostctrl facts gathered         
INFO[2022-08-05 09:12:00] Gathered fact for "saphostctrl" with argument "Ping": 
INFO[2022-08-05 09:12:00] {
  "name": "Ping",
  "value": "SUCCESS (  548364 usec)\n",
  "check_id": ""
} 
```