### PR TITLE
Map the numeric strings as numbers to send the event

### DIFF
--- a/internal/factsengine/mapper_test.go
+++ b/internal/factsengine/mapper_test.go
@@ -34,7 +34,12 @@ func (suite *MapperTestSuite) TestFactsGatheredToEvent() {
 			},
 			{
 				Name:    "dummy2",
-				Value:   "2",
+				Value:   "result",
+				CheckID: "check1",
+			},
+			{
+				Name:    "dummy3",
+				Value:   2,
 				CheckID: "check1",
 			},
 		},
@@ -53,15 +58,22 @@ func (suite *MapperTestSuite) TestFactsGatheredToEvent() {
 		FactsGathered: []*events.Fact{
 			{
 				Name: "dummy1",
-				Value: &events.Fact_TextValue{
-					TextValue: "1",
+				Value: &events.Fact_NumericValue{
+					NumericValue: float32(1),
 				},
 				CheckId: "check1",
 			},
 			{
 				Name: "dummy2",
 				Value: &events.Fact_TextValue{
-					TextValue: "2",
+					TextValue: "result",
+				},
+				CheckId: "check1",
+			},
+			{
+				Name: "dummy3",
+				Value: &events.Fact_NumericValue{
+					NumericValue: float32(2),
 				},
 				CheckId: "check1",
 			},
@@ -92,7 +104,7 @@ func (suite *MapperTestSuite) TestFactsGatheredWithErrorToEvent() {
 			},
 			{
 				Name:    "dummy2",
-				Value:   "2",
+				Value:   "result",
 				CheckID: "check1",
 			},
 		},
@@ -122,7 +134,7 @@ func (suite *MapperTestSuite) TestFactsGatheredWithErrorToEvent() {
 			{
 				Name: "dummy2",
 				Value: &events.Fact_TextValue{
-					TextValue: "2",
+					TextValue: "result",
 				},
 				CheckId: "check1",
 			},

--- a/internal/factsengine/policy_test.go
+++ b/internal/factsengine/policy_test.go
@@ -109,14 +109,14 @@ func (suite *PolicyTestSuite) TestPolicyPublishFacts() {
 					{
 						Name: "dummy1",
 						Value: &events.Fact_TextValue{
-							TextValue: "1",
+							TextValue: "result1",
 						},
 						CheckId: "check1",
 					},
 					{
 						Name: "dummy2",
 						Value: &events.Fact_TextValue{
-							TextValue: "2",
+							TextValue: "result2",
 						},
 						CheckId: "check1",
 					},
@@ -136,12 +136,12 @@ func (suite *PolicyTestSuite) TestPolicyPublishFacts() {
 		FactsGathered: []entities.Fact{
 			{
 				Name:    "dummy1",
-				Value:   "1",
+				Value:   "result1",
 				CheckID: "check1",
 			},
 			{
 				Name:    "dummy2",
-				Value:   "2",
+				Value:   "result2",
 				CheckID: "check1",
 			},
 		},


### PR DESCRIPTION
Map the numeric strings as numbers in the event conversion. This way, if we gather some fact like `30000`, this will be automatically converted to a number.