### PR TITLE
Detect Nutanix as underlying platform provider

### DIFF
--- a/internal/cloud/metadata.go
+++ b/internal/cloud/metadata.go
@@ -37,7 +37,7 @@ func NewIdentifier(executor utils.CommandExecutor) *Identifier {
 // https://github.com/ClusterLabs/crmsh/blob/master/crmsh/utils.py#L2009
 
 func (i *Identifier) identifyAzure() (bool, error) {
-	log.Debug("Checking if the VM is running on Azure...")
+	log.Debug("Checking if the system is running on Azure...")
 	output, err := i.executor.Exec("dmidecode", "-s", "chassis-asset-tag")
 	if err != nil {
 		return false, err
@@ -50,7 +50,7 @@ func (i *Identifier) identifyAzure() (bool, error) {
 }
 
 func (i *Identifier) identifyAWS() (bool, error) {
-	log.Debug("Checking if the VM is running on Aws...")
+	log.Debug("Checking if the system is running on Aws...")
 	systemVersion, err := i.executor.Exec("dmidecode", "-s", "system-version")
 	if err != nil {
 		return false, err
@@ -78,7 +78,7 @@ func (i *Identifier) identifyAWS() (bool, error) {
 }
 
 func (i *Identifier) identifyGCP() (bool, error) {
-	log.Debug("Checking if the VM is running on Gcp...")
+	log.Debug("Checking if the system is running on Gcp...")
 	output, err := i.executor.Exec("dmidecode", "-s", "bios-vendor")
 	if err != nil {
 		return false, err
@@ -91,7 +91,7 @@ func (i *Identifier) identifyGCP() (bool, error) {
 }
 
 func (i *Identifier) identifyNutanix() (bool, error) {
-	log.Debug("Checking if the VM is running on Nutanix...")
+	log.Debug("Checking if the system is running on Nutanix...")
 	output, err := i.executor.Exec("dmidecode")
 	if err != nil {
 		return false, err
@@ -104,37 +104,37 @@ func (i *Identifier) identifyNutanix() (bool, error) {
 }
 
 func (i *Identifier) IdentifyCloudProvider() (string, error) {
-	log.Info("Identifying if the VM is running in a cloud environment...")
+	log.Info("Identifying if the system is running in a cloud environment...")
 
 	if result, err := i.identifyAzure(); err != nil {
 		return "", err
 	} else if result {
-		log.Infof("VM is running on %s", Azure)
+		log.Infof("System is running on %s", Azure)
 		return Azure, nil
 	}
 
 	if result, err := i.identifyAWS(); err != nil {
 		return "", err
 	} else if result {
-		log.Infof("VM is running on %s", AWS)
+		log.Infof("System is running on %s", AWS)
 		return AWS, nil
 	}
 
 	if result, err := i.identifyGCP(); err != nil {
 		return "", err
 	} else if result {
-		log.Infof("VM is running on %s", GCP)
+		log.Infof("System is running on %s", GCP)
 		return GCP, nil
 	}
 
 	if result, err := i.identifyNutanix(); err != nil {
 		return "", err
 	} else if result {
-		log.Infof("VM is running on %s", Nutanix)
+		log.Infof("System is running on %s", Nutanix)
 		return Nutanix, nil
 	}
 
-	log.Info("VM is not running in any recognized cloud provider")
+	log.Info("The system is not running in any recognized cloud provider")
 	return "", nil
 }
 


### PR DESCRIPTION
This PR adds to the agent the capability to determine whether the OS is running on a Nutanix host.

As usual some specific content in the output of `demidecode` command is used determine these kind of information.
```bash
hana-g8-vm:~ # dmidecode | grep -i -E "nutanix|ahv"
	Version: nutanix-ahv-2.20220304.0.2429.el7
	Manufacturer: Nutanix
	Product Name: AHV 
```

In a nutshell
the `Instance` discovered during a `CloudDiscovery` can now have `nutanix` as value for the `Provider` property, and no `Metadata` would be available in this case.

Meh on the fact that we have this bare-metal thingy entangled with Cloud concepts, yet I find it wise to go like this, and track the debt. 
I am not sure we could do much better without scope creeping, and missing the point: supporting nutanix bare metal :metal: 