### PR TITLE
Refactor sbd loading

### DIFF
--- a/internal/cluster/sbd_test.go
+++ b/internal/cluster/sbd_test.go
@@ -277,10 +277,11 @@ func (suite *SbdTestSuite) TestLoadDeviceDataError() {
 	suite.EqualError(err, "sbd dump command error: error;sbd list command error: error")
 }
 
-func (suite *SbdTestSuite) TestGetSBDConfig() {
-	sbdConfig, err := getSBDConfig(helpers.GetFixturePath("discovery/cluster/sbd/sbd_config"))
+func (suite *SbdTestSuite) TestLoadSbdConfig() {
+	sbdConfig, err := LoadSbdConfig(helpers.GetFixturePath("discovery/cluster/sbd/sbd_config"))
 
-	expectedConfig := map[string]interface{}{
+	expectedConfig := map[string]string{
+		"SBD_OPTS":                "",
 		"SBD_PACEMAKER":           "yes",
 		"SBD_STARTMODE":           "always",
 		"SBD_DELAY_START":         "no",
@@ -298,13 +299,22 @@ func (suite *SbdTestSuite) TestGetSBDConfig() {
 	suite.NoError(err)
 }
 
-func (suite *SbdTestSuite) TestGetSBDConfigError() {
-	sbdConfig, err := getSBDConfig("notexist")
+func (suite *SbdTestSuite) TestLoadSbdConfigError() {
+	sbdConfig, err := LoadSbdConfig("notexist")
 
-	expectedConfig := map[string]interface{}(nil)
+	expectedConfig := map[string]string(nil)
 
 	suite.Equal(expectedConfig, sbdConfig)
 	suite.EqualError(err, "could not open sbd config file: open notexist: no such file or directory")
+}
+
+func (suite *SbdTestSuite) TestLoadSbdConfigParsingError() {
+	sbdConfig, err := LoadSbdConfig(helpers.GetFixturePath("discovery/cluster/sbd/sbd_config_invalid"))
+
+	expectedConfig := map[string]string(nil)
+
+	suite.Equal(expectedConfig, sbdConfig)
+	suite.EqualError(err, "could not parse sbd config file: error on line 1: missing =")
 }
 
 func (suite *SbdTestSuite) TestNewSBD() {
@@ -318,7 +328,8 @@ func (suite *SbdTestSuite) TestNewSBD() {
 
 	expectedSbd := SBD{
 		cluster: "mycluster",
-		Config: map[string]interface{}{
+		Config: map[string]string{
+			"SBD_OPTS":                "",
 			"SBD_PACEMAKER":           "yes",
 			"SBD_STARTMODE":           "always",
 			"SBD_DELAY_START":         "no",
@@ -402,7 +413,8 @@ func (suite *SbdTestSuite) TestNewSBDError() {
 
 	expectedSbd := SBD{ //nolint
 		cluster: "mycluster",
-		Config: map[string]interface{}{
+		Config: map[string]string{
+			"SBD_OPTS":                "",
 			"SBD_PACEMAKER":           "yes",
 			"SBD_STARTMODE":           "always",
 			"SBD_DELAY_START":         "no",
@@ -428,7 +440,8 @@ func (suite *SbdTestSuite) TestNewSBDUnhealthyDevices() {
 
 	expectedSbd := SBD{
 		cluster: "mycluster",
-		Config: map[string]interface{}{
+		Config: map[string]string{
+			"SBD_OPTS":                "",
 			"SBD_PACEMAKER":           "yes",
 			"SBD_STARTMODE":           "always",
 			"SBD_DELAY_START":         "no",

--- a/internal/factsengine/gatherers/sbd_test.go
+++ b/internal/factsengine/gatherers/sbd_test.go
@@ -27,7 +27,7 @@ func (suite *SBDGathererTestSuite) TestConfigFileCouldNotBeRead() {
 	expectedError := entities.FactGatheringError{
 		Type: "sbd-config-file-error",
 		Message: "error reading sbd configuration file: " +
-			"open /path/to/some-non-existent-sbd-config: no such file or directory",
+			"could not open sbd config file: open /path/to/some-non-existent-sbd-config: no such file or directory",
 	}
 
 	suite.EqualError(err, expectedError.Error())
@@ -40,8 +40,8 @@ func (suite *SBDGathererTestSuite) TestInvalidConfigFile() {
 	gatheredFacts, err := gatherer.Gather([]entities.FactRequest{})
 
 	expectedError := &entities.FactGatheringError{
-		Type:    "sbd-config-decoding-error",
-		Message: "error decoding configuration file: error on line 1: missing =",
+		Type:    "sbd-config-file-error",
+		Message: "error reading sbd configuration file: could not parse sbd config file: error on line 1: missing =",
 	}
 
 	suite.EqualError(err, expectedError.Error())
@@ -66,6 +66,11 @@ func (suite *SBDGathererTestSuite) TestSBDGatherer() {
 			Argument: "AN_INTEGER",
 		},
 		{
+			Name:     "sbd_empty_value",
+			Gatherer: "sbd_config",
+			Argument: "SBD_OPTS",
+		},
+		{
 			Name:     "sbd_unexistent",
 			Gatherer: "sbd_config",
 			Argument: "SBD_THIS_DOES_NOT_EXIST",
@@ -88,6 +93,10 @@ func (suite *SBDGathererTestSuite) TestSBDGatherer() {
 		{
 			Name:  "sbd_integer_value",
 			Value: &entities.FactValueInt{Value: 42},
+		},
+		{
+			Name:  "sbd_empty_value",
+			Value: &entities.FactValueString{Value: ""},
 		},
 		{
 			Name: "sbd_unexistent",

--- a/test/fixtures/discovery/cluster/expected_published_cluster_discovery.json
+++ b/test/fixtures/discovery/cluster/expected_published_cluster_discovery.json
@@ -1018,6 +1018,7 @@
         }
       ],
       "Config": {
+        "SBD_OPTS": "",
         "SBD_DELAY_START": "no",
         "SBD_DEVICE": "/dev/vdc;/dev/vdb",
         "SBD_MOVE_TO_ROOT_CGROUP": "auto",


### PR DESCRIPTION
## Description

Sbd configuration gets read in the two major processes of the agent:
- Discovery (cluster)
- Facts Gathering (`sbd_config` gatherer)

This PR reduces some duplication of sbd configuration file loading and in discovery/facts gathering.

Notes:
`utils.FindMatches('(?m)^(\w+)=(\S[^#\s]*)', sbdConfigRaw)` has been superseded by `envparse.Parse(sbdConfigFile)`.
A subtle difference here is that `FindMatches` ignores empty values like `SBD_OPTS=` while `envparse` decodes to empty string.

This means that the cluster discovery would also have `"SBD_OPTS": ""` among the other configs.

~Would this break something? :sweat_smile:~ I tried and it does not break things up. 
~Should we make sure to skip empty entries when parsing?~ I believe we should return sbd config entries even if they're empty, see https://github.com/trento-project/agent/pull/145#issuecomment-1321746186