### PR TITLE
Retrieve agent id command

### DIFF
--- a/cmd/id.go
+++ b/cmd/id.go
@@ -1,0 +1,26 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/trento-project/agent/internal/agent"
+)
+
+func NewAgentIDCmd() *cobra.Command {
+	idCmd := &cobra.Command{ //nolint
+		Use:   "id",
+		Short: "Print the agent identifier",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			agentID, err := agent.GetAgentID()
+			if err != nil {
+				return err
+			}
+			_, err = os.Stdout.WriteString(agentID)
+
+			return err
+		},
+	}
+
+	return idCmd
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -39,6 +39,7 @@ that can help you deploy, provision and operate infrastructure for SAP Applicati
 		}
 	})
 
+	rootCmd.AddCommand(NewAgentIDCmd())
 	rootCmd.AddCommand(NewStartCmd())
 	rootCmd.AddCommand(NewFactsCmd())
 	rootCmd.AddCommand(NewVersionCmd())

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -42,7 +42,7 @@ type Config struct {
 
 // NewAgent returns a new instance of Agent with the given configuration
 func NewAgent(config *Config) (*Agent, error) {
-	agentID, err := getAgentID()
+	agentID, err := GetAgentID()
 	if err != nil {
 		return nil, errors.Wrap(err, "could not get the agent ID")
 	}
@@ -68,7 +68,7 @@ func NewAgent(config *Config) (*Agent, error) {
 	return agent, nil
 }
 
-func getAgentID() (string, error) {
+func GetAgentID() (string, error) {
 	machineIDBytes, err := afero.ReadFile(fileSystem, machineIDPath)
 	if err != nil {
 		return "", err

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -31,7 +31,7 @@ func (suite *AgentTestSuite) SetupSuite() {
 }
 
 func (suite *AgentTestSuite) TestAgentGetAgentID() {
-	agentID, err := getAgentID()
+	agentID, err := GetAgentID()
 
 	suite.NoError(err)
 	suite.Equal(DummyAgentID, agentID)


### PR DESCRIPTION
This PR adds a command to reliably retrieve the agent id from a trento-agent installation.

Here's the usage
```bash
$ trento-agent id
f6fe2f71-42cc-482f-877f-00d9b4592d83
```

And here's  a sample output in case of an error
```bash
$ trento-agent id
FATA[0000] Failed to get Agent id: open /etc/machine-idz: no such file or directory
```