### PR TITLE
Fix GHA obs jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,16 +195,17 @@ jobs:
     container:
       image: ghcr.io/stefanotorresi/continuous-delivery:fix-home-reference
       env:
-        GITHUB_OAUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         OSC_CHECKOUT_DIR: /tmp/trento-agent-package
-        HOME: /home/osc
       options: -u 0:0
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: configure OSC
-        run: /scripts/init_osc_creds.sh
+        run: |
+          mkdir -p $HOME/.config/osc
+          cp /home/osc/.config/osc/oscrc $HOME/.config/osc
+          /scripts/init_osc_creds.sh
       - name: prepare _service file
         run: |
           git config --global --add safe.directory /__w/agent/agent
@@ -245,15 +246,16 @@ jobs:
     if: github.event.release
     container:
       image: ghcr.io/stefanotorresi/continuous-delivery:fix-home-reference
-      env:
-        HOME: /home/osc
       options: -u 0:0
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: configure OSC
-        run: /scripts/init_osc_creds.sh
+        run: |
+          mkdir -p $HOME/.config/osc
+          cp /home/osc/.config/osc/oscrc $HOME/.config/osc
+          /scripts/init_osc_creds.sh
       - name: prepare _service file
         run: |
           git config --global --add safe.directory /__w/agent/agent

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,17 +227,17 @@ jobs:
           sed -i 's~%%REVISION%%~${{ github.sha }}~' $FOLDER/_service && \
           sed -i 's~%%REPOSITORY%%~${{ github.repository }}~' $FOLDER/_service && \
           sed -i 's~%%VERSION%%~'"${VERSION}"'~' $FOLDER/_service
-      - name: commit changes into OBS
+      - name: checkout OBS package and update vendor archive
         run: |
           osc checkout $OBS_PROJECT trento-agent -o /tmp/osc_project
           cp $FOLDER/_service /tmp/osc_project
           pushd /tmp/osc_project
           osc service manualrun
           pushd agent
-          go mod download && go mod vendor
+          go mod vendor
           tar cvzf ../vendor.tar.gz vendor
-          popd
-          /scripts/upload.sh
+      - name: commit changes into OBS
+        run: /scripts/upload.sh
 
   obs-submit:
     needs: obs-commit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,7 +199,7 @@ jobs:
       image: ghcr.io/stefanotorresi/continuous-delivery:fix-home-reference
       env:
         GITHUB_OAUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        OSC_CHECKOUT_DIR: $HOME/trento-agent-package
+        OSC_CHECKOUT_DIR: ${{ env.HOME }}/trento-agent-package
       options: -u 0:0
     steps:
       - uses: actions/checkout@v3
@@ -238,7 +238,7 @@ jobs:
         run: |
           pushd $OSC_CHECKOUT_DIR
           osc ar
-          osc commit -m "update from GitHub actions to reference ${{ github.sha }}"
+          osc commit -m "update via GitHub Actions to reference ${{ github.sha }}"
 
   obs-submit:
     needs: obs-commit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,7 +192,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
   obs-commit:
-    needs: [test-binary, test-plugins]
+    needs: [test-binary, test-integration, test-plugins]
     runs-on: ubuntu-20.04
     #if: github.ref == 'refs/heads/main' || github.event_name == 'release'
     container:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
     tags-ignore:
       - "*"
     branches:
-      - "*"
+      - "main"
   pull_request:
   release:
     types: [published]
@@ -194,7 +194,7 @@ jobs:
   obs-commit:
     needs: [test-binary, test-integration, test-plugins]
     runs-on: ubuntu-20.04
-    #if: github.ref == 'refs/heads/main' || github.event_name == 'release'
+    if: github.ref == 'refs/heads/main' || github.event_name == 'release'
     container:
       image: ghcr.io/stefanotorresi/continuous-delivery:fix-home-reference
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,17 +209,6 @@ jobs:
           mkdir -p $HOME/.config/osc
           cp /home/osc/.config/osc/oscrc $HOME/.config/osc
           /scripts/init_osc_creds.sh
-      - name: Prepare trento-agent.changes file
-        # The .changes file is updated only in release creation. This current task should be improved
-        # in order to add the current rolling release notes
-        if: github.event_name == 'release'
-        run: |
-          git config --global --add safe.directory /__w/agent/agent
-          osc checkout $OBS_PROJECT trento-agent trento-agent.changes
-          mv trento-agent.changes $FOLDER
-          VERSION=$(./hack/get_version_from_git.sh)
-          TAG=$(echo $VERSION | cut -f1 -d+)
-          hack/gh_release_to_obs_changeset.py $REPOSITORY -a shap-staff@suse.de -t $TAG -f $FOLDER/trento-agent.changes
       - name: prepare _service file
         run: |
           git config --global --add safe.directory /__w/agent/agent
@@ -229,15 +218,28 @@ jobs:
           sed -i 's~%%VERSION%%~'"${VERSION}"'~' $FOLDER/_service
       - name: checkout OBS package and update vendor archive
         run: |
-          osc checkout $OBS_PROJECT trento-agent -o /tmp/osc_project
+          osc checkout $OBS_PROJECT trento-agent -o /tmp/obs_project
           cp $FOLDER/_service /tmp/osc_project
           pushd /tmp/osc_project
           osc service manualrun
-          pushd agent
-          go mod vendor
-          tar cvzf ../vendor.tar.gz vendor
+          pushd agent && go mod vendor && popd
+          tar --sort=name --owner=root:0 --group=root:0 --mtime='UTC 1970-01-01' -C agent -c vendor | gzip -n > vendor.tar.gz
+      - name: prepare trento-agent.changes file
+        # The .changes file is updated only in release creation. This current task should be improved
+        # in order to add the current rolling release notes
+        if: github.event_name == 'release'
+        run: |
+          git config --global --add safe.directory /__w/agent/agent
+          cp /tmp/osc_project/trento-agent.changes $FOLDER
+          VERSION=$(./hack/get_version_from_git.sh)
+          TAG=$(echo $VERSION | cut -f1 -d+)
+          hack/gh_release_to_obs_changeset.py $REPOSITORY -a shap-staff@suse.de -t $TAG -f $FOLDER/trento-agent.changes
+          cp $FOLDER/trento-agent.changes /tmp/osc_project/trento-agent.changes
       - name: commit changes into OBS
-        run: /scripts/upload.sh
+        run: |
+          pushd /tmp/osc_project
+          osc ar
+          osc commit -m "update from GitHub actions to reference ${{ github.sha }}"
 
   obs-submit:
     needs: obs-commit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,15 +212,18 @@ jobs:
           sed -i 's~%%REVISION%%~${{ github.sha }}~' $FOLDER/_service && \
           sed -i 's~%%REPOSITORY%%~${{ github.repository }}~' $FOLDER/_service && \
           sed -i 's~%%VERSION%%~'"${VERSION}"'~' $FOLDER/_service
+      - name: create vendor dependencies archive
+        run: | 
+          go mod vendor
+          tar --sort=name --owner=root:0 --group=root:0 --mtime='UTC 1970-01-01' -c vendor | gzip -n > vendor.tar.gz
       - name: checkout OBS package and update vendor archive
         run: |
           osc checkout $OBS_PROJECT trento-agent -o $OSC_CHECKOUT_DIR
           cp $FOLDER/_service $OSC_CHECKOUT_DIR
-          pushd $OSC_CHECKOUT_DIR
-          rm -v trento-agent-*.tar.gz
+          rm -v $OSC_CHECKOUT_DIR/*.tar.gz
+          pushd $OSC_CHECKOUT_DIR 
           osc service manualrun
-          pushd agent && go mod vendor && popd
-          tar --sort=name --owner=root:0 --group=root:0 --mtime='UTC 1970-01-01' -C agent -c vendor | gzip -n > vendor.tar.gz
+          cp /__w/agent/agent/vendor.tar.gz .
       - name: prepare trento-agent.changes file
         # The .changes file is updated only in release creation. This current task should be improved
         # in order to add the current rolling release notes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,7 +193,7 @@ jobs:
     runs-on: ubuntu-20.04
     if: github.ref == 'refs/heads/main' || github.event_name == 'release'
     container:
-      image: ghcr.io/stefanotorresi/continuous-delivery:fix-home-reference
+      image: ghcr.io/trento-project/continuous-delivery:main
       env:
         OSC_CHECKOUT_DIR: /tmp/trento-agent-package
       options: -u 0:0
@@ -217,7 +217,7 @@ jobs:
         run: | 
           go mod vendor
           tar --sort=name --owner=root:0 --group=root:0 --mtime='UTC 1970-01-01' -c vendor | gzip -n > vendor.tar.gz
-      - name: checkout OBS package and update vendor archive
+      - name: checkout and prepare OBS package
         run: |
           osc checkout $OBS_PROJECT trento-agent -o $OSC_CHECKOUT_DIR
           cp $FOLDER/_service $OSC_CHECKOUT_DIR
@@ -245,7 +245,7 @@ jobs:
     runs-on: ubuntu-20.04
     if: github.event.release
     container:
-      image: ghcr.io/stefanotorresi/continuous-delivery:fix-home-reference
+      image: ghcr.io/trento-project/continuous-delivery:main
       options: -u 0:0
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,9 +46,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - run: git fetch --prune --tags
       - uses: actions/setup-go@v3
         with:
           go-version: 1.18
@@ -146,7 +143,7 @@ jobs:
       - name: compress
         run: |
           set -x
-          find ./build -maxdepth 1 -mindepth 1 -type d -exec sh -c 'tar -zcf build/trento-agent-$(basename {}).tgz -C {} trento-agent -C $(pwd) packaging/systemd/trento-agent.service' \;
+          find ./build -maxdepth 1 -mindepth 1 -type d -exec sh -c 'tar -zcf build/trento-agent-$(basename {}).tgz -C {} trento-agent -C $(pwd)/packaging/systemd trento-agent.service' \;
       - uses: actions/upload-artifact@v3
         with:
           name: trento-binaries

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Continuous Integration and Demo Deployment
+name: Continuous Integration and Release
 concurrency: ci-${{ github.ref }}
 on:
   push:
@@ -41,10 +41,14 @@ jobs:
           version: v1.48.0
           skip-cache: true
           args: "--timeout=3m"
+
   test-binary:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - run: git fetch --prune --tags
       - uses: actions/setup-go@v3
         with:
           go-version: 1.18
@@ -55,8 +59,6 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
-      - name: get git tags
-        run: git fetch --prune --unshallow --tags
       - name: install-mockery
         run: go install github.com/vektra/mockery/v2
       - name: test
@@ -202,12 +204,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: configure OSC
-        # OSC credentials must be configured beforehand as the HOME variables cannot be changed from /github/home
-        # that is used to run osc commands
-        run: |
-          /scripts/init_osc_creds.sh
-          mkdir -p $HOME/.config/osc
-          cp /root/.config/osc/oscrc $HOME/.config/osc
+        run: /scripts/init_osc_creds.sh
       - name: Prepare trento-agent.changes file
         # The .changes file is updated only in release creation. This current task should be improved
         # in order to add the current rolling release notes
@@ -229,7 +226,11 @@ jobs:
       - name: commit changes into OBS
         run: |
           git config --global --add safe.directory /__w/agent/agent
-          cp $FOLDER/_service . && /scripts/upload.sh
+          cp $FOLDER/_service .
+          osc service manualrun
+          go mod download && go mod vendor
+          tar cvzf vendor.tar.gz vendor
+          /scripts/upload.sh
 
   obs-submit:
     needs: obs-commit
@@ -242,10 +243,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: configure OSC
-        run: |
-          /scripts/init_osc_creds.sh
-          mkdir -p $HOME/.config/osc
-          cp /root/.config/osc/oscrc $HOME/.config/osc
+        run: /scripts/init_osc_creds.sh
       - name: prepare _service file
         run: |
           git config --global --add safe.directory /__w/agent/agent

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,12 +199,16 @@ jobs:
       image: ghcr.io/trento-project/continuous-delivery:master
       env:
         GITHUB_OAUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      options: -u 0:0
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: configure OSC
-        run: /scripts/init_osc_creds.sh
+        run: |
+          mkdir -p $HOME/.config/osc
+          cp /home/osc/.config/osc/oscrc $HOME/.config/osc
+          /scripts/init_osc_creds.sh
       - name: Prepare trento-agent.changes file
         # The .changes file is updated only in release creation. This current task should be improved
         # in order to add the current rolling release notes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,6 +214,8 @@ jobs:
           sed -i 's~%%REPOSITORY%%~${{ github.repository }}~' $FOLDER/_service && \
           sed -i 's~%%VERSION%%~'"${VERSION}"'~' $FOLDER/_service
       - name: create vendor dependencies archive
+        # note the following tar options to strip all the things that could make the archive different without the content actually changing
+        # to make it easier to identify when dependencies changed
         run: | 
           go mod vendor
           tar --sort=name --owner=root:0 --group=root:0 --mtime='UTC 1970-01-01' -c vendor | gzip -n > vendor.tar.gz

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
     tags-ignore:
       - "*"
     branches:
-      - "main"
+      - "*"
   pull_request:
   release:
     types: [published]
@@ -194,7 +194,7 @@ jobs:
   obs-commit:
     needs: [test-binary, test-plugins]
     runs-on: ubuntu-20.04
-    if: github.ref == 'refs/heads/main' || github.event_name == 'release'
+    #if: github.ref == 'refs/heads/main' || github.event_name == 'release'
     container:
       image: ghcr.io/trento-project/continuous-delivery:master
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ env:
   REPOSITORY: ${{ github.repository }}
 
 jobs:
-  lint-agent:
+  static-analysis:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
@@ -35,6 +35,10 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
+      - name: go vet check
+        run: make vet-check
+      - name: go fmt check
+        run: make fmt-check
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
@@ -42,7 +46,7 @@ jobs:
           skip-cache: true
           args: "--timeout=3m"
 
-  test-binary:
+  test:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
@@ -60,10 +64,6 @@ jobs:
         run: go install github.com/vektra/mockery/v2
       - name: test
         run: make test
-      - name: static analysis
-        run: make vet-check
-      - name: coding styles
-        run: make fmt-check
 
   test-integration:
     runs-on: ubuntu-20.04
@@ -123,7 +123,7 @@ jobs:
 
   build-static-binary:
     runs-on: ubuntu-20.04
-    needs: [test-binary, test-integration, test-plugins]
+    needs: [static-analysis, test, test-integration, test-plugins]
     steps:
       - uses: actions/checkout@v3
         with:
@@ -189,7 +189,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
   obs-commit:
-    needs: [test-binary, test-integration, test-plugins]
+    needs: [static-analysis, test, test-integration, test-plugins]
     runs-on: ubuntu-20.04
     if: github.ref == 'refs/heads/main' || github.event_name == 'release'
     container:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,7 +244,10 @@ jobs:
     runs-on: ubuntu-20.04
     if: github.event.release
     container:
-      image: ghcr.io/trento-project/continuous-delivery:master
+      image: ghcr.io/stefanotorresi/continuous-delivery:fix-home-reference
+      env:
+        HOME: /home/osc
+      options: -u 0:0
     steps:
       - uses: actions/checkout@v3
         with:
@@ -259,4 +262,4 @@ jobs:
           sed -i 's~%%REPOSITORY%%~${{ github.repository }}~' $FOLDER/_service && \
           sed -i 's~%%VERSION%%~'"${VERSION}"'~' $FOLDER/_service
       - name: submit package
-        run: cp $FOLDER/_service . && /scripts/submit.sh
+        run: /scripts/submit.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,11 +229,14 @@ jobs:
           sed -i 's~%%VERSION%%~'"${VERSION}"'~' $FOLDER/_service
       - name: commit changes into OBS
         run: |
-          git config --global --add safe.directory /__w/agent/agent
-          cp $FOLDER/_service .
+          osc checkout $OBS_PROJECT trento-agent -o /tmp/osc_project
+          cp $FOLDER/_service /tmp/osc_project
+          pushd /tmp/osc_project
           osc service manualrun
+          pushd agent
           go mod download && go mod vendor
-          tar cvzf vendor.tar.gz vendor
+          tar cvzf ../vendor.tar.gz vendor
+          popd
           /scripts/upload.sh
 
   obs-submit:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,16 +197,14 @@ jobs:
       env:
         GITHUB_OAUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         OSC_CHECKOUT_DIR: /tmp/trento-agent-package
+        HOME: /home/osc
       options: -u 0:0
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: configure OSC
-        run: |
-          mkdir -p $HOME/.config/osc
-          cp /home/osc/.config/osc/oscrc $HOME/.config/osc
-          /scripts/init_osc_creds.sh
+        run: /scripts/init_osc_creds.sh
       - name: prepare _service file
         run: |
           git config --global --add safe.directory /__w/agent/agent

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,7 +196,7 @@ jobs:
     runs-on: ubuntu-20.04
     #if: github.ref == 'refs/heads/main' || github.event_name == 'release'
     container:
-      image: ghcr.io/trento-project/continuous-delivery:master
+      image: ghcr.io/stefanotorresi/continuous-delivery:fix-home-reference
       env:
         GITHUB_OAUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       options: -u 0:0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,7 +199,7 @@ jobs:
       image: ghcr.io/stefanotorresi/continuous-delivery:fix-home-reference
       env:
         GITHUB_OAUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        OSC_CHECKOUT_DIR: ${{ env.HOME }}/trento-agent-package
+        OSC_CHECKOUT_DIR: /tmp/trento-agent-package
       options: -u 0:0
     steps:
       - uses: actions/checkout@v3
@@ -222,6 +222,7 @@ jobs:
           osc checkout $OBS_PROJECT trento-agent -o $OSC_CHECKOUT_DIR
           cp $FOLDER/_service $OSC_CHECKOUT_DIR
           pushd $OSC_CHECKOUT_DIR
+          rm -v trento-agent-*.tar.gz
           osc service manualrun
           pushd agent && go mod vendor && popd
           tar --sort=name --owner=root:0 --group=root:0 --mtime='UTC 1970-01-01' -C agent -c vendor | gzip -n > vendor.tar.gz
@@ -238,7 +239,7 @@ jobs:
         run: |
           pushd $OSC_CHECKOUT_DIR
           osc ar
-          osc commit -m "update via GitHub Actions to reference ${{ github.sha }}"
+          osc commit -m "GitHub Actions automated update to reference ${{ github.sha }}"
 
   obs-submit:
     needs: obs-commit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,6 +199,7 @@ jobs:
       image: ghcr.io/stefanotorresi/continuous-delivery:fix-home-reference
       env:
         GITHUB_OAUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        OSC_CHECKOUT_DIR: $HOME/trento-agent-package
       options: -u 0:0
     steps:
       - uses: actions/checkout@v3
@@ -218,9 +219,9 @@ jobs:
           sed -i 's~%%VERSION%%~'"${VERSION}"'~' $FOLDER/_service
       - name: checkout OBS package and update vendor archive
         run: |
-          osc checkout $OBS_PROJECT trento-agent -o /tmp/obs_project
-          cp $FOLDER/_service /tmp/osc_project
-          pushd /tmp/osc_project
+          osc checkout $OBS_PROJECT trento-agent -o $OSC_CHECKOUT_DIR
+          cp $FOLDER/_service $OSC_CHECKOUT_DIR
+          pushd $OSC_CHECKOUT_DIR
           osc service manualrun
           pushd agent && go mod vendor && popd
           tar --sort=name --owner=root:0 --group=root:0 --mtime='UTC 1970-01-01' -C agent -c vendor | gzip -n > vendor.tar.gz
@@ -230,14 +231,12 @@ jobs:
         if: github.event_name == 'release'
         run: |
           git config --global --add safe.directory /__w/agent/agent
-          cp /tmp/osc_project/trento-agent.changes $FOLDER
           VERSION=$(./hack/get_version_from_git.sh)
           TAG=$(echo $VERSION | cut -f1 -d+)
-          hack/gh_release_to_obs_changeset.py $REPOSITORY -a shap-staff@suse.de -t $TAG -f $FOLDER/trento-agent.changes
-          cp $FOLDER/trento-agent.changes /tmp/osc_project/trento-agent.changes
+          hack/gh_release_to_obs_changeset.py $REPOSITORY -a shap-staff@suse.de -t $TAG -f $OSC_CHECKOUT_DIR/trento-agent.changes
       - name: commit changes into OBS
         run: |
-          pushd /tmp/osc_project
+          pushd $OSC_CHECKOUT_DIR
           osc ar
           osc commit -m "update from GitHub actions to reference ${{ github.sha }}"
 

--- a/packaging/suse/_service
+++ b/packaging/suse/_service
@@ -1,5 +1,5 @@
 <services>
-    <service name="tar_scm" mode="disabled">
+    <service name="tar_scm" mode="manual">
         <param name="url">https://github.com/%%REPOSITORY%%.git</param>
         <param name="scm">git</param>
         <param name="revision">%%REVISION%%</param>
@@ -8,12 +8,11 @@
         <param name="versionformat">%%VERSION%%</param>
         <param name="filename">trento-agent</param>
     </service>
-    <service name="set_version" mode="disabled">
+    <service name="set_version" mode="manual">
         <param name="file">trento-agent.spec</param>
     </service>
-    <service name="recompress" mode="disabled">
+    <service name="recompress" mode="manual">
         <param name="file">*.tar</param>
         <param name="compression">gz</param>
     </service>
-    <service name="go_modules" mode="disabled" />
 </services>


### PR DESCRIPTION
This PR changes the GHA setup so that it works with the latest changes in trento-project/continuous-delivery#13.

It also removes the need to use `obs-service-go_modules` with the RPM packaging (because upstream breaks it too frequently), and groups together all the static analysis jobs.

Same PR (more or less) will follow up on all the other repos with OBS CI jobs.