### PR TITLE
Generic get value

### DIFF
--- a/cmd/facts.go
+++ b/cmd/facts.go
@@ -48,10 +48,6 @@ func NewFactsGatherCmd() *cobra.Command {
 	if err != nil {
 		panic(err)
 	}
-	err = gatherCmd.MarkFlagRequired("argument")
-	if err != nil {
-		panic(err)
-	}
 
 	return gatherCmd
 }

--- a/internal/factsengine/entities/fact_value.go
+++ b/internal/factsengine/entities/fact_value.go
@@ -115,6 +115,9 @@ func ParseStringToFactValue(str string) FactValue {
 // foo.bar.buz access the {"foo": {"bar": {"baz": "value"}}}
 // foo.0.buz access the {"foo": [{"buz": "value"}]}
 func GetValue(fact FactValue, values string) (FactValue, *FactGatheringError) {
+	// splitDotAccess returns and empty list if the coming argument is an empty string.
+	// It is used to replace strings.Split as this 2nd returns a one element list with
+	// and empty string in the same scenario
 	splitDotAccess := func(c rune) bool {
 		return c == '.'
 	}

--- a/internal/factsengine/entities/fact_value.go
+++ b/internal/factsengine/entities/fact_value.go
@@ -1,10 +1,20 @@
 package entities
 
 import (
+	"fmt"
 	"strconv"
+	"strings"
 )
 
-// `FactValue` represents a dynamically typed value which can be either
+// nolint:gochecknoglobals
+// ValueNotFoundError is an error returned when the wanted value in GetValue
+// function is not found
+var ValueNotFoundError = FactGatheringError{
+	Type:    "value-not-found",
+	Message: "error getting value",
+}
+
+// FactValue represents a dynamically typed value which can be either
 // an int, a float, a string, a boolean, a recursive map[string] value, or a
 // list of values.
 // A producer of FactValue is expected to set one of that variants.
@@ -98,4 +108,45 @@ func ParseStringToFactValue(str string) FactValue {
 	}
 
 	return &FactValueString{Value: str}
+}
+
+// GetValue returns a value using a dot access key format from a FactValue.
+// Examples:
+// foo.bar.buz access the {"foo": {"bar": {"baz": "value"}}}
+// foo.0.buz access the {"foo": [{"buz": "value"}]}
+func GetValue(fact FactValue, values string) (FactValue, *FactGatheringError) {
+	splitDotAccess := func(c rune) bool {
+		return c == '.'
+	}
+
+	value, err := getValue(fact, strings.FieldsFunc(values, splitDotAccess))
+	if err != nil {
+		return value, ValueNotFoundError.Wrap(fmt.Sprintf("%s: %s", err.Error(), values))
+	}
+	return value, nil
+}
+
+func getValue(fact FactValue, values []string) (FactValue, error) {
+	if len(values) == 0 {
+		return fact, nil
+	}
+	switch value := fact.(type) {
+	case *FactValueMap:
+		if child, found := value.Value[values[0]]; found {
+			return getValue(child, values[1:])
+		}
+		return nil, fmt.Errorf("requested field value not found")
+
+	case *FactValueList:
+		listIndex, err := strconv.Atoi(values[0])
+		if err != nil {
+			return nil, fmt.Errorf("list index must be of integer value, %s provided", values[0])
+		}
+		if listIndex > len(value.Value)-1 {
+			return nil, fmt.Errorf("%d index is not available in the list", listIndex)
+		}
+		return getValue(value.Value[listIndex], values[1:])
+	default:
+		return value, nil
+	}
 }

--- a/internal/factsengine/entities/fact_value.go
+++ b/internal/factsengine/entities/fact_value.go
@@ -82,6 +82,25 @@ func (v *FactValueMap) AsInterface() interface{} {
 	return result
 }
 
+// GetValue returns a value using a dot access key format from a FactValue.
+// Examples:
+// foo.bar.buz access the {"foo": {"bar": {"baz": "value"}}}
+// foo.0.buz access the {"foo": [{"buz": "value"}]}
+func (v *FactValueMap) GetValue(values string) (FactValue, *FactGatheringError) {
+	// splitDotAccess returns and empty list if the coming argument is an empty string.
+	// It is used to replace strings.Split as this 2nd returns a one element list with
+	// and empty string in the same scenario
+	splitDotAccess := func(c rune) bool {
+		return c == '.'
+	}
+
+	value, err := getValue(v, strings.FieldsFunc(values, splitDotAccess))
+	if err != nil {
+		return value, ValueNotFoundError.Wrap(fmt.Sprintf("%s: %s", err.Error(), values))
+	}
+	return value, nil
+}
+
 type FactValueList struct {
 	Value []FactValue
 }
@@ -108,25 +127,6 @@ func ParseStringToFactValue(str string) FactValue {
 	}
 
 	return &FactValueString{Value: str}
-}
-
-// GetValue returns a value using a dot access key format from a FactValue.
-// Examples:
-// foo.bar.buz access the {"foo": {"bar": {"baz": "value"}}}
-// foo.0.buz access the {"foo": [{"buz": "value"}]}
-func GetValue(fact FactValue, values string) (FactValue, *FactGatheringError) {
-	// splitDotAccess returns and empty list if the coming argument is an empty string.
-	// It is used to replace strings.Split as this 2nd returns a one element list with
-	// and empty string in the same scenario
-	splitDotAccess := func(c rune) bool {
-		return c == '.'
-	}
-
-	value, err := getValue(fact, strings.FieldsFunc(values, splitDotAccess))
-	if err != nil {
-		return value, ValueNotFoundError.Wrap(fmt.Sprintf("%s: %s", err.Error(), values))
-	}
-	return value, nil
 }
 
 func getValue(fact FactValue, values []string) (FactValue, error) {

--- a/internal/factsengine/entities/fact_value_test.go
+++ b/internal/factsengine/entities/fact_value_test.go
@@ -103,3 +103,123 @@ func (suite *FactValueTestSuite) TestParseStringToFactValue() {
 		})
 	}
 }
+
+func (suite *FactValueTestSuite) TestGetValue() {
+	parsedValue := &entities.FactValueMap{
+		Value: map[string]entities.FactValue{
+			"string": &entities.FactValueString{Value: "value"},
+			"list_value": &entities.FactValueList{
+				Value: []entities.FactValue{
+					&entities.FactValueInt{Value: 1},
+					&entities.FactValueInt{Value: 2},
+					&entities.FactValueMap{
+						Value: map[string]entities.FactValue{
+							"id": &entities.FactValueString{Value: "id"},
+						},
+					},
+				},
+			},
+			"map_value": &entities.FactValueMap{
+				Value: map[string]entities.FactValue{
+					"value": &entities.FactValueString{Value: "other_value"},
+				},
+			},
+		},
+	}
+
+	cases := []struct {
+		description string
+		key         string
+		expected    entities.FactValue
+		err         *entities.FactGatheringError
+	}{
+		{
+			description: "Should return basic value",
+			key:         "string",
+			expected:    &entities.FactValueString{Value: "value"},
+			err:         nil,
+		},
+		{
+			description: "Should return value from list",
+			key:         "list_value.0",
+			expected:    &entities.FactValueInt{Value: 1},
+			err:         nil,
+		},
+		{
+			description: "Should return second value from list",
+			key:         "list_value.1",
+			expected:    &entities.FactValueInt{Value: 2},
+			err:         nil,
+		},
+		{
+			description: "Should return map value from list",
+			key:         "list_value.2.id",
+			expected:    &entities.FactValueString{Value: "id"},
+			err:         nil,
+		},
+		{
+			description: "Should return complete list",
+			key:         "list_value",
+			expected: &entities.FactValueList{
+				Value: []entities.FactValue{
+					&entities.FactValueInt{Value: 1},
+					&entities.FactValueInt{Value: 2},
+					&entities.FactValueMap{
+						Value: map[string]entities.FactValue{
+							"id": &entities.FactValueString{Value: "id"},
+						},
+					},
+				},
+			},
+			err: nil,
+		},
+		{
+			description: "Should return map value from map",
+			key:         "map_value.value",
+			expected:    &entities.FactValueString{Value: "other_value"},
+			err:         nil,
+		},
+		{
+			description: "Should return complete map when no keys are given",
+			key:         "",
+			expected:    parsedValue,
+			err:         nil,
+		},
+		{
+			description: "Should return ValueNotFoundError when value does not exist",
+			key:         "map_value.other_value",
+			expected:    nil,
+			err: &entities.FactGatheringError{
+				Type:    "value-not-found",
+				Message: "error getting value: requested field value not found: map_value.other_value",
+			},
+		},
+		{
+			description: "Should return ValueNotFoundError when given list index does not exist",
+			key:         "list_value.3",
+			expected:    nil,
+			err: &entities.FactGatheringError{
+				Type:    "value-not-found",
+				Message: "error getting value: 3 index is not available in the list: list_value.3",
+			},
+		},
+		{
+			description: "Should return ValueNotFoundError when given list index is not a number",
+			key:         "list_value.x",
+			expected:    nil,
+			err: &entities.FactGatheringError{
+				Type:    "value-not-found",
+				Message: "error getting value: list index must be of integer value, x provided: list_value.x",
+			},
+		},
+	}
+
+	for _, tt := range cases {
+		suite.T().Run(tt.description, func(t *testing.T) {
+			factValue, err := entities.GetValue(parsedValue, tt.key)
+
+			suite.Equal(factValue, tt.expected)
+			suite.Equal(err, tt.err)
+		})
+	}
+}

--- a/internal/factsengine/entities/fact_value_test.go
+++ b/internal/factsengine/entities/fact_value_test.go
@@ -104,8 +104,8 @@ func (suite *FactValueTestSuite) TestParseStringToFactValue() {
 	}
 }
 
-func (suite *FactValueTestSuite) TestGetValue() {
-	parsedValue := &entities.FactValueMap{
+func (suite *FactValueTestSuite) TestFactValueMapGetValue() {
+	mapValue := &entities.FactValueMap{
 		Value: map[string]entities.FactValue{
 			"string": &entities.FactValueString{Value: "value"},
 			"list_value": &entities.FactValueList{
@@ -182,7 +182,7 @@ func (suite *FactValueTestSuite) TestGetValue() {
 		{
 			description: "Should return complete map when no keys are given",
 			key:         "",
-			expected:    parsedValue,
+			expected:    mapValue,
 			err:         nil,
 		},
 		{
@@ -216,7 +216,7 @@ func (suite *FactValueTestSuite) TestGetValue() {
 
 	for _, tt := range cases {
 		suite.T().Run(tt.description, func(t *testing.T) {
-			factValue, err := entities.GetValue(parsedValue, tt.key)
+			factValue, err := mapValue.GetValue(tt.key)
 
 			suite.Equal(factValue, tt.expected)
 			suite.Equal(err, tt.err)

--- a/internal/factsengine/entities/fact_value_test.go
+++ b/internal/factsengine/entities/fact_value_test.go
@@ -1,92 +1,105 @@
-package entities
+package entities_test
 
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"github.com/trento-project/agent/internal/factsengine/entities"
 )
 
-func TestFactValueAsInterface(t *testing.T) {
+type FactValueTestSuite struct {
+	suite.Suite
+}
+
+func TestFactValueTestSuite(t *testing.T) {
+	suite.Run(t, new(FactValueTestSuite))
+}
+
+func (suite *FactValueTestSuite) TestFactValueAsInterface() {
 	cases := []struct {
 		description string
-		factValue   FactValue
+		factValue   entities.FactValue
 		expected    interface{}
 	}{
 		{
 			description: "FactValueInt AsInterface",
-			factValue:   &FactValueInt{Value: 1},
+			factValue:   &entities.FactValueInt{Value: 1},
 			expected:    1,
 		},
 		{
 			description: "FactValueFloat AsInterface",
-			factValue:   &FactValueFloat{Value: 1.1},
+			factValue:   &entities.FactValueFloat{Value: 1.1},
 			expected:    1.1,
 		},
 		{
 			description: "FactValueString AsInterface",
-			factValue:   &FactValueString{Value: "test"},
+			factValue:   &entities.FactValueString{Value: "test"},
 			expected:    "test",
 		},
 		{
 			description: "FactValueBool AsInterface",
-			factValue:   &FactValueBool{Value: true},
+			factValue:   &entities.FactValueBool{Value: true},
 			expected:    true,
 		},
 		{
 			description: "FactValueMap AsInterface",
-			factValue:   &FactValueMap{Value: map[string]FactValue{"test": &FactValueString{Value: "test"}}},
-			expected:    map[string]interface{}{"test": "test"},
+			factValue: &entities.FactValueMap{
+				Value: map[string]entities.FactValue{
+					"test": &entities.FactValueString{Value: "test"}}},
+			expected: map[string]interface{}{"test": "test"},
 		},
 		{
 			description: "FactValueList AsInterface",
-			factValue:   &FactValueList{Value: []FactValue{&FactValueString{Value: "test"}}},
-			expected:    []interface{}{"test"},
+			factValue: &entities.FactValueList{
+				Value: []entities.FactValue{
+					&entities.FactValueString{Value: "test"}}},
+			expected: []interface{}{"test"},
 		},
 	}
 
 	for _, tt := range cases {
-		t.Run(tt.description, func(t *testing.T) {
+		suite.T().Run(tt.description, func(t *testing.T) {
 			i := tt.factValue.AsInterface()
 
-			assert.Equal(t, i, tt.expected)
+			suite.Equal(i, tt.expected)
 		})
 	}
 }
 
-func TestParseStringToFactValue(t *testing.T) {
+func (suite *FactValueTestSuite) TestParseStringToFactValue() {
 	cases := []struct {
 		description string
 		str         string
-		expected    FactValue
+		expected    entities.FactValue
 	}{
 		{
 			description: "Should parse a string to FactValueInt",
 			str:         "1",
-			expected:    &FactValueInt{Value: 1},
+			expected:    &entities.FactValueInt{Value: 1},
 		},
 		{
 			description: "Should parse a string to  FactValueFloat",
 			str:         "1.1",
-			expected:    &FactValueFloat{Value: 1.1},
+			expected:    &entities.FactValueFloat{Value: 1.1},
 		},
 
 		{
 			description: "Should parse a string to FactValueBool",
 			str:         "true",
-			expected:    &FactValueBool{Value: true},
+			expected:    &entities.FactValueBool{Value: true},
 		},
 		{
 			description: "Should parse a string to FactValueString",
 			str:         "test",
-			expected:    &FactValueString{Value: "test"},
+			expected:    &entities.FactValueString{Value: "test"},
 		},
 	}
 
 	for _, tt := range cases {
-		t.Run(tt.description, func(t *testing.T) {
-			factValue := ParseStringToFactValue(tt.str)
+		suite.T().Run(tt.description, func(t *testing.T) {
+			factValue := entities.ParseStringToFactValue(tt.str)
 
-			assert.Equal(t, factValue, tt.expected)
+			suite.Equal(factValue, tt.expected)
 		})
 	}
 }

--- a/internal/factsengine/gatherers/corosyncconf.go
+++ b/internal/factsengine/gatherers/corosyncconf.go
@@ -66,7 +66,7 @@ func (s *CorosyncConfGatherer) Gather(factsRequests []entities.FactRequest) ([]e
 	for _, factReq := range factsRequests {
 		var fact entities.Fact
 
-		if value, err := entities.GetValue(corosyncMap, factReq.Argument); err == nil {
+		if value, err := corosyncMap.GetValue(factReq.Argument); err == nil {
 			fact = entities.NewFactGatheredWithRequest(factReq, value)
 
 		} else {
@@ -99,7 +99,7 @@ func readCorosyncConfFileByLines(filePath string) ([]string, error) {
 	return fileLines, nil
 }
 
-func corosyncConfToMap(lines []string) (entities.FactValue, error) {
+func corosyncConfToMap(lines []string) (*entities.FactValueMap, error) {
 	var cm = make(map[string]entities.FactValue)
 	var sections int
 

--- a/internal/factsengine/gatherers/corosyncconf_test.go
+++ b/internal/factsengine/gatherers/corosyncconf_test.go
@@ -100,8 +100,8 @@ func (suite *CorosyncConfTestSuite) TestCorosyncConfBasic() {
 			Name:  "corosync_not_found",
 			Value: nil,
 			Error: &entities.FactGatheringError{
-				Message: "requested field value not found: totem.not_found",
-				Type:    "corosync-conf-value-not-found",
+				Message: "error getting value: requested field value not found: totem.not_found",
+				Type:    "value-not-found",
 			},
 		},
 	}


### PR DESCRIPTION
Make `GetValue` a public function. Accessing to FactValue objects using a `dot` way (`value.other_value.0`, etc) will be a common thing next (for example, crm_mon and cibadmin will use it).
As a side effect, this gives a much more flexible way of testing `GetValue` without depending on real gatherer fixtures.
I have refactored the `fact_value_test.go` tests to use `_test` package and a proper testing suite.