### PR TITLE
Fact gathering error reply in results

### DIFF
--- a/internal/factsengine/entities/facts_gathered_test.go
+++ b/internal/factsengine/entities/facts_gathered_test.go
@@ -73,7 +73,7 @@ func (suite *FactsTestSuite) TestFactsGatheredWithErrorToEvent() {
 				Name:    "dummy1",
 				Value:   nil,
 				CheckID: "check1",
-				Error: &Error{
+				Error: &FactGatheringError{
 					Message: "some message",
 					Type:    "some_type",
 				},
@@ -139,7 +139,7 @@ func (suite *FactsTestSuite) TestFactsPrettifyFactsGatheredItemWithError() {
 		Name:    "some-fact",
 		Value:   nil,
 		CheckID: "check1",
-		Error: &Error{
+		Error: &FactGatheringError{
 			Message: "some message",
 			Type:    "some_type",
 		},

--- a/internal/factsengine/gatherers/cibadmin_test.go
+++ b/internal/factsengine/gatherers/cibadmin_test.go
@@ -93,9 +93,31 @@ func (suite *CibAdminTestSuite) TestCibAdminGatherCmdNotFound() {
 		},
 	}
 
-	_, err := p.Gather(factRequests)
+	factResults, err := p.Gather(factRequests)
 
-	suite.EqualError(err, "cibadmin not found")
+	expectedResults := []entities.FactsGatheredItem{
+		{
+			Name:    "instance_number",
+			CheckID: "check1",
+			Value:   nil,
+			Error: &entities.FactGatheringError{
+				Message: "error running cibadmin command: cibadmin not found",
+				Type:    "cibadmin-execution-error",
+			},
+		},
+		{
+			Name:    "sid",
+			Value:   nil,
+			CheckID: "check2",
+			Error: &entities.FactGatheringError{
+				Message: "error running cibadmin command: cibadmin not found",
+				Type:    "cibadmin-execution-error",
+			},
+		},
+	}
+
+	suite.NoError(err)
+	suite.ElementsMatch(expectedResults, factResults)
 }
 
 func (suite *CibAdminTestSuite) TestCibAdminGatherError() {
@@ -124,8 +146,13 @@ func (suite *CibAdminTestSuite) TestCibAdminGatherError() {
 	expectedResults := []entities.FactsGatheredItem{
 		{
 			Name:    "instance_number",
-			Value:   "",
+			Value:   nil,
 			CheckID: "check1",
+			Error: &entities.FactGatheringError{
+				Message: "requested xpath value not found: " +
+					"requested xpath //primitive[@type='SAPHana']/instance_attributes/nvpair[@name='InstancNumber']/@value not found",
+				Type: "xml-xpath-value-not-found",
+			},
 		},
 		{
 			Name:    "sid",

--- a/internal/factsengine/gatherers/corosynccmapctl.go
+++ b/internal/factsengine/gatherers/corosynccmapctl.go
@@ -12,6 +12,18 @@ const (
 	CorosyncCmapCtlFactKey = "corosync-cmapctl"
 )
 
+var (
+	CmapctlError = entities.FactGatheringError{ // nolint
+		Type:    "cmapctl-execution-error",
+		Message: "error running cmaptcl command",
+	}
+
+	CmapctlValueNotFoundError = entities.FactGatheringError{ // nolint
+		Type:    "cmapctl-value-not-found",
+		Message: "requested field value not found",
+	}
+)
+
 type CorosyncCmapctlGatherer struct {
 	executor CommandExecutor
 }
@@ -30,21 +42,26 @@ func (s *CorosyncCmapctlGatherer) Gather(factsRequests []entities.FactRequest) (
 	facts := []entities.FactsGatheredItem{}
 	log.Infof("Starting %s facts gathering process", CorosyncCmapCtlFactKey)
 
-	corosyncCmapctl, err := s.executor.Exec(
-		"corosync-cmapctl", "-b")
+	corosyncCmapctl, err := s.executor.Exec("corosync-cmapctl", "-b")
 	if err != nil {
-		return facts, err
+		gatheringError := CmapctlError.Wrap(err.Error())
+		log.Errorf(gatheringError.Error())
+		return entities.NewFactsGatheredListWithError(factsRequests, &gatheringError), nil
 	}
 
 	corosyncCmapctlMap := utils.FindMatches(`(?m)^(\S*)\s\(\S*\)\s=\s(.*)$`, corosyncCmapctl)
 
 	for _, factReq := range factsRequests {
+		var fact entities.FactsGatheredItem
+
 		if value, ok := corosyncCmapctlMap[factReq.Argument]; ok {
-			fact := entities.NewFactGatheredWithRequest(factReq, fmt.Sprint(value))
-			facts = append(facts, fact)
+			fact = entities.NewFactGatheredWithRequest(factReq, fmt.Sprint(value))
 		} else {
-			log.Warnf("%s gatherer: requested fact %s not found", CorosyncCmapCtlFactKey, factReq.Argument)
+			gatheringError := CmapctlValueNotFoundError.Wrap(fmt.Sprintf("requested fact %s not found", factReq.Argument))
+			log.Errorf(gatheringError.Error())
+			fact = entities.NewFactGatheredWithError(factReq, &gatheringError)
 		}
+		facts = append(facts, fact)
 	}
 
 	log.Infof("Requested %s facts gathered", CorosyncCmapCtlFactKey)

--- a/internal/factsengine/gatherers/corosynccmapctl_test.go
+++ b/internal/factsengine/gatherers/corosynccmapctl_test.go
@@ -41,7 +41,16 @@ func (suite *CorosyncCmapctlTestSuite) TestCorosyncCmapctlGathererMissingFact() 
 
 	factResults, err := c.Gather(factRequests)
 
-	expectedResults := []entities.FactsGatheredItem{}
+	expectedResults := []entities.FactsGatheredItem{
+		{
+			Name:  "madeup_fact",
+			Value: nil,
+			Error: &entities.FactGatheringError{
+				Message: "requested field value not found: requested fact madeup.fact not found",
+				Type:    "cmapctl-value-not-found",
+			},
+		},
+	}
 
 	suite.NoError(err)
 	suite.ElementsMatch(expectedResults, factResults)
@@ -122,12 +131,34 @@ func (suite *CorosyncCmapctlTestSuite) TestCorosyncCmapctlCommandNotFound() {
 			Gatherer: "corosync-cmapctl",
 			Argument: "quorum.provider",
 		},
+		{
+			Name:     "other_provider",
+			Gatherer: "corosync-cmapctl",
+			Argument: "other.provider",
+		},
 	}
 
 	factResults, err := c.Gather(factRequests)
 
-	expectedResults := []entities.FactsGatheredItem{}
+	expectedResults := []entities.FactsGatheredItem{
+		{
+			Name:  "quorum_provider",
+			Value: nil,
+			Error: &entities.FactGatheringError{
+				Message: "error running cmaptcl command: executable file not found in $PATH",
+				Type:    "cmapctl-execution-error",
+			},
+		},
+		{
+			Name:  "other_provider",
+			Value: nil,
+			Error: &entities.FactGatheringError{
+				Message: "error running cmaptcl command: executable file not found in $PATH",
+				Type:    "cmapctl-execution-error",
+			},
+		},
+	}
 
-	suite.Error(err)
+	suite.NoError(err)
 	suite.ElementsMatch(expectedResults, factResults)
 }

--- a/internal/factsengine/gatherers/corosyncconf_test.go
+++ b/internal/factsengine/gatherers/corosyncconf_test.go
@@ -93,6 +93,10 @@ func (suite *CorosyncConfTestSuite) TestCorosyncConfBasic() {
 		{
 			Name:  "corosync_not_found",
 			Value: nil,
+			Error: &entities.FactGatheringError{
+				Message: "requested field value not found: requested fact totem.not_found not found",
+				Type:    "corosync-conf-value-not-found",
+			},
 		},
 	}
 
@@ -111,9 +115,22 @@ func (suite *CorosyncConfTestSuite) TestCorosyncConfFileNotExists() {
 		},
 	}
 
-	_, err := c.Gather(factRequests)
+	factResults, err := c.Gather(factRequests)
 
-	suite.EqualError(err, "could not open corosync.conf file: open not_found: no such file or directory")
+	expectedResults := []entities.FactsGatheredItem{
+		{
+			Name:  "corosync_token",
+			Value: nil,
+			Error: &entities.FactGatheringError{
+				Message: "error reading corosync.conf file: " +
+					"could not open corosync.conf file: open not_found: no such file or directory",
+				Type: "corosync-conf-file-error",
+			},
+		},
+	}
+
+	suite.NoError(err)
+	suite.ElementsMatch(expectedResults, factResults)
 }
 
 func (suite *CorosyncConfTestSuite) TestCorosyncConfInvalid() {
@@ -127,7 +144,19 @@ func (suite *CorosyncConfTestSuite) TestCorosyncConfInvalid() {
 		},
 	}
 
-	_, err := c.Gather(factRequests)
+	factResults, err := c.Gather(factRequests)
 
-	suite.EqualError(err, "invalid corosync file structure. some section is not closed properly")
+	expectedResults := []entities.FactsGatheredItem{
+		{
+			Name:  "corosync_token",
+			Value: nil,
+			Error: &entities.FactGatheringError{
+				Message: "error decoding corosync.conf file: invalid corosync file structure. some section is not closed properly",
+				Type:    "corosync-conf-decoding-error",
+			},
+		},
+	}
+
+	suite.NoError(err)
+	suite.ElementsMatch(expectedResults, factResults)
 }

--- a/internal/factsengine/gatherers/crmmon.go
+++ b/internal/factsengine/gatherers/crmmon.go
@@ -1,4 +1,4 @@
-package gatherers
+package gatherers // nolint
 
 import (
 	log "github.com/sirupsen/logrus"
@@ -8,6 +8,11 @@ import (
 const (
 	CrmMonGathererName = "crm_mon"
 )
+
+var CrmmonError = entities.FactGatheringError{ // nolint
+	Type:    "crmmon-execution-error",
+	Message: "error running crm_mon command",
+}
 
 type CrmMonGatherer struct {
 	executor CommandExecutor
@@ -28,7 +33,9 @@ func (g *CrmMonGatherer) Gather(factsRequests []entities.FactRequest) ([]entitie
 
 	crmmon, err := g.executor.Exec("crm_mon", "--output-as", "xml")
 	if err != nil {
-		return nil, err
+		gatheringError := CrmmonError.Wrap(err.Error())
+		log.Errorf(gatheringError.Error())
+		return entities.NewFactsGatheredListWithError(factsRequests, &gatheringError), nil
 	}
 
 	facts, err := GatherFromXML(string(crmmon), factsRequests)

--- a/internal/factsengine/gatherers/crmmon_test.go
+++ b/internal/factsengine/gatherers/crmmon_test.go
@@ -89,9 +89,31 @@ func (suite *CrmMonTestSuite) TestCrmMonGatherCmdNotFound() {
 		},
 	}
 
-	_, err := p.Gather(factRequests)
+	factResults, err := p.Gather(factRequests)
 
-	suite.EqualError(err, "crm_mon not found")
+	expectedResults := []entities.FactsGatheredItem{
+		{
+			Name:    "role",
+			CheckID: "check1",
+			Value:   nil,
+			Error: &entities.FactGatheringError{
+				Message: "error running crm_mon command: crm_mon not found",
+				Type:    "crmmon-execution-error",
+			},
+		},
+		{
+			Name:    "active",
+			Value:   nil,
+			CheckID: "check2",
+			Error: &entities.FactGatheringError{
+				Message: "error running crm_mon command: crm_mon not found",
+				Type:    "crmmon-execution-error",
+			},
+		},
+	}
+
+	suite.NoError(err)
+	suite.ElementsMatch(expectedResults, factResults)
 }
 
 func (suite *CrmMonTestSuite) TestCrmMonGatherError() {
@@ -121,13 +143,19 @@ func (suite *CrmMonTestSuite) TestCrmMonGatherError() {
 	expectedResults := []entities.FactsGatheredItem{
 		{
 			Name:    "role",
-			Value:   "",
+			Value:   nil,
 			CheckID: "check1",
+			Error: &entities.FactGatheringError{
+				Message: "requested xpath value not found: " +
+					"requested xpath //resource[@resource_agent='stonith:external/sbd']/@rle not found",
+				Type: "xml-xpath-value-not-found",
+			},
 		},
 		{
 			Name:    "active",
 			Value:   "true",
 			CheckID: "check2",
+			Error:   nil,
 		},
 	}
 

--- a/internal/factsengine/gatherers/packageversion_test.go
+++ b/internal/factsengine/gatherers/packageversion_test.go
@@ -97,8 +97,12 @@ func (suite *PackageVersionTestSuite) TestPackageVersionGatherError() {
 		},
 		{
 			Name:    "pacemaker",
-			Value:   "package pacemake is not installed\n",
+			Value:   nil,
 			CheckID: "check2",
+			Error: &entities.FactGatheringError{
+				Message: "package not found: package pacemake is not installed",
+				Type:    "package_not_found",
+			},
 		},
 	}
 

--- a/internal/factsengine/gatherers/systemd_test.go
+++ b/internal/factsengine/gatherers/systemd_test.go
@@ -98,9 +98,31 @@ func (suite *SystemDTestSuite) TestSystemDGatherNotInitialized() {
 		},
 	}
 
-	_, err := s.Gather(factRequests)
+	gatheredFacts, err := s.Gather(factRequests)
 
-	suite.EqualError(err, "systemd gatherer not initialized properly")
+	expectedResults := []entities.FactsGatheredItem{
+		{
+			Name:    "corosync",
+			Value:   nil,
+			CheckID: "check1",
+			Error: &entities.FactGatheringError{
+				Message: "systemd gatherer not initialized properly",
+				Type:    "systemd-gatherer-not-initialized",
+			},
+		},
+		{
+			Name:    "pacemaker",
+			Value:   nil,
+			CheckID: "check2",
+			Error: &entities.FactGatheringError{
+				Message: "systemd gatherer not initialized properly",
+				Type:    "systemd-gatherer-not-initialized",
+			},
+		},
+	}
+
+	suite.NoError(err)
+	suite.ElementsMatch(expectedResults, gatheredFacts)
 }
 
 func (suite *SystemDTestSuite) TestSystemDGatherError() {
@@ -129,7 +151,29 @@ func (suite *SystemDTestSuite) TestSystemDGatherError() {
 		},
 	}
 
-	_, err := s.Gather(factRequests)
+	gatheredFacts, err := s.Gather(factRequests)
 
-	suite.EqualError(err, "Error getting unit states: error listing")
+	expectedResults := []entities.FactsGatheredItem{
+		{
+			Name:    "corosync",
+			Value:   nil,
+			CheckID: "check1",
+			Error: &entities.FactGatheringError{
+				Message: "error getting unit states: error listing",
+				Type:    "systemd-list-units-error",
+			},
+		},
+		{
+			Name:    "pacemaker",
+			Value:   nil,
+			CheckID: "check2",
+			Error: &entities.FactGatheringError{
+				Message: "error getting unit states: error listing",
+				Type:    "systemd-list-units-error",
+			},
+		},
+	}
+
+	suite.NoError(err)
+	suite.ElementsMatch(expectedResults, gatheredFacts)
 }

--- a/internal/factsengine/gatherers/verifypassword_test.go
+++ b/internal/factsengine/gatherers/verifypassword_test.go
@@ -101,7 +101,17 @@ func (suite *PasswordTestSuite) TestPasswordGatherWrongArguments() {
 
 	factResults, err := verifyPasswordGatherer.Gather(factRequests)
 
-	expectedResults := []entities.FactsGatheredItem{}
+	expectedResults := []entities.FactsGatheredItem{
+		{
+			Name:    "hacluster",
+			Value:   nil,
+			CheckID: "check1",
+			Error: &entities.FactGatheringError{
+				Message: "the provided argument should follow the \"username:password\" format",
+				Type:    "verify-password-invalid-argument",
+			},
+		},
+	}
 
 	suite.NoError(err)
 	suite.ElementsMatch(expectedResults, factResults)


### PR DESCRIPTION
Implementation of the fact gathering errors reply in the results. 
When any error happens during a fact gathering, this is send in the `Error` field of the `FactGathered` struct.

This is the an example of the log and result:
```
INFO[2022-09-06 09:18:50] Starting facts gathering process             
INFO[2022-09-06 09:18:50] Starting Package versions facts gathering process 
ERRO[2022-09-06 09:18:51] fact gathering error: type: package_not_found - package not found: package other is not installed 
INFO[2022-09-06 09:18:51] Requested Package versions facts gathered    
INFO[2022-09-06 09:18:51] Requested facts gathered                     
INFO[2022-09-06 09:18:51] Publishing gathered facts to the checks engine service 
INFO[2022-09-06 09:18:51] Gathered facts published properly  
```

```
{
  "agent_id": "-",
  "execution_id": "-",
  "facts_gathered": [
    {
      "check_id": "check2",
      "name": "pacemaker_version",
      "value": "2.0.5+20201202.ba59be712"
    },
    {
      "check_id": "check3",
      "name": "corosync_version",
      "value": "2.4.5"
    },
    {
      "check_id": "check3",
      "error": {
        "message": "package not found: package other is not installed",
        "type": "package_not_found"
      },
      "name": "other_version",
      "value": null
    }
  ]
}
```