### PR TITLE
Fact gathering errors

### DIFF
--- a/internal/factsengine/entities/facts_gathered.go
+++ b/internal/factsengine/entities/facts_gathered.go
@@ -24,12 +24,12 @@ type FactsGathered struct {
 	FactsGathered []Fact
 }
 
-func (e FactGatheringError) Error() string {
+func (e *FactGatheringError) Error() string {
 	return fmt.Sprintf("fact gathering error: type: %s - %s", e.Type, e.Message)
 }
 
-func (e FactGatheringError) Wrap(msg string) FactGatheringError {
-	return FactGatheringError{
+func (e *FactGatheringError) Wrap(msg string) *FactGatheringError {
+	return &FactGatheringError{
 		Message: fmt.Sprintf("%s: %v", e.Message, msg),
 		Type:    e.Type,
 	}

--- a/internal/factsengine/entities/facts_gathered.go
+++ b/internal/factsengine/entities/facts_gathered.go
@@ -25,7 +25,7 @@ type FactsGathered struct {
 }
 
 func (e *FactGatheringError) Error() string {
-	return fmt.Sprintf("fact gathering error: type: %s - %s", e.Type, e.Message)
+	return fmt.Sprintf("fact gathering error: %s - %s", e.Type, e.Message)
 }
 
 func (e *FactGatheringError) Wrap(msg string) *FactGatheringError {

--- a/internal/factsengine/gatherers/corosyncconf.go
+++ b/internal/factsengine/gatherers/corosyncconf.go
@@ -24,6 +24,24 @@ var (
 	valuePatternCompiled        = regexp.MustCompile(`^\s*(\w+)\s*:\s*(\S+).*`)
 )
 
+// nolint:gochecknoglobals
+var (
+	CorosyncConfFileError = entities.FactGatheringError{
+		Type:    "corosync-conf-file-error",
+		Message: "error reading corosync.conf file",
+	}
+
+	CorosyncConfDecodingError = entities.FactGatheringError{
+		Type:    "corosync-conf-decoding-error",
+		Message: "error decoding corosync.conf file",
+	}
+
+	CorosyncConfValueNotFoundError = entities.FactGatheringError{
+		Type:    "corosync-conf-value-not-found",
+		Message: "requested field value not found",
+	}
+)
+
 type CorosyncConfGatherer struct {
 	configFile string
 }
@@ -44,16 +62,27 @@ func (s *CorosyncConfGatherer) Gather(factsRequests []entities.FactRequest) ([]e
 
 	corosyncConfile, err := readCorosyncConfFileByLines(s.configFile)
 	if err != nil {
-		return facts, err
+		gatheringError := CorosyncConfFileError.Wrap(err.Error())
+		return entities.NewFactsGatheredListWithError(factsRequests, &gatheringError), gatheringError
 	}
 
 	corosycnMap, err := corosyncConfToMap(corosyncConfile)
 	if err != nil {
-		return facts, err
+		gatheringError := CorosyncConfDecodingError.Wrap(err.Error())
+		return entities.NewFactsGatheredListWithError(factsRequests, &gatheringError), gatheringError
 	}
 
 	for _, factReq := range factsRequests {
-		fact := entities.NewFactGatheredWithRequest(factReq, getValue(corosycnMap, strings.Split(factReq.Argument, ".")))
+		var fact entities.Fact
+
+		if value := getValue(corosycnMap, strings.Split(factReq.Argument, ".")); value != nil {
+			fact = entities.NewFactGatheredWithRequest(factReq, value)
+
+		} else {
+			gatheringError := CorosyncConfValueNotFoundError.Wrap(factReq.Argument)
+			log.Error(gatheringError)
+			fact = entities.NewFactGatheredWithError(factReq, &gatheringError)
+		}
 		facts = append(facts, fact)
 	}
 

--- a/internal/factsengine/gatherers/corosyncconf.go
+++ b/internal/factsengine/gatherers/corosyncconf.go
@@ -65,7 +65,7 @@ func (s *CorosyncConfGatherer) Gather(factsRequests []entities.FactRequest) ([]e
 		return nil, CorosyncConfFileError.Wrap(err.Error())
 	}
 
-	corosycnMap, err := corosyncConfToMap(corosyncConfile)
+	corosyncMap, err := corosyncConfToMap(corosyncConfile)
 	if err != nil {
 		return nil, CorosyncConfDecodingError.Wrap(err.Error())
 	}
@@ -73,7 +73,7 @@ func (s *CorosyncConfGatherer) Gather(factsRequests []entities.FactRequest) ([]e
 	for _, factReq := range factsRequests {
 		var fact entities.Fact
 
-		if value := getValue(corosycnMap, strings.Split(factReq.Argument, ".")); value != nil {
+		if value := getValue(corosyncMap, strings.Split(factReq.Argument, ".")); value != nil {
 			fact = entities.NewFactGatheredWithRequest(factReq, value)
 
 		} else {

--- a/internal/factsengine/gatherers/corosyncconf.go
+++ b/internal/factsengine/gatherers/corosyncconf.go
@@ -62,14 +62,12 @@ func (s *CorosyncConfGatherer) Gather(factsRequests []entities.FactRequest) ([]e
 
 	corosyncConfile, err := readCorosyncConfFileByLines(s.configFile)
 	if err != nil {
-		gatheringError := CorosyncConfFileError.Wrap(err.Error())
-		return entities.NewFactsGatheredListWithError(factsRequests, &gatheringError), gatheringError
+		return nil, CorosyncConfFileError.Wrap(err.Error())
 	}
 
 	corosycnMap, err := corosyncConfToMap(corosyncConfile)
 	if err != nil {
-		gatheringError := CorosyncConfDecodingError.Wrap(err.Error())
-		return entities.NewFactsGatheredListWithError(factsRequests, &gatheringError), gatheringError
+		return nil, CorosyncConfDecodingError.Wrap(err.Error())
 	}
 
 	for _, factReq := range factsRequests {
@@ -81,7 +79,7 @@ func (s *CorosyncConfGatherer) Gather(factsRequests []entities.FactRequest) ([]e
 		} else {
 			gatheringError := CorosyncConfValueNotFoundError.Wrap(factReq.Argument)
 			log.Error(gatheringError)
-			fact = entities.NewFactGatheredWithError(factReq, &gatheringError)
+			fact = entities.NewFactGatheredWithError(factReq, gatheringError)
 		}
 		facts = append(facts, fact)
 	}

--- a/internal/factsengine/gatherers/corosyncconf_test.go
+++ b/internal/factsengine/gatherers/corosyncconf_test.go
@@ -127,16 +127,9 @@ func (suite *CorosyncConfTestSuite) TestCorosyncConfFileNotExists() {
 			"open not_found: no such file or directory",
 		Type: "corosync-conf-file-error",
 	}
-	expectedResults := []entities.Fact{
-		{
-			Name:  "corosync_token",
-			Value: nil,
-			Error: expectedError,
-		},
-	}
 
 	suite.EqualError(err, expectedError.Error())
-	suite.ElementsMatch(expectedResults, factsGathered)
+	suite.Empty(factsGathered)
 }
 
 func (suite *CorosyncConfTestSuite) TestCorosyncConfInvalid() {
@@ -157,14 +150,7 @@ func (suite *CorosyncConfTestSuite) TestCorosyncConfInvalid() {
 			"some section is not closed properly",
 		Type: "corosync-conf-decoding-error",
 	}
-	expectedResults := []entities.Fact{
-		{
-			Name:  "corosync_token",
-			Value: nil,
-			Error: expectedError,
-		},
-	}
 
 	suite.EqualError(err, expectedError.Error())
-	suite.ElementsMatch(expectedResults, factsGathered)
+	suite.Empty(factsGathered)
 }

--- a/internal/factsengine/gathering_test.go
+++ b/internal/factsengine/gathering_test.go
@@ -1,7 +1,6 @@
 package factsengine
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -64,7 +63,7 @@ func NewErrorGatherer() *ErrorGatherer {
 }
 
 func (s *ErrorGatherer) Gather(_ []entities.FactRequest) ([]entities.Fact, error) {
-	return []entities.Fact{}, fmt.Errorf("kabum")
+	return nil, &entities.FactGatheringError{Type: "dummy-type", Message: "some error"}
 }
 
 func (suite *GatheringTestSuite) TestGatheringGatherFacts() {
@@ -183,6 +182,16 @@ func (suite *GatheringTestSuite) TestFactsEngineGatherFactsErrorGathering() {
 			Name:    "dummy1",
 			Value:   "1",
 			CheckID: "check1",
+			Error:   nil,
+		},
+		{
+			Name:    "error",
+			Value:   nil,
+			CheckID: "check1",
+			Error: &entities.FactGatheringError{
+				Type:    "dummy-type",
+				Message: "some error",
+			},
 		},
 	}
 

--- a/internal/factsengine/mapper_test.go
+++ b/internal/factsengine/mapper_test.go
@@ -97,7 +97,7 @@ func (suite *MapperTestSuite) TestFactsGatheredWithErrorToEvent() {
 				Name:    "dummy1",
 				Value:   nil,
 				CheckID: "check1",
-				Error: &entities.Error{
+				Error: &entities.FactGatheringError{
 					Message: "some message",
 					Type:    "some_type",
 				},


### PR DESCRIPTION
Add the `FactGatheringError` usage in the corosync.conf gatherer.

In case of an "abnormal" error doesn't allow to run properly the facts gathering (corosync file doesn't exist for example), a custom error is returned in the `error` parameter, and all the requests are filled with this error.