### PR TITLE
Fix special lists usage in corosyncconf gatherer

### DIFF
--- a/internal/factsengine/gatherers/corosyncconf_test.go
+++ b/internal/factsengine/gatherers/corosyncconf_test.go
@@ -36,6 +36,11 @@ func (suite *CorosyncConfTestSuite) TestCorosyncConfBasic() {
 			Argument: "totem.join",
 		},
 		{
+			Name:     "corosync_interfaces",
+			Gatherer: "corosync.conf",
+			Argument: "totem.interface",
+		},
+		{
 			Name:     "corosync_node1id",
 			Gatherer: "corosync.conf",
 			Argument: "nodelist.node.0.nodeid",
@@ -71,6 +76,18 @@ func (suite *CorosyncConfTestSuite) TestCorosyncConfBasic() {
 			Error: nil,
 		},
 		{
+			Name: "corosync_interfaces",
+			Value: &entities.FactValueList{Value: []entities.FactValue{
+				&entities.FactValueMap{Value: map[string]entities.FactValue{
+					"ringnumber":  &entities.FactValueInt{Value: 0},
+					"bindnetaddr": &entities.FactValueString{Value: "192.168.1.0"},
+					"mcastport":   &entities.FactValueInt{Value: 5405},
+					"ttl":         &entities.FactValueInt{Value: 1},
+				}},
+			}},
+			Error: nil,
+		},
+		{
 			Name:  "corosync_node1id",
 			Value: &entities.FactValueInt{Value: 1},
 			Error: nil,
@@ -103,6 +120,80 @@ func (suite *CorosyncConfTestSuite) TestCorosyncConfBasic() {
 				Message: "error getting value: requested field value not found: totem.not_found",
 				Type:    "value-not-found",
 			},
+		},
+	}
+
+	suite.NoError(err)
+	suite.ElementsMatch(expectedResults, factsGathered)
+}
+
+func (suite *CorosyncConfTestSuite) TestCorosyncConfOneNode() {
+	c := NewCorosyncConfGatherer(helpers.GetFixturePath("gatherers/corosync.conf.one_node"))
+
+	factsRequest := []entities.FactRequest{
+		{
+			Name:     "corosync_nodes",
+			Gatherer: "corosync.conf",
+			Argument: "nodelist.node",
+		},
+	}
+
+	factsGathered, err := c.Gather(factsRequest)
+
+	expectedResults := []entities.Fact{
+
+		{
+			Name: "corosync_nodes",
+			Value: &entities.FactValueList{Value: []entities.FactValue{
+				&entities.FactValueMap{Value: map[string]entities.FactValue{
+					"ring0_addr": &entities.FactValueString{Value: "10.0.0.119"},
+					"ring1_addr": &entities.FactValueString{Value: "10.0.0.120"},
+					"nodeid":     &entities.FactValueInt{Value: 1},
+				}},
+			}},
+			Error: nil,
+		},
+	}
+
+	suite.NoError(err)
+	suite.ElementsMatch(expectedResults, factsGathered)
+}
+
+func (suite *CorosyncConfTestSuite) TestCorosyncConfThreeNodes() {
+	c := NewCorosyncConfGatherer(helpers.GetFixturePath("gatherers/corosync.conf.three_node"))
+
+	factsRequest := []entities.FactRequest{
+		{
+			Name:     "corosync_nodes",
+			Gatherer: "corosync.conf",
+			Argument: "nodelist.node",
+		},
+	}
+
+	factsGathered, err := c.Gather(factsRequest)
+
+	expectedResults := []entities.Fact{
+
+		{
+			Name: "corosync_nodes",
+			Value: &entities.FactValueList{Value: []entities.FactValue{
+				&entities.FactValueMap{Value: map[string]entities.FactValue{
+					"ring0_addr": &entities.FactValueString{Value: "10.0.0.119"},
+					"ring1_addr": &entities.FactValueString{Value: "10.0.0.120"},
+					"nodeid":     &entities.FactValueInt{Value: 1},
+				}},
+				&entities.FactValueMap{Value: map[string]entities.FactValue{
+					"ring0_addr": &entities.FactValueString{Value: "10.0.1.153"},
+					"ring1_addr": &entities.FactValueString{Value: "10.0.1.154"},
+					"nodeid":     &entities.FactValueInt{Value: 2},
+				}},
+				&entities.FactValueMap{Value: map[string]entities.FactValue{
+					"ring0_addr": &entities.FactValueString{Value: "10.0.1.155"},
+					"ring1_addr": &entities.FactValueString{Value: "10.0.1.156"},
+					"nodeid":     &entities.FactValueInt{Value: 3},
+				}},
+			}},
+			Error: nil,
 		},
 	}
 

--- a/pkg/factsengine/entities/fact_value.go
+++ b/pkg/factsengine/entities/fact_value.go
@@ -116,6 +116,11 @@ func (v *FactValueList) AsInterface() interface{} {
 	return result
 }
 
+// AsInterface converts a FactValueList internal value to an interface{}.
+func (v *FactValueList) AppendValue(value FactValue) {
+	v.Value = append(v.Value, value)
+}
+
 // ParseStringToFactValue parses a string to a FactValue type.
 func ParseStringToFactValue(str string) FactValue {
 	if i, err := strconv.Atoi(str); err == nil {

--- a/pkg/factsengine/entities/fact_value_test.go
+++ b/pkg/factsengine/entities/fact_value_test.go
@@ -104,6 +104,20 @@ func (suite *FactValueTestSuite) TestParseStringToFactValue() {
 	}
 }
 
+func (suite *FactValueTestSuite) TestFactValueListAppend() {
+	list := entities.FactValueList{Value: []entities.FactValue{
+		&entities.FactValueInt{Value: 1},
+	}}
+	list.AppendValue(&entities.FactValueInt{Value: 2})
+
+	expected := entities.FactValueList{Value: []entities.FactValue{
+		&entities.FactValueInt{Value: 1},
+		&entities.FactValueInt{Value: 2},
+	}}
+
+	suite.Equal(list, expected)
+}
+
 func (suite *FactValueTestSuite) TestFactValueMapGetValue() {
 	mapValue := &entities.FactValueMap{
 		Value: map[string]entities.FactValue{

--- a/test/fixtures/gatherers/corosync.conf.basic
+++ b/test/fixtures/gatherers/corosync.conf.basic
@@ -34,7 +34,7 @@ totem {
 	# over. If you define more than one interface stanza, you must
 	# also set rrp_mode.
 	interface {
-                # Rings must be consecutively numbered, starting at 0.
+		# Rings must be consecutively numbered, starting at 0.
 		ringnumber: 0
 		# This is normally the *network* address of the
 		# interface to bind to. This ensures that you can use

--- a/test/fixtures/gatherers/corosync.conf.one_node
+++ b/test/fixtures/gatherers/corosync.conf.one_node
@@ -1,0 +1,8 @@
+nodelist {
+        node {
+                ring0_addr: 10.0.0.119
+                ring1_addr: 10.0.0.120
+                nodeid: 1
+        }
+}
+

--- a/test/fixtures/gatherers/corosync.conf.three_node
+++ b/test/fixtures/gatherers/corosync.conf.three_node
@@ -1,0 +1,18 @@
+nodelist {
+        node {
+                ring0_addr: 10.0.0.119
+                ring1_addr: 10.0.0.120
+                nodeid: 1
+        }
+        node {
+                ring0_addr: 10.0.1.153
+                ring1_addr: 10.0.1.154 
+                nodeid: 2
+        }
+	node {
+                ring0_addr: 10.0.1.155
+                ring1_addr: 10.0.1.156 
+                nodeid: 3
+        }
+}
+


### PR DESCRIPTION
Fix how `node` and `interface` lists are used. They have list nature, so even if we have 1,2,3,x elements, they are returned as lists.

PD: I have been looking at using some `lexer` kind of code to parse the file, and even though it is doable, I prefer to open a tech debt ticket on this, and work in a future sprint, as I expect important work there.

One node nodelist:
```./trento-agent facts gather --gatherer "corosync.conf" --argument nodelist
INFO[2022-12-15 09:13:25] loading plugins                              
INFO[2022-12-15 09:13:25] Starting corosync.conf file facts gathering process 
INFO[2022-12-15 09:13:25] Requested corosync.conf file facts gathered  
INFO[2022-12-15 09:13:25] Gathered fact for "corosync.conf" with argument "nodelist": 
INFO[2022-12-15 09:13:25] {
  "Name": "nodelist",
  "CheckID": "",
  "Value": {
    "Value": {
      "node": {
        "Value": [
          {
            "Value": {
              "nodeid": {
                "Value": 1
              },
              "ring0_addr": {
                "Value": "10.0.0.119"
              },
              "ring1_addr": {
                "Value": "10.0.0.120"
              }
            }
          }
        ]
      }
    }
  },
  "Error": null
}
```

3 nodes:

```
./trento-agent facts gather --gatherer "corosync.conf" --argument nodelist
INFO[2022-12-15 09:13:57] loading plugins                              
INFO[2022-12-15 09:13:57] Starting corosync.conf file facts gathering process 
INFO[2022-12-15 09:13:57] Requested corosync.conf file facts gathered  
INFO[2022-12-15 09:13:57] Gathered fact for "corosync.conf" with argument "nodelist": 
INFO[2022-12-15 09:13:57] {
  "Name": "nodelist",
  "CheckID": "",
  "Value": {
    "Value": {
      "node": {
        "Value": [
          {
            "Value": {
              "nodeid": {
                "Value": 1
              },
              "ring0_addr": {
                "Value": "10.0.0.119"
              },
              "ring1_addr": {
                "Value": "10.0.0.120"
              }
            }
          },
          {
            "Value": {
              "nodeid": {
                "Value": 2
              },
              "ring0_addr": {
                "Value": "10.0.1.153"
              },
              "ring1_addr": {
                "Value": "10.0.1.154"
              }
            }
          },
          {
            "Value": {
              "nodeid": {
                "Value": 3
              },
              "ring0_addr": {
                "Value": "10.0.1.155"
              },
              "ring1_addr": {
                "Value": "10.0.1.156"
              }
            }
          }
        ]
      }
    }
  },
  "Error": null
}
```