### PR TITLE
Sbd dump gatherer

### DIFF
--- a/internal/core/cluster/sbd_test.go
+++ b/internal/core/cluster/sbd_test.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -278,25 +279,29 @@ func (suite *SbdTestSuite) TestLoadDeviceDataError() {
 }
 
 func (suite *SbdTestSuite) TestLoadSbdConfig() {
-	sbdConfig, err := LoadSbdConfig(helpers.GetFixturePath("discovery/cluster/sbd/sbd_config"))
+	sbdConfigVariants := []string{"sbd_config", "sbd_config_quoted_devices"}
 
-	expectedConfig := map[string]string{
-		"SBD_OPTS":                "",
-		"SBD_PACEMAKER":           "yes",
-		"SBD_STARTMODE":           "always",
-		"SBD_DELAY_START":         "no",
-		"SBD_WATCHDOG_DEV":        "/dev/watchdog",
-		"SBD_WATCHDOG_TIMEOUT":    "5",
-		"SBD_TIMEOUT_ACTION":      "flush,reboot",
-		"SBD_MOVE_TO_ROOT_CGROUP": "auto",
-		"SBD_DEVICE":              "/dev/vdc;/dev/vdb",
-		"AN_INTEGER":              "42",
-		"TEST":                    "Value",
-		"TEST2":                   "Value2",
+	for _, sbdConfigVariant := range sbdConfigVariants {
+		sbdConfig, err := LoadSbdConfig(helpers.GetFixturePath(fmt.Sprintf("discovery/cluster/sbd/%s", sbdConfigVariant)))
+
+		expectedConfig := map[string]string{
+			"SBD_OPTS":                "",
+			"SBD_PACEMAKER":           "yes",
+			"SBD_STARTMODE":           "always",
+			"SBD_DELAY_START":         "no",
+			"SBD_WATCHDOG_DEV":        "/dev/watchdog",
+			"SBD_WATCHDOG_TIMEOUT":    "5",
+			"SBD_TIMEOUT_ACTION":      "flush,reboot",
+			"SBD_MOVE_TO_ROOT_CGROUP": "auto",
+			"SBD_DEVICE":              "/dev/vdc;/dev/vdb",
+			"AN_INTEGER":              "42",
+			"TEST":                    "Value",
+			"TEST2":                   "Value2",
+		}
+
+		suite.Equal(expectedConfig, sbdConfig)
+		suite.NoError(err)
 	}
-
-	suite.Equal(expectedConfig, sbdConfig)
-	suite.NoError(err)
 }
 
 func (suite *SbdTestSuite) TestLoadSbdConfigError() {

--- a/internal/factsengine/gatherers/gatherer.go
+++ b/internal/factsengine/gatherers/gatherer.go
@@ -16,5 +16,6 @@ func StandardGatherers() map[string]FactGatherer {
 		SystemDGathererName:         NewDefaultSystemDGatherer(),
 		PackageVersionGathererName:  NewDefaultPackageVersionGatherer(),
 		SBDConfigGathererName:       NewDefaultSBDGatherer(),
+		SBDDumpGathererName:         NewDefaultSBDDumpGatherer(),
 	}
 }

--- a/internal/factsengine/gatherers/sbddump.go
+++ b/internal/factsengine/gatherers/sbddump.go
@@ -1,0 +1,147 @@
+package gatherers
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/trento-project/agent/pkg/factsengine/entities"
+	"github.com/trento-project/agent/pkg/utils"
+)
+
+const (
+	SBDDumpGathererName = "sbd_dump"
+)
+
+// nolint:gochecknoglobals
+var (
+	SBDDevicesLoadingError = entities.FactGatheringError{
+		Type:    "sbd-devices-loading-error",
+		Message: "error loading the configured sbd devices",
+	}
+
+	SBDDumpCommandError = entities.FactGatheringError{
+		Type:    "sbd-dump-command-error",
+		Message: "error while executing sbd dump",
+	}
+)
+
+type SBDDumpGatherer struct {
+	executor    utils.CommandExecutor
+	sbdGatherer *SBDGatherer
+}
+
+func NewDefaultSBDDumpGatherer() *SBDDumpGatherer {
+	return NewSBDDumpGatherer(utils.Executor{}, NewDefaultSBDGatherer())
+}
+
+func NewSBDDumpGatherer(executor utils.CommandExecutor, sbdGatherer *SBDGatherer) *SBDDumpGatherer {
+	return &SBDDumpGatherer{
+		executor:    executor,
+		sbdGatherer: sbdGatherer,
+	}
+}
+
+func (gatherer *SBDDumpGatherer) Gather(factsRequests []entities.FactRequest) ([]entities.Fact, error) {
+	facts := []entities.Fact{}
+	log.Infof("Starting %s facts gathering process", SBDDumpGathererName)
+
+	configuredDevices, err := loadDevices(gatherer.sbdGatherer)
+
+	if err != nil {
+		return facts, SBDDevicesLoadingError.Wrap(err.Error())
+	}
+
+	for _, factRequest := range factsRequests {
+		var fact entities.Fact
+
+		if devicesDumps, err := getSBDDevicesDumps(gatherer.executor, configuredDevices); err == nil {
+			fact = entities.NewFactGatheredWithRequest(factRequest, &entities.FactValueMap{Value: devicesDumps})
+		} else {
+			gatheringError := SBDDumpCommandError.Wrap(err.Error())
+
+			fact = entities.NewFactGatheredWithError(factRequest, gatheringError)
+		}
+		facts = append(facts, fact)
+	}
+
+	log.Infof("Requested %s facts gathered", SBDDumpGathererName)
+	return facts, nil
+}
+
+func loadDevices(gatherer *SBDGatherer) ([]string, error) {
+	sbdDevicesRequest := []entities.FactRequest{
+		{
+			Name:     "configured_devices",
+			Gatherer: "sbd_config",
+			Argument: "SBD_DEVICE",
+		},
+	}
+
+	sbdDevicesFacts, err := gatherer.Gather(sbdDevicesRequest)
+
+	if err != nil {
+		return []string{}, err
+	}
+
+	sbdDevicesFact := sbdDevicesFacts[0]
+
+	if sbdDevicesFact.Error != nil {
+		return []string{}, sbdDevicesFact.Error
+	}
+
+	deviceAsStringValue, ok := sbdDevicesFact.Value.(*entities.FactValueString)
+
+	if !ok {
+		return []string{}, fmt.Errorf("Unable to determine the device name: %s", sbdDevicesFact.Value)
+	}
+
+	return strings.Split(deviceAsStringValue.Value, ";"), nil
+}
+
+func getSBDDevicesDumps(
+	executor utils.CommandExecutor,
+	configuredDevices []string) (map[string]entities.FactValue, error) {
+	var devicesDumps = make(map[string]entities.FactValue)
+
+	for _, device := range configuredDevices {
+		SBDDumpMap, err := getSBDDumpFactValueMap(executor, device)
+		if err != nil {
+			log.Errorf("Error getting sbd dump for device: %s", device)
+
+			return nil, err
+		}
+
+		devicesDumps[device] = SBDDumpMap
+	}
+
+	return devicesDumps, nil
+}
+
+func getSBDDumpFactValueMap(executor utils.CommandExecutor, device string) (*entities.FactValueMap, error) {
+	SBDDump, err := executor.Exec("sbd", "-d", device, "dump")
+	if err != nil {
+		return nil, err
+	}
+
+	SBDDumpMap := utils.FindMatches(`(?m)^(\S+(?: \S+)*)\s*:\s(\S*)$`, SBDDump)
+
+	var deviceDump = make(map[string]entities.FactValue)
+
+	for key, value := range SBDDumpMap {
+		valueAsString, ok := value.(string)
+
+		if !ok {
+			err := fmt.Errorf(`Unable to parse sbd dump entry "%s" as string: %s`, key, value)
+			log.Error(err)
+			return nil, err
+		}
+
+		key = regexp.MustCompile(`[()]`).ReplaceAllString(key, "")
+
+		deviceDump[strings.ToLower(key)] = entities.ParseStringToFactValue(valueAsString)
+	}
+
+	return &entities.FactValueMap{Value: deviceDump}, nil
+}

--- a/internal/factsengine/gatherers/sbddump.go
+++ b/internal/factsengine/gatherers/sbddump.go
@@ -54,7 +54,7 @@ func (gatherer *SBDDumpGatherer) Gather(factsRequests []entities.FactRequest) ([
 	configuredDevices, err := loadDevices(gatherer.sbdConfigFile)
 
 	if err != nil {
-		return facts, SBDDevicesLoadingError.Wrap(err.Error())
+		return nil, SBDDevicesLoadingError.Wrap(err.Error())
 	}
 
 	for _, factRequest := range factsRequests {
@@ -112,7 +112,7 @@ func getSBDDevicesDumps(
 func getSBDDumpFactValueMap(executor utils.CommandExecutor, device string) (*entities.FactValueMap, error) {
 	SBDDump, err := executor.Exec("sbd", "-d", device, "dump")
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("Error while dumping information for device %s: %w", device, err)
 	}
 
 	SBDDumpMap := utils.FindMatches(`(?m)^(\S+(?: \S+)*)\s*:\s(\S*)$`, SBDDump)

--- a/internal/factsengine/gatherers/sbddump_test.go
+++ b/internal/factsengine/gatherers/sbddump_test.go
@@ -25,7 +25,7 @@ func (suite *SBDDumpTestSuite) TestSBDDumpUnableToLoadDevices() {
 	mockExecutor := new(utilsMocks.CommandExecutor)
 	sbdDumpGatherer := gatherers.NewSBDDumpGatherer(
 		mockExecutor,
-		gatherers.NewSBDGatherer(helpers.GetFixturePath("discovery/cluster/sbd/sbd_config_invalid")),
+		helpers.GetFixturePath("discovery/cluster/sbd/sbd_config_invalid"),
 	)
 
 	factRequests := []entities.FactRequest{
@@ -38,10 +38,8 @@ func (suite *SBDDumpTestSuite) TestSBDDumpUnableToLoadDevices() {
 	gatheredFacts, err := sbdDumpGatherer.Gather(factRequests)
 
 	expectedError := &entities.FactGatheringError{
-		Message: "error loading the configured sbd devices: fact gathering error: " +
-			"sbd-config-file-error - error reading sbd configuration file: " +
-			"could not parse sbd config file: error on line 1: missing =",
-		Type: "sbd-devices-loading-error",
+		Message: "error loading the configured sbd devices: could not parse sbd config file: error on line 1: missing =",
+		Type:    "sbd-devices-loading-error",
 	}
 	suite.EqualError(err, expectedError.Error())
 	suite.Empty(gatheredFacts)
@@ -57,7 +55,7 @@ func (suite *SBDDumpTestSuite) TestSBDDumpUnableToDumpDevice() {
 
 	sbdDumpGatherer := gatherers.NewSBDDumpGatherer(
 		mockExecutor,
-		gatherers.NewSBDGatherer(helpers.GetFixturePath("discovery/cluster/sbd/sbd_config")),
+		helpers.GetFixturePath("discovery/cluster/sbd/sbd_config"),
 	)
 
 	factRequests := []entities.FactRequest{
@@ -111,7 +109,7 @@ func (suite *SBDDumpTestSuite) TestSBDDumpGatherer() {
 
 	sbdDumpGatherer := gatherers.NewSBDDumpGatherer(
 		mockExecutor,
-		gatherers.NewSBDGatherer(helpers.GetFixturePath("discovery/cluster/sbd/sbd_config")),
+		helpers.GetFixturePath("discovery/cluster/sbd/sbd_config"),
 	)
 
 	factRequests := []entities.FactRequest{
@@ -130,12 +128,12 @@ func (suite *SBDDumpTestSuite) TestSBDDumpGatherer() {
 
 	deviceVDBDump := &entities.FactValueMap{Value: map[string]entities.FactValue{
 		"header_version":   &entities.FactValueFloat{Value: 2.1},
-		"number_of_slots":  &entities.FactValueInt{Value: 255},
-		"sector_size":      &entities.FactValueInt{Value: 512},
+		"number_of_slots":  &entities.FactValueInt{Value: 188},
+		"sector_size":      &entities.FactValueInt{Value: 1024},
 		"timeout_allocate": &entities.FactValueInt{Value: 2},
-		"timeout_loop":     &entities.FactValueInt{Value: 1},
-		"timeout_msgwait":  &entities.FactValueInt{Value: 10},
-		"timeout_watchdog": &entities.FactValueInt{Value: 5},
+		"timeout_loop":     &entities.FactValueInt{Value: 3},
+		"timeout_msgwait":  &entities.FactValueInt{Value: 120},
+		"timeout_watchdog": &entities.FactValueInt{Value: 60},
 		"uuid":             &entities.FactValueString{Value: "e09c8993-0cba-438d-a4c3-78e91f58ee52"},
 	}}
 

--- a/internal/factsengine/gatherers/sbddump_test.go
+++ b/internal/factsengine/gatherers/sbddump_test.go
@@ -77,7 +77,7 @@ func (suite *SBDDumpTestSuite) TestSBDDumpUnableToDumpDevice() {
 			Name:  "sbd_devices_dump",
 			Value: nil,
 			Error: &entities.FactGatheringError{
-				Message: "error while executing sbd dump: a failure",
+				Message: "error while executing sbd dump: Error while dumping information for device /dev/vdb: a failure",
 				Type:    "sbd-dump-command-error",
 			},
 		},
@@ -85,7 +85,7 @@ func (suite *SBDDumpTestSuite) TestSBDDumpUnableToDumpDevice() {
 			Name:  "another_sbd_devices_dump",
 			Value: nil,
 			Error: &entities.FactGatheringError{
-				Message: "error while executing sbd dump: a failure",
+				Message: "error while executing sbd dump: Error while dumping information for device /dev/vdb: a failure",
 				Type:    "sbd-dump-command-error",
 			},
 		},

--- a/internal/factsengine/gatherers/sbddump_test.go
+++ b/internal/factsengine/gatherers/sbddump_test.go
@@ -1,0 +1,172 @@
+package gatherers_test
+
+import (
+	"errors"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/trento-project/agent/internal/factsengine/gatherers"
+	"github.com/trento-project/agent/pkg/factsengine/entities"
+	utilsMocks "github.com/trento-project/agent/pkg/utils/mocks"
+	"github.com/trento-project/agent/test/helpers"
+)
+
+type SBDDumpTestSuite struct {
+	suite.Suite
+}
+
+func TestSBDDumpTestSuite(t *testing.T) {
+	suite.Run(t, new(SBDDumpTestSuite))
+}
+
+func (suite *SBDDumpTestSuite) TestSBDDumpUnableToLoadDevices() {
+	mockExecutor := new(utilsMocks.CommandExecutor)
+	sbdDumpGatherer := gatherers.NewSBDDumpGatherer(
+		mockExecutor,
+		gatherers.NewSBDGatherer(helpers.GetFixturePath("discovery/cluster/sbd/sbd_config_invalid")),
+	)
+
+	factRequests := []entities.FactRequest{
+		{
+			Name:     "sbd_devices_dump",
+			Gatherer: "sbd_dump",
+		},
+	}
+
+	gatheredFacts, err := sbdDumpGatherer.Gather(factRequests)
+
+	expectedError := &entities.FactGatheringError{
+		Message: "error loading the configured sbd devices: fact gathering error: " +
+			"sbd-config-file-error - error reading sbd configuration file: " +
+			"could not parse sbd config file: error on line 1: missing =",
+		Type: "sbd-devices-loading-error",
+	}
+	suite.EqualError(err, expectedError.Error())
+	suite.Empty(gatheredFacts)
+}
+
+func (suite *SBDDumpTestSuite) TestSBDDumpUnableToDumpDevice() {
+	mockExecutor := new(utilsMocks.CommandExecutor)
+
+	mockOutputFile, _ := os.Open(helpers.GetFixturePath("gatherers/dev.vdc.sbddump.output"))
+	mockOutput, _ := ioutil.ReadAll(mockOutputFile)
+	mockExecutor.On("Exec", "sbd", "-d", "/dev/vdb", "dump").Return(nil, errors.New("a failure"))
+	mockExecutor.On("Exec", "sbd", "-d", "/dev/vdc", "dump").Return(mockOutput, nil)
+
+	sbdDumpGatherer := gatherers.NewSBDDumpGatherer(
+		mockExecutor,
+		gatherers.NewSBDGatherer(helpers.GetFixturePath("discovery/cluster/sbd/sbd_config")),
+	)
+
+	factRequests := []entities.FactRequest{
+		{
+			Name:     "sbd_devices_dump",
+			Gatherer: "sbd_dump",
+		},
+		{
+			Name:     "another_sbd_devices_dump",
+			Gatherer: "sbd_dump",
+			Argument: "an-ignored-argument",
+		},
+	}
+
+	gatheredFacts, err := sbdDumpGatherer.Gather(factRequests)
+
+	expectedFacts := []entities.Fact{
+		{
+			Name:  "sbd_devices_dump",
+			Value: nil,
+			Error: &entities.FactGatheringError{
+				Message: "error while executing sbd dump: a failure",
+				Type:    "sbd-dump-command-error",
+			},
+		},
+		{
+			Name:  "another_sbd_devices_dump",
+			Value: nil,
+			Error: &entities.FactGatheringError{
+				Message: "error while executing sbd dump: a failure",
+				Type:    "sbd-dump-command-error",
+			},
+		},
+	}
+
+	suite.NoError(err)
+	suite.ElementsMatch(expectedFacts, gatheredFacts)
+}
+
+func (suite *SBDDumpTestSuite) TestSBDDumpGatherer() {
+	mockExecutor := new(utilsMocks.CommandExecutor)
+
+	deviceVDBMockOutputFile, _ := os.Open(helpers.GetFixturePath("gatherers/dev.vdb.sbddump.output"))
+	deviceVDBMockOutput, _ := ioutil.ReadAll(deviceVDBMockOutputFile)
+
+	deviceVDCMockOutputFile, _ := os.Open(helpers.GetFixturePath("gatherers/dev.vdc.sbddump.output"))
+	deviceVDCMockOutput, _ := ioutil.ReadAll(deviceVDCMockOutputFile)
+
+	mockExecutor.On("Exec", "sbd", "-d", "/dev/vdb", "dump").Return(deviceVDBMockOutput, nil)
+	mockExecutor.On("Exec", "sbd", "-d", "/dev/vdc", "dump").Return(deviceVDCMockOutput, nil)
+
+	sbdDumpGatherer := gatherers.NewSBDDumpGatherer(
+		mockExecutor,
+		gatherers.NewSBDGatherer(helpers.GetFixturePath("discovery/cluster/sbd/sbd_config")),
+	)
+
+	factRequests := []entities.FactRequest{
+		{
+			Name:     "sbd_devices_dump",
+			Gatherer: "sbd_dump",
+		},
+		{
+			Name:     "another_sbd_devices_dump",
+			Gatherer: "sbd_dump",
+			Argument: "an-ignored-argument",
+		},
+	}
+
+	factResults, err := sbdDumpGatherer.Gather(factRequests)
+
+	deviceVDBDump := &entities.FactValueMap{Value: map[string]entities.FactValue{
+		"header_version":   &entities.FactValueFloat{Value: 2.1},
+		"number_of_slots":  &entities.FactValueInt{Value: 255},
+		"sector_size":      &entities.FactValueInt{Value: 512},
+		"timeout_allocate": &entities.FactValueInt{Value: 2},
+		"timeout_loop":     &entities.FactValueInt{Value: 1},
+		"timeout_msgwait":  &entities.FactValueInt{Value: 10},
+		"timeout_watchdog": &entities.FactValueInt{Value: 5},
+		"uuid":             &entities.FactValueString{Value: "e09c8993-0cba-438d-a4c3-78e91f58ee52"},
+	}}
+
+	deviceVDCDump := &entities.FactValueMap{Value: map[string]entities.FactValue{
+		"header_version":   &entities.FactValueFloat{Value: 2.1},
+		"number_of_slots":  &entities.FactValueInt{Value: 255},
+		"sector_size":      &entities.FactValueInt{Value: 512},
+		"timeout_allocate": &entities.FactValueInt{Value: 2},
+		"timeout_loop":     &entities.FactValueInt{Value: 1},
+		"timeout_msgwait":  &entities.FactValueInt{Value: 10},
+		"timeout_watchdog": &entities.FactValueInt{Value: 5},
+		"uuid":             &entities.FactValueString{Value: "e5b7c05a-1d3c-43d0-827a-9d4dd05ca54a"},
+	}}
+
+	expectedResults := []entities.Fact{
+		{
+			Name: "sbd_devices_dump",
+			Value: &entities.FactValueMap{Value: map[string]entities.FactValue{
+				"/dev/vdb": deviceVDBDump,
+				"/dev/vdc": deviceVDCDump,
+			}},
+		},
+		{
+			Name: "another_sbd_devices_dump",
+			Value: &entities.FactValueMap{Value: map[string]entities.FactValue{
+				"/dev/vdb": deviceVDBDump,
+				"/dev/vdc": deviceVDCDump,
+			}},
+		},
+	}
+
+	suite.NoError(err)
+	suite.ElementsMatch(expectedResults, factResults)
+}

--- a/test/fixtures/discovery/cluster/sbd/sbd_config_quoted_devices
+++ b/test/fixtures/discovery/cluster/sbd/sbd_config_quoted_devices
@@ -114,5 +114,6 @@ SBD_MOVE_TO_ROOT_CGROUP=auto
 SBD_OPTS=
 SBD_DEVICE="/dev/vdc;/dev/vdb"
 #SBD_DEVICE=/dev/vdc;/dev/vdb
+AN_INTEGER=42
 TEST=Value# Some comment
 TEST2=Value2 # Some comment

--- a/test/fixtures/gatherers/dev.vdb.sbddump.output
+++ b/test/fixtures/gatherers/dev.vdb.sbddump.output
@@ -1,0 +1,10 @@
+==Dumping header on disk /dev/vdb
+Header version     : 2.1
+UUID               : e09c8993-0cba-438d-a4c3-78e91f58ee52
+Number of slots    : 255
+Sector size        : 512
+Timeout (watchdog) : 5
+Timeout (allocate) : 2
+Timeout (loop)     : 1
+Timeout (msgwait)  : 10
+==Header on disk /dev/vdb is dumped

--- a/test/fixtures/gatherers/dev.vdb.sbddump.output
+++ b/test/fixtures/gatherers/dev.vdb.sbddump.output
@@ -1,10 +1,10 @@
 ==Dumping header on disk /dev/vdb
 Header version     : 2.1
 UUID               : e09c8993-0cba-438d-a4c3-78e91f58ee52
-Number of slots    : 255
-Sector size        : 512
-Timeout (watchdog) : 5
+Number of slots    : 188
+Sector size        : 1024
+Timeout (watchdog) : 60
 Timeout (allocate) : 2
-Timeout (loop)     : 1
-Timeout (msgwait)  : 10
+Timeout (loop)     : 3
+Timeout (msgwait)  : 120
 ==Header on disk /dev/vdb is dumped

--- a/test/fixtures/gatherers/dev.vdc.sbddump.output
+++ b/test/fixtures/gatherers/dev.vdc.sbddump.output
@@ -1,0 +1,10 @@
+==Dumping header on disk /dev/vdc
+Header version     : 2.1
+UUID               : e5b7c05a-1d3c-43d0-827a-9d4dd05ca54a
+Number of slots    : 255
+Sector size        : 512
+Timeout (watchdog) : 5
+Timeout (allocate) : 2
+Timeout (loop)     : 1
+Timeout (msgwait)  : 10
+==Header on disk /dev/vdc is dumped


### PR DESCRIPTION
Follows up https://github.com/trento-project/agent/pull/74 and enables porting of checks
- B089BE SBD watchdog timeout is set to expected value
- 68626E SBD `msgwait` timeout value is two times the watchdog timeout

A little sanitization of the keys has been applied to simplify usage of the result at expression level (ie `Timeout (watchdog)` becomes `timeout_watchdog`)

```yaml
facts:
  - name: sbd_devices_dump
    gatherer: sbd_dump

expectations:
  # B089BE
  - name: sbd_watchdog_timeout_is_correct
    expect: facts.sbd_devices_dump.values().all(|device| device.timeout_watchdog == values.expected_watchdog_timeout)

  # 68626E
  - name: sbd_msgwait_timeout_is_double_of_watchdog_timeout
    expect: facts.sbd_devices_dump.values().all(|device| device.timeout_msgwait == 2 * device.timeout_watchdog)
```

Doc added here https://github.com/trento-project/wanda/pull/137