### PR TITLE
Add kvm discovery

### DIFF
--- a/internal/cloud/metadata_test.go
+++ b/internal/cloud/metadata_test.go
@@ -46,6 +46,14 @@ func dmidecodeNutanix() []byte {
 	`)
 }
 
+func systemdDetectVirtKVM() []byte {
+	return []byte("kvm")
+}
+
+func systemdDetectVirtEmpty() []byte {
+	return []byte("none")
+}
+
 func dmidecodeEmpty() []byte {
 	return []byte("")
 }
@@ -177,6 +185,41 @@ func (suite *CloudMetadataTestSuite) TestIdentifyProviderNutanix() {
 	suite.NoError(err)
 }
 
+func (suite *CloudMetadataTestSuite) TestIdentifyProviderKVM() {
+	mockCommand := new(utilsMocks.CommandExecutor)
+
+	mockCommand.On("Exec", "dmidecode", "-s", "chassis-asset-tag").Return(
+		dmidecodeEmpty(), nil,
+	)
+
+	mockCommand.On("Exec", "dmidecode", "-s", "system-version").Return(
+		dmidecodeEmpty(), nil,
+	)
+
+	mockCommand.On("Exec", "dmidecode", "-s", "system-manufacturer").Return(
+		dmidecodeEmpty(), nil,
+	)
+
+	mockCommand.On("Exec", "dmidecode", "-s", "bios-vendor").Return(
+		dmidecodeEmpty(), nil,
+	)
+
+	mockCommand.On("Exec", "dmidecode").Return(
+		dmidecodeEmpty(), nil,
+	)
+
+	mockCommand.On("Exec", "systemd-detect-virt").Return(
+		systemdDetectVirtKVM(), nil,
+	)
+
+	cIdentifier := NewIdentifier(mockCommand)
+
+	provider, err := cIdentifier.IdentifyCloudProvider()
+
+	suite.Equal("kvm", provider)
+	suite.NoError(err)
+}
+
 func (suite *CloudMetadataTestSuite) TestIdentifyCloudProviderNoCloud() {
 	mockCommand := new(utilsMocks.CommandExecutor)
 
@@ -198,6 +241,10 @@ func (suite *CloudMetadataTestSuite) TestIdentifyCloudProviderNoCloud() {
 
 	mockCommand.On("Exec", "dmidecode").Return(
 		dmidecodeEmpty(), nil,
+	)
+
+	mockCommand.On("Exec", "systemd-detect-virt").Return(
+		systemdDetectVirtEmpty(), nil,
 	)
 
 	cIdentifier := NewIdentifier(mockCommand)
@@ -314,6 +361,40 @@ func (suite *CloudMetadataTestSuite) TestNewInstanceNutanix() {
 	suite.Equal(interface{}(nil), c.Metadata)
 }
 
+func (suite *CloudMetadataTestSuite) TestNewInstanceKVM() {
+	mockCommand := new(utilsMocks.CommandExecutor)
+
+	mockCommand.On("Exec", "dmidecode", "-s", "chassis-asset-tag").Return(
+		dmidecodeEmpty(), nil,
+	)
+
+	mockCommand.On("Exec", "dmidecode", "-s", "system-version").Return(
+		dmidecodeEmpty(), nil,
+	)
+
+	mockCommand.On("Exec", "dmidecode", "-s", "system-manufacturer").Return(
+		dmidecodeEmpty(), nil,
+	)
+
+	mockCommand.On("Exec", "dmidecode", "-s", "bios-vendor").Return(
+		dmidecodeEmpty(), nil,
+	)
+
+	mockCommand.On("Exec", "dmidecode").Return(
+		dmidecodeEmpty(), nil,
+	)
+
+	mockCommand.On("Exec", "systemd-detect-virt").Return(
+		systemdDetectVirtKVM(), nil,
+	)
+
+	c, err := NewCloudInstance(mockCommand)
+
+	suite.NoError(err)
+	suite.Equal("kvm", c.Provider)
+	suite.Equal(interface{}(nil), c.Metadata)
+}
+
 func (suite *CloudMetadataTestSuite) TestNewCloudInstanceNoCloud() {
 	mockCommand := new(utilsMocks.CommandExecutor)
 
@@ -335,6 +416,10 @@ func (suite *CloudMetadataTestSuite) TestNewCloudInstanceNoCloud() {
 
 	mockCommand.On("Exec", "dmidecode").Return(
 		dmidecodeEmpty(), nil,
+	)
+
+	mockCommand.On("Exec", "systemd-detect-virt").Return(
+		systemdDetectVirtEmpty(), nil,
 	)
 
 	c, err := NewCloudInstance(mockCommand)


### PR DESCRIPTION
This PR allows the agent to detect KVM as underlying platform, in a similar way as PR #110 does for `Nutanix`.

Instead of using `dmidecode`, we use here `systemd-detect-virt`, which reports `kvm` when executed on a virtual machine running on a KVM hypervisor:
![Captura desde 2022-09-22 16-29-05](https://user-images.githubusercontent.com/2668401/191788900-8b8b530a-08ae-4eb7-8be4-e0376c5140bb.png)

`dmidecode` was not giving enough details, only demostrating that QEMU was in use in the host machine:
![Captura desde 2022-09-22 14-27-05](https://user-images.githubusercontent.com/2668401/191789107-5d4dccee-1af5-4f2a-abdd-89a977e9294b.png)

Notice that I've placed the `identifyKVM()` call after the `identifyNutanix()` call, as I suspect that `nutanix` is could also report `kvm` as it's hypervisor (AHV) is based on KVM. No way to confirm until we can test it.

This is a bit tricky though and is starting to show proof that we might want to restructure the code and separate the concepts of "Cloud Provider" and "virtualization provider" (the latter meaning "hypervisor"), as I could easily see `kvm` being detected in future providers we might include support for.
