### PR TITLE
Port systemd gatherer

### DIFF
--- a/internal/factsengine/gatherers/corosyncconf.go
+++ b/internal/factsengine/gatherers/corosyncconf.go
@@ -14,8 +14,8 @@ import (
 )
 
 const (
-	CorosyncFactKey  = "corosync.conf"
-	CorosyncConfPath = "/etc/corosync/corosync.conf"
+	CorosyncConfGathererName = "corosync.conf"
+	CorosyncConfPath         = "/etc/corosync/corosync.conf"
 )
 
 var (

--- a/internal/factsengine/gatherers/gatherer.go
+++ b/internal/factsengine/gatherers/gatherer.go
@@ -10,7 +10,8 @@ type FactGatherer interface {
 
 func StandardGatherers() map[string]FactGatherer {
 	return map[string]FactGatherer{
-		CorosyncFactKey:  NewDefaultCorosyncConfGatherer(),
-		HostsFileFactKey: NewDefaultHostsFileGatherer(),
+		CorosyncConfGathererName: NewDefaultCorosyncConfGatherer(),
+		HostsFileGathererName:    NewDefaultHostsFileGatherer(),
+		SystemDGathererName:      NewDefaultSystemDGatherer(),
 	}
 }

--- a/internal/factsengine/gatherers/hostsfile.go
+++ b/internal/factsengine/gatherers/hostsfile.go
@@ -12,11 +12,11 @@ import (
 )
 
 const (
-	HostsFileFactKey    = "hosts"
-	HostsFilePath       = "/etc/hosts"
-	ipMatchGroup        = "ip"
-	hostnamesMatchGroup = "hostnames"
-	parsingRegexp       = `(?m)(?P<` + ipMatchGroup + `>\S+)\s+(?P<` + hostnamesMatchGroup + `>.+)`
+	HostsFileGathererName = "hosts"
+	HostsFilePath         = "/etc/hosts"
+	ipMatchGroup          = "ip"
+	hostnamesMatchGroup   = "hostnames"
+	parsingRegexp         = `(?m)(?P<` + ipMatchGroup + `>\S+)\s+(?P<` + hostnamesMatchGroup + `>.+)`
 )
 
 var (

--- a/internal/factsengine/gatherers/registry_test.go
+++ b/internal/factsengine/gatherers/registry_test.go
@@ -19,10 +19,10 @@ func TestRegistryTest(t *testing.T) {
 
 func (suite *RegistryTest) RegistryTestGetGatherer() {
 	registry := gatherers.NewRegistry(map[string]gatherers.FactGatherer{
-		gatherers.CorosyncFactKey: gatherers.NewDefaultCorosyncConfGatherer(),
+		gatherers.CorosyncConfGathererName: gatherers.NewDefaultCorosyncConfGatherer(),
 	})
 
-	r, err := registry.GetGatherer(gatherers.CorosyncFactKey)
+	r, err := registry.GetGatherer(gatherers.CorosyncConfGathererName)
 	expectedGatherer := gatherers.NewDefaultCorosyncConfGatherer()
 
 	suite.NoError(err)
@@ -31,14 +31,14 @@ func (suite *RegistryTest) RegistryTestGetGatherer() {
 
 func (suite *RegistryTest) RegistryTestAddGatherers() {
 	registry := gatherers.NewRegistry(map[string]gatherers.FactGatherer{
-		gatherers.CorosyncFactKey: gatherers.NewDefaultCorosyncConfGatherer(),
+		gatherers.CorosyncConfGathererName: gatherers.NewDefaultCorosyncConfGatherer(),
 	})
 
 	registry.AddGatherers(map[string]gatherers.FactGatherer{
 		"test": &mocks.FactGatherer{},
 	})
 
-	expectedGatherers := []string{gatherers.CorosyncFactKey, "test"}
+	expectedGatherers := []string{gatherers.CorosyncConfGathererName, "test"}
 
 	// we sort the array in order to have consistency in the tests
 	// map keys are not ordered ofc
@@ -51,7 +51,7 @@ func (suite *RegistryTest) RegistryTestAddGatherers() {
 
 func (suite *RegistryTest) TestFactsEngineGetGathererNotFound() {
 	registry := gatherers.NewRegistry(map[string]gatherers.FactGatherer{
-		gatherers.CorosyncFactKey: gatherers.NewDefaultCorosyncConfGatherer(),
+		gatherers.CorosyncConfGathererName: gatherers.NewDefaultCorosyncConfGatherer(),
 	})
 	_, err := registry.GetGatherer("other")
 


### PR DESCRIPTION
Port systemd gatherer to use the new FactValue object. The used argument is the name of the daemon to get the state.
It returns an `active/inactive` string. If the deamon is disabled or does not even exist, `inactive` is returned.
We could actually return more things as map if needed. All of [this](https://github.com/coreos/go-systemd/blob/d5623bf85e8e73ae6352f78ee6b55a287619dd4e/dbus/methods.go#L379)
 [Ref](https://github.com/coreos/go-systemd).



```
facts:
  - name: sbd_state
    gatherer: systemd
    argument: sbd
```

PD:
I have renamed some constants from other gatherers to use more meaningful names.

