### PR TITLE
Use DI for the CommandExecutor

### DIFF
--- a/internal/factsengine/factsengine.go
+++ b/internal/factsengine/factsengine.go
@@ -21,17 +21,16 @@ type FactsEngine struct {
 }
 
 func NewFactsEngine(agentID, factsEngineService string) *FactsEngine {
-	commandExecutor := gatherers.Executor{}
 	return &FactsEngine{
 		agentID:             agentID,
 		factsEngineService:  factsEngineService,
 		factsServiceAdapter: nil,
 		factGatherers: map[string]gatherers.FactGatherer{
 			gatherers.CorosyncFactKey:            gatherers.NewCorosyncConfGatherer(),
-			gatherers.CorosyncCmapCtlFactKey:     gatherers.NewCorosyncCmapctlGatherer(commandExecutor),
-			gatherers.PackageVersionGathererName: gatherers.NewPackageVersionGatherer(commandExecutor),
-			gatherers.CrmMonGathererName:         gatherers.NewCrmMonGatherer(commandExecutor),
-			gatherers.CibAdminGathererName:       gatherers.NewCibAdminGatherer(commandExecutor),
+			gatherers.CorosyncCmapCtlFactKey:     gatherers.NewDefaultCorosyncCmapctlGatherer(),
+			gatherers.PackageVersionGathererName: gatherers.NewDefaultPackageVersionGatherer(),
+			gatherers.CrmMonGathererName:         gatherers.NewDefaultCrmMonGatherer(),
+			gatherers.CibAdminGathererName:       gatherers.NewDefaultCibAdminGatherer(),
 			gatherers.SystemDGathererName:        gatherers.NewSystemDGatherer(),
 			gatherers.SBDConfigGathererName:      gatherers.NewSBDGathererWithDefaultConfig(),
 		},

--- a/internal/factsengine/factsengine.go
+++ b/internal/factsengine/factsengine.go
@@ -21,16 +21,17 @@ type FactsEngine struct {
 }
 
 func NewFactsEngine(agentID, factsEngineService string) *FactsEngine {
+	commandExecutor := gatherers.Executor{}
 	return &FactsEngine{
 		agentID:             agentID,
 		factsEngineService:  factsEngineService,
 		factsServiceAdapter: nil,
 		factGatherers: map[string]gatherers.FactGatherer{
 			gatherers.CorosyncFactKey:            gatherers.NewCorosyncConfGatherer(),
-			gatherers.CorosyncCmapCtlFactKey:     gatherers.NewCorosyncCmapctlGatherer(),
-			gatherers.PackageVersionGathererName: gatherers.NewPackageVersionGatherer(),
-			gatherers.CrmMonGathererName:         gatherers.NewCrmMonGatherer(),
-			gatherers.CibAdminGathererName:       gatherers.NewCibAdminGatherer(),
+			gatherers.CorosyncCmapCtlFactKey:     gatherers.NewCorosyncCmapctlGatherer(commandExecutor),
+			gatherers.PackageVersionGathererName: gatherers.NewPackageVersionGatherer(commandExecutor),
+			gatherers.CrmMonGathererName:         gatherers.NewCrmMonGatherer(commandExecutor),
+			gatherers.CibAdminGathererName:       gatherers.NewCibAdminGatherer(commandExecutor),
 			gatherers.SystemDGathererName:        gatherers.NewSystemDGatherer(),
 			gatherers.SBDConfigGathererName:      gatherers.NewSBDGathererWithDefaultConfig(),
 		},

--- a/internal/factsengine/gatherers/cibadmin.go
+++ b/internal/factsengine/gatherers/cibadmin.go
@@ -12,6 +12,10 @@ type CibAdminGatherer struct {
 	executor CommandExecutor
 }
 
+func NewDefaultCibAdminGatherer() *CibAdminGatherer {
+	return NewCibAdminGatherer(Executor{})
+}
+
 func NewCibAdminGatherer(executor CommandExecutor) *CibAdminGatherer {
 	return &CibAdminGatherer{
 		executor: executor,

--- a/internal/factsengine/gatherers/cibadmin.go
+++ b/internal/factsengine/gatherers/cibadmin.go
@@ -12,9 +12,9 @@ type CibAdminGatherer struct {
 	executor CommandExecutor
 }
 
-func NewCibAdminGatherer() *CibAdminGatherer {
+func NewCibAdminGatherer(executor CommandExecutor) *CibAdminGatherer {
 	return &CibAdminGatherer{
-		executor: Executor{},
+		executor: executor,
 	}
 }
 

--- a/internal/factsengine/gatherers/cibadmin_test.go
+++ b/internal/factsengine/gatherers/cibadmin_test.go
@@ -12,6 +12,7 @@ import (
 
 type CibAdminTestSuite struct {
 	suite.Suite
+	mockExecutor   *mocks.CommandExecutor
 	cibAdminOutput []byte
 }
 
@@ -26,15 +27,15 @@ func (suite *CibAdminTestSuite) SetupSuite() {
 	suite.cibAdminOutput = content
 }
 
-func (suite *CibAdminTestSuite) TestCibAdminGather() {
-	mockExecutor := new(mocks.CommandExecutor)
+func (suite *CibAdminTestSuite) SetupTest() {
+	suite.mockExecutor = new(mocks.CommandExecutor)
+}
 
-	mockExecutor.On("Exec", "cibadmin", "--query", "--local").Return(
+func (suite *CibAdminTestSuite) TestCibAdminGather() {
+	suite.mockExecutor.On("Exec", "cibadmin", "--query", "--local").Return(
 		suite.cibAdminOutput, nil)
 
-	p := &CibAdminGatherer{
-		executor: mockExecutor,
-	}
+	p := NewCibAdminGatherer(suite.mockExecutor)
 
 	factRequests := []FactRequest{
 		{
@@ -71,14 +72,10 @@ func (suite *CibAdminTestSuite) TestCibAdminGather() {
 }
 
 func (suite *CibAdminTestSuite) TestCibAdminGatherCmdNotFound() {
-	mockExecutor := new(mocks.CommandExecutor)
-
-	mockExecutor.On("Exec", "cibadmin", "--query", "--local").Return(
+	suite.mockExecutor.On("Exec", "cibadmin", "--query", "--local").Return(
 		suite.cibAdminOutput, errors.New("cibadmin not found"))
 
-	p := &CibAdminGatherer{
-		executor: mockExecutor,
-	}
+	p := NewCibAdminGatherer(suite.mockExecutor)
 
 	factRequests := []FactRequest{
 		{
@@ -101,14 +98,10 @@ func (suite *CibAdminTestSuite) TestCibAdminGatherCmdNotFound() {
 }
 
 func (suite *CibAdminTestSuite) TestCibAdminGatherError() {
-	mockExecutor := new(mocks.CommandExecutor)
-
-	mockExecutor.On("Exec", "cibadmin", "--query", "--local").Return(
+	suite.mockExecutor.On("Exec", "cibadmin", "--query", "--local").Return(
 		suite.cibAdminOutput, nil)
 
-	p := &CibAdminGatherer{
-		executor: mockExecutor,
-	}
+	p := NewCibAdminGatherer(suite.mockExecutor)
 
 	factRequests := []FactRequest{
 		{

--- a/internal/factsengine/gatherers/corosynccmapctl.go
+++ b/internal/factsengine/gatherers/corosynccmapctl.go
@@ -15,6 +15,10 @@ type CorosyncCmapctlGatherer struct {
 	executor CommandExecutor
 }
 
+func NewDefaultCorosyncCmapctlGatherer() *CorosyncCmapctlGatherer {
+	return NewCorosyncCmapctlGatherer(Executor{})
+}
+
 func NewCorosyncCmapctlGatherer(executor CommandExecutor) *CorosyncCmapctlGatherer {
 	return &CorosyncCmapctlGatherer{
 		executor: executor,

--- a/internal/factsengine/gatherers/corosynccmapctl.go
+++ b/internal/factsengine/gatherers/corosynccmapctl.go
@@ -15,9 +15,9 @@ type CorosyncCmapctlGatherer struct {
 	executor CommandExecutor
 }
 
-func NewCorosyncCmapctlGatherer() *CorosyncCmapctlGatherer {
+func NewCorosyncCmapctlGatherer(executor CommandExecutor) *CorosyncCmapctlGatherer {
 	return &CorosyncCmapctlGatherer{
-		executor: Executor{},
+		executor: executor,
 	}
 }
 

--- a/internal/factsengine/gatherers/corosynccmapctl_test.go
+++ b/internal/factsengine/gatherers/corosynccmapctl_test.go
@@ -12,22 +12,23 @@ import (
 
 type CorosyncCmapctlTestSuite struct {
 	suite.Suite
+	mockExecutor *mocks.CommandExecutor
 }
 
 func TestCorosyncCmapctlTestSuite(t *testing.T) {
 	suite.Run(t, new(CorosyncCmapctlTestSuite))
 }
 
-func (suite *CorosyncCmapctlTestSuite) TestCorosyncCmapctlGathererMissingFact() {
-	mockExecutor := new(mocks.CommandExecutor)
+func (suite *CorosyncCmapctlTestSuite) SetupTest() {
+	suite.mockExecutor = new(mocks.CommandExecutor)
+}
 
+func (suite *CorosyncCmapctlTestSuite) TestCorosyncCmapctlGathererMissingFact() {
 	mockOutputFile, _ := os.Open("../../../test/fixtures/gatherers/corosynccmap-ctl.output")
 	mockOutput, _ := io.ReadAll(mockOutputFile)
-	mockExecutor.On("Exec", "corosync-cmapctl", "-b").Return(mockOutput, nil)
+	suite.mockExecutor.On("Exec", "corosync-cmapctl", "-b").Return(mockOutput, nil)
 
-	c := &CorosyncCmapctlGatherer{
-		executor: mockExecutor,
-	}
+	c := NewCorosyncCmapctlGatherer(suite.mockExecutor)
 
 	factRequests := []FactRequest{
 		{
@@ -46,15 +47,11 @@ func (suite *CorosyncCmapctlTestSuite) TestCorosyncCmapctlGathererMissingFact() 
 }
 
 func (suite *CorosyncCmapctlTestSuite) TestCorosyncCmapctlGatherer() {
-	mockExecutor := new(mocks.CommandExecutor)
-
 	mockOutputFile, _ := os.Open("../../../test/fixtures/gatherers/corosynccmap-ctl.output")
 	mockOutput, _ := io.ReadAll(mockOutputFile)
-	mockExecutor.On("Exec", "corosync-cmapctl", "-b").Return(mockOutput, nil)
+	suite.mockExecutor.On("Exec", "corosync-cmapctl", "-b").Return(mockOutput, nil)
 
-	c := &CorosyncCmapctlGatherer{
-		executor: mockExecutor,
-	}
+	c := NewCorosyncCmapctlGatherer(suite.mockExecutor)
 
 	factRequests := []FactRequest{
 		{
@@ -114,13 +111,9 @@ func (suite *CorosyncCmapctlTestSuite) TestCorosyncCmapctlGatherer() {
 }
 
 func (suite *CorosyncCmapctlTestSuite) TestCorosyncCmapctlCommandNotFound() {
-	mockExecutor := new(mocks.CommandExecutor)
+	suite.mockExecutor.On("Exec", "corosync-cmapctl", "-b").Return(nil, exec.ErrNotFound)
 
-	mockExecutor.On("Exec", "corosync-cmapctl", "-b").Return(nil, exec.ErrNotFound)
-
-	c := &CorosyncCmapctlGatherer{
-		executor: mockExecutor,
-	}
+	c := NewCorosyncCmapctlGatherer(suite.mockExecutor)
 
 	factRequests := []FactRequest{
 		{

--- a/internal/factsengine/gatherers/crmmon.go
+++ b/internal/factsengine/gatherers/crmmon.go
@@ -12,9 +12,9 @@ type CrmMonGatherer struct {
 	executor CommandExecutor
 }
 
-func NewCrmMonGatherer() *CrmMonGatherer {
+func NewCrmMonGatherer(executor CommandExecutor) *CrmMonGatherer {
 	return &CrmMonGatherer{
-		executor: Executor{},
+		executor: executor,
 	}
 }
 

--- a/internal/factsengine/gatherers/crmmon.go
+++ b/internal/factsengine/gatherers/crmmon.go
@@ -12,6 +12,10 @@ type CrmMonGatherer struct {
 	executor CommandExecutor
 }
 
+func NewDefaultCrmMonGatherer() *CrmMonGatherer {
+	return NewCrmMonGatherer(Executor{})
+}
+
 func NewCrmMonGatherer(executor CommandExecutor) *CrmMonGatherer {
 	return &CrmMonGatherer{
 		executor: executor,

--- a/internal/factsengine/gatherers/crmmon_test.go
+++ b/internal/factsengine/gatherers/crmmon_test.go
@@ -12,6 +12,7 @@ import (
 
 type CrmMonTestSuite struct {
 	suite.Suite
+	mockExecutor *mocks.CommandExecutor
 	crmMonOutput []byte
 }
 
@@ -19,7 +20,8 @@ func TestCrmMonTestSuite(t *testing.T) {
 	suite.Run(t, new(CrmMonTestSuite))
 }
 
-func (suite *CrmMonTestSuite) SetupSuite() {
+func (suite *CrmMonTestSuite) SetupTest() {
+	suite.mockExecutor = new(mocks.CommandExecutor)
 	lFile, _ := os.Open("../../../test/fixtures/gatherers/crmmon.xml")
 	content, _ := io.ReadAll(lFile)
 
@@ -27,14 +29,10 @@ func (suite *CrmMonTestSuite) SetupSuite() {
 }
 
 func (suite *CrmMonTestSuite) TestCrmMonGather() {
-	mockExecutor := new(mocks.CommandExecutor)
-
-	mockExecutor.On("Exec", "crm_mon", "--output-as", "xml").Return(
+	suite.mockExecutor.On("Exec", "crm_mon", "--output-as", "xml").Return(
 		suite.crmMonOutput, nil)
 
-	p := &CrmMonGatherer{
-		executor: mockExecutor,
-	}
+	p := NewCrmMonGatherer(suite.mockExecutor)
 
 	factRequests := []FactRequest{
 		{
@@ -71,14 +69,9 @@ func (suite *CrmMonTestSuite) TestCrmMonGather() {
 }
 
 func (suite *CrmMonTestSuite) TestCrmMonGatherCmdNotFound() {
-	mockExecutor := new(mocks.CommandExecutor)
-
-	mockExecutor.On("Exec", "crm_mon", "--output-as", "xml").Return(
+	suite.mockExecutor.On("Exec", "crm_mon", "--output-as", "xml").Return(
 		suite.crmMonOutput, errors.New("crm_mon not found"))
-
-	p := &CrmMonGatherer{
-		executor: mockExecutor,
-	}
+	p := NewCrmMonGatherer(suite.mockExecutor)
 
 	factRequests := []FactRequest{
 		{
@@ -101,14 +94,11 @@ func (suite *CrmMonTestSuite) TestCrmMonGatherCmdNotFound() {
 }
 
 func (suite *CrmMonTestSuite) TestCrmMonGatherError() {
-	mockExecutor := new(mocks.CommandExecutor)
 
-	mockExecutor.On("Exec", "crm_mon", "--output-as", "xml").Return(
+	suite.mockExecutor.On("Exec", "crm_mon", "--output-as", "xml").Return(
 		suite.crmMonOutput, nil)
 
-	p := &CrmMonGatherer{
-		executor: mockExecutor,
-	}
+	p := NewCrmMonGatherer(suite.mockExecutor)
 
 	factRequests := []FactRequest{
 		{

--- a/internal/factsengine/gatherers/packageversion.go
+++ b/internal/factsengine/gatherers/packageversion.go
@@ -12,6 +12,10 @@ type PackageVersionGatherer struct {
 	executor CommandExecutor
 }
 
+func NewDefaultPackageVersionGatherer() *PackageVersionGatherer {
+	return NewPackageVersionGatherer(Executor{})
+}
+
 func NewPackageVersionGatherer(executor CommandExecutor) *PackageVersionGatherer {
 	return &PackageVersionGatherer{
 		executor: executor,

--- a/internal/factsengine/gatherers/packageversion.go
+++ b/internal/factsengine/gatherers/packageversion.go
@@ -12,9 +12,9 @@ type PackageVersionGatherer struct {
 	executor CommandExecutor
 }
 
-func NewPackageVersionGatherer() *PackageVersionGatherer {
+func NewPackageVersionGatherer(executor CommandExecutor) *PackageVersionGatherer {
 	return &PackageVersionGatherer{
-		executor: Executor{},
+		executor: executor,
 	}
 }
 

--- a/internal/factsengine/gatherers/packageversion_test.go
+++ b/internal/factsengine/gatherers/packageversion_test.go
@@ -10,23 +10,24 @@ import (
 
 type PackageVersionTestSuite struct {
 	suite.Suite
+	mockExecutor *mocks.CommandExecutor
 }
 
 func TestPackageVersionTestSuite(t *testing.T) {
 	suite.Run(t, new(PackageVersionTestSuite))
 }
 
-func (suite *PackageVersionTestSuite) TestPackageVersionGather() {
-	mockExecutor := new(mocks.CommandExecutor)
+func (suite *PackageVersionTestSuite) SetupTest() {
+	suite.mockExecutor = new(mocks.CommandExecutor)
+}
 
-	mockExecutor.On("Exec", "rpm", "-q", "--qf", "%{VERSION}", "corosync").Return(
+func (suite *PackageVersionTestSuite) TestPackageVersionGather() {
+	suite.mockExecutor.On("Exec", "rpm", "-q", "--qf", "%{VERSION}", "corosync").Return(
 		[]byte("2.4.5"), nil)
-	mockExecutor.On("Exec", "rpm", "-q", "--qf", "%{VERSION}", "pacemaker").Return(
+	suite.mockExecutor.On("Exec", "rpm", "-q", "--qf", "%{VERSION}", "pacemaker").Return(
 		[]byte("2.0.5+20201202.ba59be712"), nil)
 
-	p := &PackageVersionGatherer{
-		executor: mockExecutor,
-	}
+	p := NewPackageVersionGatherer(suite.mockExecutor)
 
 	factRequests := []FactRequest{
 		{
@@ -63,16 +64,12 @@ func (suite *PackageVersionTestSuite) TestPackageVersionGather() {
 }
 
 func (suite *PackageVersionTestSuite) TestPackageVersionGatherError() {
-	mockExecutor := new(mocks.CommandExecutor)
-
-	mockExecutor.On("Exec", "rpm", "-q", "--qf", "%{VERSION}", "corosync").Return(
+	suite.mockExecutor.On("Exec", "rpm", "-q", "--qf", "%{VERSION}", "corosync").Return(
 		[]byte("2.4.5"), nil)
-	mockExecutor.On("Exec", "rpm", "-q", "--qf", "%{VERSION}", "pacemake").Return(
+	suite.mockExecutor.On("Exec", "rpm", "-q", "--qf", "%{VERSION}", "pacemake").Return(
 		[]byte("package pacemake is not installed\n"), errors.New("some error"))
 
-	p := &PackageVersionGatherer{
-		executor: mockExecutor,
-	}
+	p := NewPackageVersionGatherer(suite.mockExecutor)
 
 	factRequests := []FactRequest{
 		{


### PR DESCRIPTION
Switch gatherers that use the CommandExecutor to do it using dependency injection