### PR TITLE
Implement /etc/hosts file gatherer

### DIFF
--- a/internal/factsengine/gatherers/gatherer.go
+++ b/internal/factsengine/gatherers/gatherer.go
@@ -1,6 +1,8 @@
 package gatherers
 
-import "github.com/trento-project/agent/internal/factsengine/entities"
+import (
+	"github.com/trento-project/agent/internal/factsengine/entities"
+)
 
 type FactGatherer interface {
 	Gather(factsRequests []entities.FactRequest) ([]entities.Fact, error)
@@ -8,6 +10,7 @@ type FactGatherer interface {
 
 func StandardGatherers() map[string]FactGatherer {
 	return map[string]FactGatherer{
-		CorosyncFactKey: NewDefaultCorosyncConfGatherer(),
+		CorosyncFactKey:  NewDefaultCorosyncConfGatherer(),
+		HostsFileFactKey: NewDefaultHostsFileGatherer(),
 	}
 }

--- a/internal/factsengine/gatherers/hostsfile.go
+++ b/internal/factsengine/gatherers/hostsfile.go
@@ -1,0 +1,138 @@
+package gatherers
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/trento-project/agent/internal/factsengine/entities"
+)
+
+const (
+	HostsFileFactKey    = "hosts"
+	HostsFilePath       = "/etc/hosts"
+	ipMatchGroup        = "ip"
+	hostnamesMatchGroup = "hostnames"
+)
+
+var (
+	parsingRegexp      = `(?m)(?P<` + ipMatchGroup + `>\S+)\s+(?P<` + hostnamesMatchGroup + `>.+)`
+	HostsEntryCompiled = regexp.MustCompile(parsingRegexp)
+	//HostsEntryCompiled = regexp.MustCompile(`(?m)(?P<ip>\S+)\s+(?P<hostnames>.+)`)
+)
+
+// nolint:gochecknoglobals
+var (
+	HostsFileError = entities.FactGatheringError{
+		Type:    "hosts-file-error",
+		Message: "error reading /etc/hosts file",
+	}
+
+	HostsFileDecodingError = entities.FactGatheringError{
+		Type:    "hosts-file-decoding-error",
+		Message: "error decoding /etc/hosts file",
+	}
+
+	HostsEntryNotFoundError = entities.FactGatheringError{
+		Type:    "hosts-file-value-not-found",
+		Message: "requested field value not found in /etc/hosts file",
+	}
+)
+
+type HostsFileGatherer struct {
+	hostsFile string
+}
+
+func NewDefaultHostsFileGatherer() *HostsFileGatherer {
+	return NewHostsFileGatherer(HostsFilePath)
+}
+
+func NewHostsFileGatherer(hostsFile string) *HostsFileGatherer {
+	return &HostsFileGatherer{hostsFile: hostsFile}
+}
+
+func (s *HostsFileGatherer) Gather(factsRequests []entities.FactRequest) ([]entities.Fact, error) {
+	facts := []entities.Fact{}
+	log.Infof("Starting /etc/hosts file facts gathering process")
+
+	hostsFile, err := readHostsFileByLines(s.hostsFile)
+	if err != nil {
+		return nil, HostsFileError.Wrap(err.Error())
+	}
+
+	hostsFileMap, err := hostsFileToMap(hostsFile)
+	if err != nil {
+		return nil, HostsFileDecodingError.Wrap(err.Error())
+	}
+
+	for _, factReq := range factsRequests {
+		var fact entities.Fact
+		var found bool
+
+		for hostname, ip := range hostsFileMap {
+			if hostname == factReq.Argument {
+				fact = entities.NewFactGatheredWithRequest(factReq, ip)
+				facts = append(facts, fact)
+				found = true
+				break
+			}
+		}
+		if !found {
+			return nil, errors.New(HostsEntryNotFoundError.Error())
+		}
+	}
+
+	log.Infof("Requested /etc/hosts file facts gathered")
+	return facts, nil
+}
+
+func readHostsFileByLines(filePath string) ([]string, error) {
+	hostsFile, err := os.Open(filePath)
+	if err != nil {
+		return nil, err
+	}
+
+	defer hostsFile.Close()
+
+	fileScanner := bufio.NewScanner(hostsFile)
+	fileScanner.Split(bufio.ScanLines)
+	var fileLines []string
+
+	for fileScanner.Scan() {
+		if strings.HasPrefix(fileScanner.Text(), "#") || fileScanner.Text() == "" {
+			continue
+		}
+		fileLines = append(fileLines, fileScanner.Text())
+	}
+
+	return fileLines, nil
+}
+
+func hostsFileToMap(lines []string) (map[string][]string, error) {
+	var hostsFileMap = make(map[string][]string)
+	var paramsMap = make(map[string]string)
+
+	for _, line := range lines {
+		match := HostsEntryCompiled.FindStringSubmatch(line)
+
+		if match == nil {
+			return nil, fmt.Errorf("invalid hosts file structure")
+		}
+		for i, name := range HostsEntryCompiled.SubexpNames() {
+			if i > 0 && i <= len(match) {
+				paramsMap[name] = match[i]
+			}
+		}
+		hostnames := strings.Fields(paramsMap["hostnames"])
+		for _, hostname := range hostnames {
+			hostsFileMap[hostname] = append(hostsFileMap[hostname], paramsMap["ip"])
+		}
+
+	}
+
+	return hostsFileMap, nil
+}

--- a/internal/factsengine/gatherers/hostsfile_test.go
+++ b/internal/factsengine/gatherers/hostsfile_test.go
@@ -44,18 +44,25 @@ func (suite *HostsFileTestSuite) TestHostsFileBasic() {
 
 	expectedResults := []entities.Fact{
 		{
-			Name:    "hosts_localhost",
-			Value:   []string{"127.0.0.1", "::1"},
+			Name: "hosts_localhost",
+			Value: &entities.FactValueList{Value: []entities.FactValue{
+				&entities.FactValueString{Value: "127.0.0.1"},
+				&entities.FactValueString{Value: "::1"},
+			}},
 			CheckID: "check1",
 		},
 		{
-			Name:    "hosts_somehost",
-			Value:   []string{"127.0.1.1"},
+			Name: "hosts_somehost",
+			Value: &entities.FactValueList{Value: []entities.FactValue{
+				&entities.FactValueString{Value: "127.0.1.1"},
+			}},
 			CheckID: "check2",
 		},
 		{
-			Name:    "hosts_ip6-localhost",
-			Value:   []string{"::1"},
+			Name: "hosts_ip6-localhost",
+			Value: &entities.FactValueList{Value: []entities.FactValue{
+				&entities.FactValueString{Value: "::1"},
+			}},
 			CheckID: "check3",
 		},
 	}

--- a/internal/factsengine/gatherers/hostsfile_test.go
+++ b/internal/factsengine/gatherers/hostsfile_test.go
@@ -101,8 +101,17 @@ func (suite *HostsFileTestSuite) TestHostsFileIgnoresCommentedHosts() {
 
 	factResults, err := c.Gather(factRequests)
 
-	expectedResults := []entities.Fact{}
+	expectedResults := []entities.Fact{
+		{
+			Name:  "hosts_commented-host",
+			Value: nil,
+			Error: &entities.FactGatheringError{
+				Message: "requested field value not found in /etc/hosts file: commented-host",
+				Type:    "hosts-file-value-not-found",
+			},
+		},
+	}
 
-	suite.EqualError(err, "fact gathering error: hosts-file-value-not-found - requested field value not found in /etc/hosts file")
+	suite.NoError(err)
 	suite.ElementsMatch(expectedResults, factResults)
 }

--- a/internal/factsengine/gatherers/hostsfile_test.go
+++ b/internal/factsengine/gatherers/hostsfile_test.go
@@ -84,7 +84,8 @@ func (suite *HostsFileTestSuite) TestHostsFileNotExists() {
 
 	_, err := c.Gather(factRequests)
 
-	suite.EqualError(err, "fact gathering error: hosts-file-error - error reading /etc/hosts file: open non_existing_file: no such file or directory")
+	suite.EqualError(err, "fact gathering error: hosts-file-error - error reading /etc/hosts file: "+
+		"open non_existing_file: no such file or directory")
 }
 
 func (suite *HostsFileTestSuite) TestHostsFileIgnoresCommentedHosts() {

--- a/internal/factsengine/gatherers/hostsfile_test.go
+++ b/internal/factsengine/gatherers/hostsfile_test.go
@@ -1,0 +1,101 @@
+package gatherers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/trento-project/agent/internal/factsengine/entities"
+	"github.com/trento-project/agent/test/helpers"
+)
+
+type HostsFileTestSuite struct {
+	suite.Suite
+}
+
+func TestHostsFileTestSuite(t *testing.T) {
+	suite.Run(t, new(HostsFileTestSuite))
+}
+
+func (suite *HostsFileTestSuite) TestHostsFileBasic() {
+	c := NewHostsFileGatherer(helpers.GetFixturePath("gatherers/hosts.basic"))
+
+	factRequests := []entities.FactRequest{
+		{
+			Name:     "hosts_localhost",
+			Gatherer: "hosts",
+			Argument: "localhost",
+			CheckID:  "check1",
+		},
+		{
+			Name:     "hosts_somehost",
+			Gatherer: "hosts",
+			Argument: "somehost",
+			CheckID:  "check2",
+		},
+		{
+			Name:     "hosts_ip6-localhost",
+			Gatherer: "hosts",
+			Argument: "ip6-localhost",
+			CheckID:  "check3",
+		},
+	}
+
+	factResults, err := c.Gather(factRequests)
+
+	expectedResults := []entities.Fact{
+		{
+			Name:    "hosts_localhost",
+			Value:   []string{"127.0.0.1", "::1"},
+			CheckID: "check1",
+		},
+		{
+			Name:    "hosts_somehost",
+			Value:   []string{"127.0.1.1"},
+			CheckID: "check2",
+		},
+		{
+			Name:    "hosts_ip6-localhost",
+			Value:   []string{"::1"},
+			CheckID: "check3",
+		},
+	}
+
+	suite.NoError(err)
+	suite.ElementsMatch(expectedResults, factResults)
+}
+
+func (suite *HostsFileTestSuite) TestHostsFileNotExists() {
+	c := NewHostsFileGatherer("non_existing_file")
+
+	factRequests := []entities.FactRequest{
+		{
+			Name:     "hosts_somehost",
+			Gatherer: "hosts",
+			Argument: "somehost",
+		},
+	}
+
+	_, err := c.Gather(factRequests)
+
+	suite.EqualError(err, "fact gathering error: hosts-file-error - error reading /etc/hosts file: open non_existing_file: no such file or directory")
+}
+
+func (suite *HostsFileTestSuite) TestHostsFileIgnoresCommentedHosts() {
+
+	c := NewHostsFileGatherer(helpers.GetFixturePath("gatherers/hosts.basic"))
+
+	factRequests := []entities.FactRequest{
+		{
+			Name:     "hosts_commented-host",
+			Gatherer: "hosts",
+			Argument: "commented-host",
+		},
+	}
+
+	factResults, err := c.Gather(factRequests)
+
+	expectedResults := []entities.Fact{}
+
+	suite.EqualError(err, "fact gathering error: hosts-file-value-not-found - requested field value not found in /etc/hosts file")
+	suite.ElementsMatch(expectedResults, factResults)
+}

--- a/test/fixtures/gatherers/hosts.basic
+++ b/test/fixtures/gatherers/hosts.basic
@@ -1,0 +1,9 @@
+# Host addresses
+127.0.0.1  localhost
+127.0.1.1  somehost
+52.84.66.74 suse.com
+
+#127.0.0.1 commented-host
+::1        localhost ip6-localhost ip6-loopback
+ff02::1    ip6-allnodes
+ff02::2    ip6-allrouters


### PR DESCRIPTION
This PR:
 - Changes a bit the corosyncconf gatherer to use dependency injection for the interaction with the filesystem. This improves the testability
 - Implements a gatherer that collects facts about the /etc/hosts file. Given a hostname as argument, it will return a list of IPs that the hostname resolves to.
 - Takes care about some minor complains by the linter