### PR TITLE
Match workflow name correctly for dependabot

### DIFF
--- a/.github/workflows/dependabot_auto_merge.yml
+++ b/.github/workflows/dependabot_auto_merge.yml
@@ -5,7 +5,7 @@ on:
     types:
       - completed
     workflows:
-      - Continuous Integration and Demo Deployment
+      - Continuous Integration and Release
 
 jobs:
   auto-merge:


### PR DESCRIPTION
Fix `dependabot_auto_merge` to match the correct workflow name