### PR TITLE
Add FactValue type

### DIFF
--- a/internal/factsengine/entities/fact_value.go
+++ b/internal/factsengine/entities/fact_value.go
@@ -1,0 +1,99 @@
+package entities
+
+import "strconv"
+
+// `FactValue` represents a dynamically typed value which can be either
+// an int, a float, a string, a boolean, a recursive map[string] value, or a
+// list of values.
+// A producer of FactValue is expected to set one of that variants.
+type FactValue interface {
+	isFactValue()
+	AsInterface() interface{}
+}
+
+type FactValueInt struct {
+	Value int
+}
+
+func (v *FactValueInt) isFactValue() {}
+
+// AsInterface converts a FactValueInt internal value to an interface{}.
+func (v *FactValueInt) AsInterface() interface{} {
+	return v.Value
+}
+
+type FactValueFloat struct {
+	Value float64
+}
+
+func (v *FactValueFloat) isFactValue() {}
+
+// AsInterface converts a FactValueFloat internal value to an interface{}.
+func (v *FactValueFloat) AsInterface() interface{} {
+	return v.Value
+}
+
+type FactValueBool struct {
+	Value bool
+}
+
+func (v *FactValueBool) isFactValue() {}
+
+// AsInterface converts a FactValueBool internal value to an interface{}.
+func (v *FactValueBool) AsInterface() interface{} {
+	return v.Value
+}
+
+type FactValueString struct {
+	Value string
+}
+
+func (v *FactValueString) isFactValue() {}
+
+// AsInterface converts a FactValueString internal value to an interface{}.
+func (v *FactValueString) AsInterface() interface{} {
+	return v.Value
+}
+
+type FactValueMap struct {
+	Value map[string]FactValue
+}
+
+func (v *FactValueMap) isFactValue() {}
+
+// AsInterface converts a FactValueMap internal value to an interface{}.
+func (v *FactValueMap) AsInterface() interface{} {
+	result := make(map[string]interface{})
+	for key, value := range v.Value {
+		result[key] = value.AsInterface()
+	}
+	return result
+}
+
+type FactValueList struct {
+	Value []FactValue
+}
+
+func (v *FactValueList) isFactValue() {}
+
+// AsInterface converts a FactValueList internal value to an interface{}.
+func (v *FactValueList) AsInterface() interface{} {
+	result := []interface{}{}
+	for _, item := range v.Value {
+		result = append(result, item.AsInterface())
+	}
+	return result
+}
+
+// ParseStringToFactValue parses a string to a FactValue type.
+func ParseStringToFactValue(str string) FactValue {
+	if i, err := strconv.Atoi(str); err == nil {
+		return &FactValueInt{Value: i}
+	} else if b, err := strconv.ParseBool(str); err == nil {
+		return &FactValueBool{Value: b}
+	} else if f, err := strconv.ParseFloat(str, 64); err == nil {
+		return &FactValueFloat{Value: f}
+	}
+
+	return &FactValueString{Value: str}
+}

--- a/internal/factsengine/entities/fact_value.go
+++ b/internal/factsengine/entities/fact_value.go
@@ -1,18 +1,8 @@
 package entities
 
 import (
-	"encoding/gob"
 	"strconv"
 )
-
-func init() {
-	gob.Register(&FactValueInt{})
-	gob.Register(&FactValueFloat{})
-	gob.Register(&FactValueString{})
-	gob.Register(&FactValueBool{})
-	gob.Register(&FactValueList{})
-	gob.Register(&FactValueMap{})
-}
 
 // `FactValue` represents a dynamically typed value which can be either
 // an int, a float, a string, a boolean, a recursive map[string] value, or a

--- a/internal/factsengine/entities/fact_value.go
+++ b/internal/factsengine/entities/fact_value.go
@@ -1,6 +1,18 @@
 package entities
 
-import "strconv"
+import (
+	"encoding/gob"
+	"strconv"
+)
+
+func init() {
+	gob.Register(&FactValueInt{})
+	gob.Register(&FactValueFloat{})
+	gob.Register(&FactValueString{})
+	gob.Register(&FactValueBool{})
+	gob.Register(&FactValueList{})
+	gob.Register(&FactValueMap{})
+}
 
 // `FactValue` represents a dynamically typed value which can be either
 // an int, a float, a string, a boolean, a recursive map[string] value, or a

--- a/internal/factsengine/entities/fact_value_test.go
+++ b/internal/factsengine/entities/fact_value_test.go
@@ -1,0 +1,92 @@
+package entities
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFactValueAsInterface(t *testing.T) {
+	cases := []struct {
+		description string
+		factValue   FactValue
+		expected    interface{}
+	}{
+		{
+			description: "FactValueInt AsInterface",
+			factValue:   &FactValueInt{Value: 1},
+			expected:    1,
+		},
+		{
+			description: "FactValueFloat AsInterface",
+			factValue:   &FactValueFloat{Value: 1.1},
+			expected:    1.1,
+		},
+		{
+			description: "FactValueString AsInterface",
+			factValue:   &FactValueString{Value: "test"},
+			expected:    "test",
+		},
+		{
+			description: "FactValueBool AsInterface",
+			factValue:   &FactValueBool{Value: true},
+			expected:    true,
+		},
+		{
+			description: "FactValueMap AsInterface",
+			factValue:   &FactValueMap{Value: map[string]FactValue{"test": &FactValueString{Value: "test"}}},
+			expected:    map[string]interface{}{"test": "test"},
+		},
+		{
+			description: "FactValueList AsInterface",
+			factValue:   &FactValueList{Value: []FactValue{&FactValueString{Value: "test"}}},
+			expected:    []interface{}{"test"},
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.description, func(t *testing.T) {
+			i := tt.factValue.AsInterface()
+
+			assert.Equal(t, i, tt.expected)
+		})
+	}
+}
+
+func TestParseStringToFactValue(t *testing.T) {
+	cases := []struct {
+		description string
+		str         string
+		expected    FactValue
+	}{
+		{
+			description: "Should parse a string to FactValueInt",
+			str:         "1",
+			expected:    &FactValueInt{Value: 1},
+		},
+		{
+			description: "Should parse a string to  FactValueFloat",
+			str:         "1.1",
+			expected:    &FactValueFloat{Value: 1.1},
+		},
+
+		{
+			description: "Should parse a string to FactValueBool",
+			str:         "true",
+			expected:    &FactValueBool{Value: true},
+		},
+		{
+			description: "Should parse a string to FactValueString",
+			str:         "test",
+			expected:    &FactValueString{Value: "test"},
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.description, func(t *testing.T) {
+			factValue := ParseStringToFactValue(tt.str)
+
+			assert.Equal(t, factValue, tt.expected)
+		})
+	}
+}

--- a/internal/factsengine/entities/facts_gathered.go
+++ b/internal/factsengine/entities/facts_gathered.go
@@ -14,7 +14,7 @@ type FactGatheringError struct {
 type Fact struct {
 	Name    string
 	CheckID string
-	Value   interface{}
+	Value   FactValue
 	Error   *FactGatheringError
 }
 
@@ -36,7 +36,7 @@ func (e *FactGatheringError) Wrap(msg string) *FactGatheringError {
 	}
 }
 
-func NewFactGatheredWithRequest(factReq FactRequest, value interface{}) Fact {
+func NewFactGatheredWithRequest(factReq FactRequest, value FactValue) Fact {
 	return Fact{
 		Name:    factReq.Name,
 		CheckID: factReq.CheckID,

--- a/internal/factsengine/factsengine_integration_test.go
+++ b/internal/factsengine/factsengine_integration_test.go
@@ -2,7 +2,6 @@ package factsengine
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"testing"
 
@@ -70,7 +69,7 @@ func (s *FactsEngineIntegrationTestGatherer) Gather(requests []entities.FactRequ
 	for i, req := range requests {
 		fact := entities.Fact{
 			Name:    req.Name,
-			Value:   fmt.Sprint(i),
+			Value:   &entities.FactValueInt{Value: i},
 			CheckID: req.CheckID,
 			Error:   nil,
 		}

--- a/internal/factsengine/gatherers/corosyncconf_test.go
+++ b/internal/factsengine/gatherers/corosyncconf_test.go
@@ -62,38 +62,38 @@ func (suite *CorosyncConfTestSuite) TestCorosyncConfBasic() {
 	expectedResults := []entities.Fact{
 		{
 			Name:  "corosync_token",
-			Value: "30000",
+			Value: &entities.FactValueInt{Value: 30000},
 			Error: nil,
 		},
 		{
 			Name:  "corosync_join",
-			Value: "60",
+			Value: &entities.FactValueInt{Value: 60},
 			Error: nil,
 		},
 		{
 			Name:  "corosync_node1id",
-			Value: "1",
+			Value: &entities.FactValueInt{Value: 1},
 			Error: nil,
 		},
 		{
 			Name:  "corosync_node2id",
-			Value: "2",
+			Value: &entities.FactValueInt{Value: 2},
 			Error: nil,
 		},
 		{
 			Name: "corosync_nodes",
-			Value: []interface{}{
-				map[string]interface{}{
-					"ring0_addr": "10.0.0.119",
-					"ring1_addr": "10.0.0.120",
-					"nodeid":     "1",
-				},
-				map[string]interface{}{
-					"ring0_addr": "10.0.1.153",
-					"ring1_addr": "10.0.1.154",
-					"nodeid":     "2",
-				},
-			},
+			Value: &entities.FactValueList{Value: []entities.FactValue{
+				&entities.FactValueMap{Value: map[string]entities.FactValue{
+					"ring0_addr": &entities.FactValueString{Value: "10.0.0.119"},
+					"ring1_addr": &entities.FactValueString{Value: "10.0.0.120"},
+					"nodeid":     &entities.FactValueInt{Value: 1},
+				}},
+				&entities.FactValueMap{Value: map[string]entities.FactValue{
+					"ring0_addr": &entities.FactValueString{Value: "10.0.1.153"},
+					"ring1_addr": &entities.FactValueString{Value: "10.0.1.154"},
+					"nodeid":     &entities.FactValueInt{Value: 2},
+				}},
+			}},
 			Error: nil,
 		},
 		{

--- a/internal/factsengine/gathering_test.go
+++ b/internal/factsengine/gathering_test.go
@@ -52,7 +52,7 @@ func (suite *GatheringTestSuite) TestGatheringGatherFacts() {
 		Return([]entities.Fact{
 			{
 				Name:    "dummy1",
-				Value:   "1",
+				Value:   &entities.FactValueInt{Value: 1},
 				CheckID: "check1",
 			},
 		}, nil).Times(1)
@@ -62,7 +62,7 @@ func (suite *GatheringTestSuite) TestGatheringGatherFacts() {
 		Return([]entities.Fact{
 			{
 				Name:    "dummy2",
-				Value:   "2",
+				Value:   &entities.FactValueInt{Value: 2},
 				CheckID: "check1",
 			},
 		}, nil).Times(1)
@@ -77,12 +77,12 @@ func (suite *GatheringTestSuite) TestGatheringGatherFacts() {
 	expectedFacts := []entities.Fact{
 		{
 			Name:    "dummy1",
-			Value:   "1",
+			Value:   &entities.FactValueInt{Value: 1},
 			CheckID: "check1",
 		},
 		{
 			Name:    "dummy2",
-			Value:   "2",
+			Value:   &entities.FactValueInt{Value: 2},
 			CheckID: "check1",
 		},
 	}
@@ -118,7 +118,7 @@ func (suite *GatheringTestSuite) TestFactsEngineGatherFactsGathererNotFound() {
 		Return([]entities.Fact{
 			{
 				Name:    "dummy1",
-				Value:   "1",
+				Value:   &entities.FactValueInt{Value: 1},
 				CheckID: "check1",
 			},
 		}, nil).Times(1)
@@ -128,7 +128,7 @@ func (suite *GatheringTestSuite) TestFactsEngineGatherFactsGathererNotFound() {
 		Return([]entities.Fact{
 			{
 				Name:    "dummy2",
-				Value:   "2",
+				Value:   &entities.FactValueInt{Value: 1},
 				CheckID: "check1",
 			},
 		}, nil).Times(1)
@@ -143,7 +143,7 @@ func (suite *GatheringTestSuite) TestFactsEngineGatherFactsGathererNotFound() {
 	expectedFacts := []entities.Fact{
 		{
 			Name:    "dummy1",
-			Value:   "1",
+			Value:   &entities.FactValueInt{Value: 1},
 			CheckID: "check1",
 		},
 	}
@@ -179,7 +179,7 @@ func (suite *GatheringTestSuite) TestFactsEngineGatherFactsErrorGathering() {
 		Return([]entities.Fact{
 			{
 				Name:    "dummy1",
-				Value:   "1",
+				Value:   &entities.FactValueInt{Value: 1},
 				CheckID: "check1",
 			},
 		}, nil).Times(1)
@@ -198,7 +198,7 @@ func (suite *GatheringTestSuite) TestFactsEngineGatherFactsErrorGathering() {
 	expectedFacts := []entities.Fact{
 		{
 			Name:    "dummy1",
-			Value:   "1",
+			Value:   &entities.FactValueInt{Value: 1},
 			CheckID: "check1",
 			Error:   nil,
 		},

--- a/internal/factsengine/mapper_test.go
+++ b/internal/factsengine/mapper_test.go
@@ -37,17 +37,41 @@ func (suite *MapperTestSuite) TestFactsGatheredToEvent() {
 		FactsGathered: []entities.Fact{
 			{
 				Name:    "dummy1",
-				Value:   "1",
+				Value:   &entities.FactValueString{Value: "result"},
 				CheckID: "check1",
 			},
 			{
 				Name:    "dummy2",
-				Value:   "result",
+				Value:   &entities.FactValueInt{Value: 2},
 				CheckID: "check1",
 			},
 			{
 				Name:    "dummy3",
-				Value:   2,
+				Value:   &entities.FactValueFloat{Value: 2.0},
+				CheckID: "check1",
+			},
+			{
+				Name:    "dummy4",
+				Value:   &entities.FactValueBool{Value: true},
+				CheckID: "check1",
+			},
+			{
+				Name: "dummy5",
+				Value: &entities.FactValueList{
+					Value: []entities.FactValue{
+						&entities.FactValueString{Value: "a"},
+						&entities.FactValueString{Value: "b"},
+					},
+				},
+				CheckID: "check1",
+			},
+			{
+				Name: "dummy5",
+				Value: &entities.FactValueMap{
+					Value: map[string]entities.FactValue{
+						"a": &entities.FactValueString{Value: "c"},
+					},
+				},
 				CheckID: "check1",
 			},
 		},
@@ -69,8 +93,8 @@ func (suite *MapperTestSuite) TestFactsGatheredToEvent() {
 				Name: "dummy1",
 				FactValue: &events.Fact_Value{
 					Value: &structpb.Value{
-						Kind: &structpb.Value_NumberValue{
-							NumberValue: float64(1),
+						Kind: &structpb.Value_StringValue{
+							StringValue: "result",
 						},
 					},
 				},
@@ -80,8 +104,8 @@ func (suite *MapperTestSuite) TestFactsGatheredToEvent() {
 				Name: "dummy2",
 				FactValue: &events.Fact_Value{
 					Value: &structpb.Value{
-						Kind: &structpb.Value_StringValue{
-							StringValue: "result",
+						Kind: &structpb.Value_NumberValue{
+							NumberValue: float64(2),
 						},
 					},
 				},
@@ -92,7 +116,59 @@ func (suite *MapperTestSuite) TestFactsGatheredToEvent() {
 				FactValue: &events.Fact_Value{
 					Value: &structpb.Value{
 						Kind: &structpb.Value_NumberValue{
-							NumberValue: float64(2),
+							NumberValue: 2.0,
+						},
+					},
+				},
+				CheckId: "check1",
+			},
+			{
+				Name: "dummy4",
+				FactValue: &events.Fact_Value{
+					Value: &structpb.Value{
+						Kind: &structpb.Value_BoolValue{
+							BoolValue: true,
+						},
+					},
+				},
+				CheckId: "check1",
+			},
+			{
+				Name: "dummy5",
+				FactValue: &events.Fact_Value{
+					Value: &structpb.Value{
+						Kind: &structpb.Value_ListValue{
+							ListValue: &structpb.ListValue{
+								Values: []*structpb.Value{
+									{
+										Kind: &structpb.Value_StringValue{
+											StringValue: "a",
+										},
+									},
+									{
+										Kind: &structpb.Value_StringValue{
+											StringValue: "b",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				CheckId: "check1",
+			},
+			{
+				Name: "dummy5",
+				FactValue: &events.Fact_Value{
+					Value: &structpb.Value{
+						Kind: &structpb.Value_StructValue{
+							StructValue: &structpb.Struct{
+								Fields: map[string]*structpb.Value{
+									"a": {
+										Kind: &structpb.Value_StringValue{StringValue: "c"},
+									},
+								},
+							},
 						},
 					},
 				},
@@ -123,7 +199,7 @@ func (suite *MapperTestSuite) TestFactsGatheredWithErrorToEvent() {
 			},
 			{
 				Name:    "dummy2",
-				Value:   "result",
+				Value:   &entities.FactValueString{Value: "result"},
 				CheckID: "check1",
 			},
 		},

--- a/internal/factsengine/plugininterface/interface.go
+++ b/internal/factsengine/plugininterface/interface.go
@@ -1,11 +1,23 @@
 package plugininterface
 
 import (
+	"encoding/gob"
 	"net/rpc"
 
 	"github.com/hashicorp/go-plugin"
 	"github.com/trento-project/agent/internal/factsengine/entities"
 )
+
+// TODO: move this to a common place in the pkg folder
+// This is needed by the plugin system to be able to serialize the FactValue type
+func init() {
+	gob.Register(&entities.FactValueInt{})
+	gob.Register(&entities.FactValueFloat{})
+	gob.Register(&entities.FactValueString{})
+	gob.Register(&entities.FactValueBool{})
+	gob.Register(&entities.FactValueList{})
+	gob.Register(&entities.FactValueMap{})
+}
 
 // Gatherer is the interface exposed as a plugin.
 type Gatherer interface {

--- a/internal/factsengine/policy_test.go
+++ b/internal/factsengine/policy_test.go
@@ -162,12 +162,12 @@ func (suite *PolicyTestSuite) TestPolicyPublishFacts() {
 		FactsGathered: []entities.Fact{
 			{
 				Name:    "dummy1",
-				Value:   "result1",
+				Value:   &entities.FactValueString{Value: "result1"},
 				CheckID: "check1",
 			},
 			{
 				Name:    "dummy2",
-				Value:   "result2",
+				Value:   &entities.FactValueString{Value: "result2"},
 				CheckID: "check1",
 			},
 		},

--- a/plugin_examples/dummy.go
+++ b/plugin_examples/dummy.go
@@ -21,7 +21,7 @@ func (s dummyGatherer) Gather(factsRequests []entities.FactRequest) ([]entities.
 
 	for _, factReq := range factsRequests {
 		value := rand.Int() // nolint
-		fact := entities.NewFactGatheredWithRequest(factReq, fmt.Sprint(value))
+		fact := entities.NewFactGatheredWithRequest(factReq, &entities.FactValueString{Value: fmt.Sprint(value)})
 		facts = append(facts, fact)
 	}
 


### PR DESCRIPTION
Adds `FactValue` variant type and the possibility to return lists or maps from the gatherer.
Using variant types with sealed interfaces is not the most idiomatic thing in golang, but the `structpb` package from google uses the same trick to define the google protobuf value, and it saves us some runtime errors if the users returns types that we do not handle as `interface{}`.
The conversion to a protobuf message is straight forward by just using the `AsInterface()` method.

Existings gatehrers and plugins are refactored to comply with the new return type.

Also, I've added float and bool type and an utility function to parse a string to a number or a bool.
