### PR TITLE
Agent-wanda integration experiment - agent specific messages

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -115,11 +115,18 @@ func NewStartCmd() *cobra.Command {
 	if err != nil {
 		panic(err)
 	}
-	startCmd.Flags().String("facts-service-url", "amqp://guest:guest@localhost:5672", "Facts service queue url")
+	startCmd.Flags().String("facts-service-url", "amqp://wanda:wanda@localhost:5672", "Facts service queue url")
 	err = startCmd.Flags().MarkHidden("facts-service-url")
 	if err != nil {
 		panic(err)
 	}
+
+	startCmd.Flags().String("override-agent-id", "agent-1", "")
+	err = startCmd.Flags().MarkHidden("override-agent-id")
+	if err != nil {
+		panic(err)
+	}
+
 	return startCmd
 }
 

--- a/internal/agent.go
+++ b/internal/agent.go
@@ -3,12 +3,12 @@ package internal
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
+	"github.com/spf13/viper"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/trento-project/agent/internal/discovery"
@@ -68,13 +68,17 @@ func NewAgent(config *Config) (*Agent, error) {
 }
 
 func getAgentID() (string, error) {
-	machineIDBytes, err := afero.ReadFile(fileSystem, machineIDPath)
-	if err != nil {
-		return "", err
-	}
+	// machineIDBytes, err := afero.ReadFile(fileSystem, machineIDPath)
+	// if err != nil {
+	// 	return "", err
+	// }
 
-	machineID := strings.TrimSpace(string(machineIDBytes))
+	// machineID := strings.TrimSpace(string(machineIDBytes))
+
+	machineID := viper.GetString("override-agent-id")
 	agentID := uuid.NewSHA1(trentoNamespace, []byte(machineID))
+
+	log.Infof("agent id: %s", agentID.String())
 
 	return agentID.String(), nil
 }
@@ -83,22 +87,22 @@ func getAgentID() (string, error) {
 func (a *Agent) Start(ctx context.Context) error {
 	g, groupCtx := errgroup.WithContext(ctx)
 
-	for _, d := range a.discoveries {
-		dLoop := d
-		g.Go(func() error {
-			log.Infof("Starting %s loop...", dLoop.GetID())
-			a.startDiscoverTicker(groupCtx, dLoop)
-			log.Infof("%s discover loop stopped.", dLoop.GetID())
-			return nil
-		})
-	}
+	// for _, d := range a.discoveries {
+	// 	dLoop := d
+	// 	g.Go(func() error {
+	// 		log.Infof("Starting %s loop...", dLoop.GetID())
+	// 		a.startDiscoverTicker(groupCtx, dLoop)
+	// 		log.Infof("%s discover loop stopped.", dLoop.GetID())
+	// 		return nil
+	// 	})
+	// }
 
-	g.Go(func() error {
-		log.Info("Starting heartbeat loop...")
-		a.startHeartbeatTicker(groupCtx)
-		log.Info("heartbeat loop stopped.")
-		return nil
-	})
+	// g.Go(func() error {
+	// 	log.Info("Starting heartbeat loop...")
+	// 	a.startHeartbeatTicker(groupCtx)
+	// 	log.Info("heartbeat loop stopped.")
+	// 	return nil
+	// })
 
 	if a.config.FactsEngineEnabled {
 		c := factsengine.NewFactsEngine(a.agentID, a.config.FactsServiceURL)

--- a/internal/factsengine/adapters/rabbitmq.go
+++ b/internal/factsengine/adapters/rabbitmq.go
@@ -1,6 +1,8 @@
 package adapters
 
 import (
+	"fmt"
+
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/wagslane/go-rabbitmq"
@@ -51,6 +53,9 @@ func (r *RabbitMQAdapter) Unsubscribe() error {
 func (r *RabbitMQAdapter) Listen(
 	queue, exchange string, handle func(contentType string, message []byte) error) error {
 
+	// agentID, _ := internal.GetAgentID()
+	agentID := queue
+
 	return r.consumer.StartConsuming(
 		func(d rabbitmq.Delivery) rabbitmq.Action {
 			// TODO: Handle different kind of errors returning some sort of metadata
@@ -63,20 +68,26 @@ func (r *RabbitMQAdapter) Listen(
 
 			return rabbitmq.Ack
 		},
-		queue,
-		[]string{queue},
+		// "events_wanda"
+		fmt.Sprintf("agent-%s", agentID),
+		[]string{fmt.Sprintf("checks.agents.execution.%s", agentID)},
 		rabbitmq.WithConsumeOptionsQueueDurable,
-		rabbitmq.WithConsumeOptionsQueueAutoDelete,
+		// rabbitmq.WithConsumeOptionsQueueAutoDelete,
 		rabbitmq.WithConsumeOptionsBindingExchangeName(exchange),
+		rabbitmq.WithConsumeOptionsBindingExchangeKind("topic"),
+		rabbitmq.WithConsumeOptionsConsumerName(fmt.Sprintf("agent-%s", agentID)),
+		rabbitmq.WithConsumeOptionsQueueArgs(rabbitmq.Table{
+			"x-dead-letter-exchange": "events.deadletter",
+		}),
 		rabbitmq.WithConsumeOptionsBindingExchangeDurable,
-		rabbitmq.WithConsumeOptionsBindingExchangeAutoDelete,
+		// rabbitmq.WithConsumeOptionsBindingExchangeAutoDelete,
 	)
 }
 
 func (r *RabbitMQAdapter) Publish(exchange, contentType string, message []byte) error {
 	return r.publisher.Publish(
 		message,
-		[]string{""},
+		[]string{"checks.executions"},
 		rabbitmq.WithPublishOptionsContentType(contentType),
 		rabbitmq.WithPublishOptionsMandatory,
 		rabbitmq.WithPublishOptionsPersistentDelivery,

--- a/internal/factsengine/gatherers/corosyncconf.go
+++ b/internal/factsengine/gatherers/corosyncconf.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	CorosyncFactKey  = "corosync.conf"
+	CorosyncFactKey  = "corosync"
 	CorosyncConfPath = "/etc/corosync/corosync.conf"
 )
 


### PR DESCRIPTION
~Disclaimer: this branches out from https://github.com/trento-project/agent/pull/73 which was closed in favor of https://github.com/trento-project/agent/pull/88 Delete me~

I manage to port the changes on top of main, less noise. Delete me anyway :smile: 

---

This draft goes with this experiment https://github.com/trento-project/wanda/pull/16

Nothing fancy:
- some code has been commented for the sake of the test
- hooked with wanda queues/routing keys
- fakes the presence of a corosync conf to pretend it can gather facts (and it can)
- hack to get deterministic agent ids

Here's the vscode debug config
```
{
    "name": "Launch Trento Agent",
    "type": "go",
    "request": "launch",
    "mode": "auto",
    "program": "${workspaceFolder}/main.go",
    "args": [
        "start",
        "--factsengine",
        "--override-agent-id=agent-1",
        "--config=path/to/your/trento-agent.yaml",
    ]
},
{
    "name": "Launch Trento Agent 2",
    "type": "go",
    "request": "launch",
    "mode": "auto",
    "program": "${workspaceFolder}/main.go",
    "args": [
        "start",
        "--factsengine",
        "--override-agent-id=agent-2",
        "--config=path/to/your/trento-agent.yaml",
    ]
},
{
    "name": "Launch Trento Agent 3",
    "type": "go",
    "request": "launch",
    "mode": "auto",
    "program": "${workspaceFolder}/main.go",
    "args": [
        "start",
        "--factsengine",
        "--override-agent-id=agent-3",
        "--config=path/to/your/trento-agent.yaml",
    ]
},
{
    "name": "Launch Trento Agent 4",
    "type": "go",
    "request": "launch",
    "mode": "auto",
    "program": "${workspaceFolder}/main.go",
    "args": [
        "start",
        "--factsengine",
        "--override-agent-id=agent-4",
        "--config=path/to/your/trento-agent.yaml",
    ]
},
```