### PR TITLE
Use go-envparse in sbd gatherer

### DIFF
--- a/internal/factsengine/gatherers/_todo/sbd_test.go
+++ b/internal/factsengine/gatherers/_todo/sbd_test.go
@@ -49,7 +49,7 @@ func (suite *SBDGathererTestSuite) TestSomeRequiredValueDoesNotExistInConfig() {
 
 	gatheredFacts, err := gatherer.Gather(requestedFacts)
 
-	expectedFacts := []entities.FactsGatheredItem{
+	expectedFacts := []entities.Fact{
 		{
 			Name:  "sbd_pacemaker",
 			Value: "yes",
@@ -87,7 +87,7 @@ func (suite *SBDGathererTestSuite) TestSBDGatherer() {
 
 	gatheredFacts, _ := gatherer.Gather(requestedFacts)
 
-	expectedFacts := []entities.FactsGatheredItem{
+	expectedFacts := []entities.Fact{
 		{
 			Name:  "sbd_pacemaker",
 			Value: "yes",


### PR DESCRIPTION
Follows up https://github.com/trento-project/agent/pull/122 by using [go-envparse](https://github.com/hashicorp/go-envparse) to parse sbd configuration.

Note: I couldn't really run tests locally :sweat_smile: some issues with the temporary `_todo` packaging.
I temporarily moved the files among the _real_ gatherers and tested that way (passed), then moved back in `_todo`

Low prio, we'll get back to gatherers at a certain point :smile: 