### PR TITLE
Fix list conversion issues in the xml gatherer

### DIFF
--- a/internal/factsengine/gatherers/cibadmin.go
+++ b/internal/factsengine/gatherers/cibadmin.go
@@ -45,8 +45,8 @@ func (g *CibAdminGatherer) Gather(factsRequests []entities.FactRequest) ([]entit
 		return nil, CibAdminCommandError.Wrap(err.Error())
 	}
 
-	elementsToList := []string{"primitive", "clone", "master", "group",
-		"nvpair", "op", "rsc_location", "rsc_order", "rsc_colocation"}
+	elementsToList := map[string]bool{"primitive": true, "clone": true, "master": true, "group": true,
+		"nvpair": true, "op": true, "rsc_location": true, "rsc_order": true, "rsc_colocation": true}
 
 	factValueMap, err := parseXMLToFactValueMap(cibadmin, elementsToList)
 	if err != nil {

--- a/internal/factsengine/gatherers/cibadmin_test.go
+++ b/internal/factsengine/gatherers/cibadmin_test.go
@@ -101,6 +101,12 @@ func (suite *CibAdminTestSuite) TestCibAdminGather() {
 			Argument: "cib.not_found.crm_config",
 			CheckID:  "check3",
 		},
+		{
+			Name:     "primitives",
+			Gatherer: "cibadmin",
+			Argument: "cib.configuration.resources.primitive.0",
+			CheckID:  "check4",
+		},
 	}
 
 	factResults, err := p.Gather(factRequests)
@@ -130,6 +136,33 @@ func (suite *CibAdminTestSuite) TestCibAdminGather() {
 				Type: "value-not-found",
 				Message: "error getting value: requested field value not found: " +
 					"cib.not_found.crm_config"},
+		},
+		{
+			Name: "primitives",
+			Value: &entities.FactValueMap{
+				Value: map[string]entities.FactValue{
+					"id":    &entities.FactValueString{Value: "stonith-sbd"},
+					"class": &entities.FactValueString{Value: "stonith"},
+					"type":  &entities.FactValueString{Value: "external/sbd"},
+					"instance_attributes": &entities.FactValueMap{
+						Value: map[string]entities.FactValue{
+							"id": &entities.FactValueString{Value: "stonith-sbd-instance_attributes"},
+							"nvpair": &entities.FactValueList{
+								Value: []entities.FactValue{
+									&entities.FactValueMap{
+										Value: map[string]entities.FactValue{
+											"id":    &entities.FactValueString{Value: "stonith-sbd-instance_attributes-pcmk_delay_max"},
+											"name":  &entities.FactValueString{Value: "pcmk_delay_max"},
+											"value": &entities.FactValueString{Value: "30s"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			CheckID: "check4",
 		},
 	}
 

--- a/internal/factsengine/gatherers/xml.go
+++ b/internal/factsengine/gatherers/xml.go
@@ -32,26 +32,38 @@ func parseXMLToFactValueMap(xmlContent []byte, elementsToList map[string]bool) (
 	return factValueMap, nil
 }
 
+// convertListElements returns and updated version of the current xml map, where the keys in elementsToList
+// are converted to lists if they are unique entries. This is required due how xml works, as the initial
+// xml to map conversion cannot know if the coming entry is an unique element or not
 func convertListElements(currentMap map[string]interface{}, elementsToList map[string]bool) map[string]interface{} {
 	convertedMap := make(map[string]interface{})
 	for key, value := range currentMap {
 		switch assertedValue := value.(type) {
 		case map[string]interface{}:
-			convertedMap[key] = convertListElements(assertedValue, elementsToList)
-		case []interface{}:
-			newList := []interface{}{}
-			for _, item := range assertedValue {
-				if toMap, ok := item.(map[string]interface{}); ok {
-					newList = append(newList, convertListElements(toMap, elementsToList))
-				} else {
-					newList = append(newList, item)
-				}
+			{
+				convertedMap[key] = convertListElements(assertedValue, elementsToList)
 			}
-			convertedMap[key] = newList
+		// Item is a list, so each element must be treated to see if its children need a conversion.
+		// The items could be maps itself, so they must recurse yet again
+		case []interface{}:
+			{
+				newList := []interface{}{}
+				for _, item := range assertedValue {
+					if toMap, ok := item.(map[string]interface{}); ok {
+						newList = append(newList, convertListElements(toMap, elementsToList))
+					} else {
+						newList = append(newList, item)
+					}
+				}
+				convertedMap[key] = newList
+			}
 		default:
-			convertedMap[key] = assertedValue
+			{
+				convertedMap[key] = assertedValue
+			}
 		}
 
+		// If the current key is not a list and it is included in the elementsToList, initialize as list
 		_, isList := convertedMap[key].([]interface{})
 		if elementsToList[key] && !isList {
 			convertedMap[key] = []interface{}{convertedMap[key]}

--- a/pkg/factsengine/entities/fact_value.go
+++ b/pkg/factsengine/entities/fact_value.go
@@ -39,8 +39,8 @@ func NewFactValue(factInterface interface{}) (FactValue, error) {
 		return &FactValueList{Value: newList}, nil
 	case map[string]interface{}:
 		newMap := make(map[string]FactValue)
-		for key, value := range value {
-			newValue, err := NewFactValue(value)
+		for key, mapValue := range value {
+			newValue, err := NewFactValue(mapValue)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
During the last sprint review I noticed that in some corner cases, the conversion to list was doing something strange.
At the end I have been forced to change how it was, adding some recursive code to convert the desired fields to list properly.

The code might looks complex, what it is what is is in this sort of things on golang...