### PR TITLE
Hidden agent id flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,12 +224,20 @@ You can install it with `go install github.com/vektra/mockery/v2`.
 
 > Be sure to add the `mockery` binary to your `$PATH` environment variable so that `make` can find it. That usually comes with configuring `$GOPATH`, `$GOBIN`, and adding the latter to your `$PATH`.
 
-
-
 > Please note that the `trento agent` component requires to be running on
 > the OS (_not_ inside a container) so, while it is technically possible to run `trento agent`
 > commands in the container, it makes little sense because most of its internals
 > require direct access to the host of the HA Cluster components.
+
+## Fake Agent ID
+
+In some circunstances, having a fake Agent ID might be useful, specially during development and testing stages. The hidden `agent-id` flag is available for that.
+
+Here an example on how to use it:
+
+`./trento-agent start --agent-id "800ddd9b-8497-493f-b9fa-1bd6c9afb230"`
+
+> Don't use this flag on production systems, as the agent ID must be unique by definition and any change affects the whole Trento usage.
 
 ## Fact gathering plugin system
 

--- a/README.md
+++ b/README.md
@@ -231,11 +231,11 @@ You can install it with `go install github.com/vektra/mockery/v2`.
 
 ## Fake Agent ID
 
-In some circunstances, having a fake Agent ID might be useful, specially during development and testing stages. The hidden `agent-id` flag is available for that.
+In some circunstances, having a fake Agent ID might be useful, specially during development and testing stages. The hidden `force-agent-id` flag is available for that.
 
 Here an example on how to use it:
 
-`./trento-agent start --agent-id "800ddd9b-8497-493f-b9fa-1bd6c9afb230"`
+`./trento-agent start --force-agent-id "800ddd9b-8497-493f-b9fa-1bd6c9afb230"`
 
 > Don't use this flag on production systems, as the agent ID must be unique by definition and any change affects the whole Trento usage.
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -52,7 +52,7 @@ func LoadConfig(fileSystem afero.Fs) (*agent.Config, error) {
 		return nil, errors.New("api-key is required, cannot start agent")
 	}
 
-	agentID := viper.GetString("agent-id")
+	agentID := viper.GetString("force-agent-id")
 	if agentID == "" {
 		id, err := agent.GetAgentID(fileSystem)
 		if err != nil {

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/spf13/afero"
 	"github.com/spf13/viper"
 	"github.com/trento-project/agent/internal/agent"
 	"github.com/trento-project/agent/internal/discovery"
@@ -20,7 +21,7 @@ func validatePeriod(durationFlag string, minValue time.Duration) error {
 	return nil
 }
 
-func LoadConfig() (*agent.Config, error) {
+func LoadConfig(fileSystem afero.Fs) (*agent.Config, error) {
 	minPeriodValues := map[string]time.Duration{
 		"cluster-discovery-period":      discovery.ClusterDiscoveryMinPeriod,
 		"sapsystem-discovery-period":    discovery.SAPDiscoveryMinPeriod,
@@ -51,10 +52,19 @@ func LoadConfig() (*agent.Config, error) {
 		return nil, errors.New("api-key is required, cannot start agent")
 	}
 
+	agentID := viper.GetString("agent-id")
+	if agentID == "" {
+		id, err := agent.GetAgentID(fileSystem)
+		if err != nil {
+			return nil, errors.Wrap(err, "could not get the agent ID")
+		}
+		agentID = id
+	}
+
 	collectorConfig := &collector.Config{
 		ServerURL: viper.GetString("server-url"),
 		APIKey:    apiKey,
-		AgentID:   "",
+		AgentID:   agentID,
 	}
 
 	discoveryPeriodsConfig := &discovery.DiscoveriesPeriodConfig{
@@ -72,6 +82,7 @@ func LoadConfig() (*agent.Config, error) {
 	}
 
 	return &agent.Config{
+		AgentID:           agentID,
 		InstanceName:      hostname,
 		DiscoveriesConfig: discoveriesConfig,
 		// Feature flag to enable the facts engine

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -15,36 +15,12 @@ import (
 	"github.com/trento-project/agent/test/helpers"
 )
 
-const hostname = "some-hostname"
-
-// nolint
-var expectedConfig = &agent.Config{
-	AgentID:      "some-agent-id",
-	InstanceName: hostname,
-	DiscoveriesConfig: &discovery.DiscoveriesConfig{
-		SSHAddress: "some-ssh-address",
-		DiscoveriesPeriodsConfig: &discovery.DiscoveriesPeriodConfig{
-			Cluster:      10 * time.Second,
-			SAPSystem:    10 * time.Second,
-			Cloud:        10 * time.Second,
-			Host:         10 * time.Second,
-			Subscription: 900 * time.Second,
-		},
-		CollectorConfig: &collector.Config{
-			ServerURL: "http://serverurl",
-			APIKey:    "some-api-key",
-			AgentID:   "some-agent-id",
-		},
-	},
-	FactsEngineEnabled: false,
-	FactsServiceURL:    "amqp://guest:guest@localhost:5672",
-	PluginsFolder:      "/usr/etc/trento/plugins/",
-}
-
 type AgentCmdTestSuite struct {
 	suite.Suite
-	cmd        *cobra.Command
-	fileSystem afero.Fs
+	cmd            *cobra.Command
+	fileSystem     afero.Fs
+	hostname       string
+	expectedConfig *agent.Config
 }
 
 func TestAgentCmdTestSuite(t *testing.T) {
@@ -71,6 +47,29 @@ func (suite *AgentCmdTestSuite) SetupTest() {
 
 	suite.cmd = cmd
 	suite.fileSystem = helpers.MockMachineIDFile()
+	suite.hostname = "some-hostname"
+	suite.expectedConfig = &agent.Config{
+		AgentID:      "some-agent-id",
+		InstanceName: "some-hostname",
+		DiscoveriesConfig: &discovery.DiscoveriesConfig{
+			SSHAddress: "some-ssh-address",
+			DiscoveriesPeriodsConfig: &discovery.DiscoveriesPeriodConfig{
+				Cluster:      10 * time.Second,
+				SAPSystem:    10 * time.Second,
+				Cloud:        10 * time.Second,
+				Host:         10 * time.Second,
+				Subscription: 900 * time.Second,
+			},
+			CollectorConfig: &collector.Config{
+				ServerURL: "http://serverurl",
+				APIKey:    "some-api-key",
+				AgentID:   "some-agent-id",
+			},
+		},
+		FactsEngineEnabled: false,
+		FactsServiceURL:    "amqp://guest:guest@localhost:5672",
+		PluginsFolder:      "/usr/etc/trento/plugins/",
+	}
 }
 
 func (suite *AgentCmdTestSuite) TestConfigFromFlags() {
@@ -90,10 +89,10 @@ func (suite *AgentCmdTestSuite) TestConfigFromFlags() {
 	_ = suite.cmd.Execute()
 
 	config, err := LoadConfig(suite.fileSystem)
-	config.InstanceName = hostname
+	config.InstanceName = suite.hostname
 	suite.NoError(err)
 
-	suite.EqualValues(expectedConfig, config)
+	suite.EqualValues(suite.expectedConfig, config)
 }
 
 func (suite *AgentCmdTestSuite) TestConfigFromEnv() {
@@ -110,10 +109,10 @@ func (suite *AgentCmdTestSuite) TestConfigFromEnv() {
 	_ = suite.cmd.Execute()
 
 	config, err := LoadConfig(suite.fileSystem)
-	config.InstanceName = hostname
+	config.InstanceName = suite.hostname
 	suite.NoError(err)
 
-	suite.EqualValues(expectedConfig, config)
+	suite.EqualValues(suite.expectedConfig, config)
 }
 
 func (suite *AgentCmdTestSuite) TestConfigFromFile() {
@@ -122,10 +121,10 @@ func (suite *AgentCmdTestSuite) TestConfigFromFile() {
 	_ = suite.cmd.Execute()
 
 	config, err := LoadConfig(suite.fileSystem)
-	config.InstanceName = hostname
+	config.InstanceName = suite.hostname
 	suite.NoError(err)
 
-	suite.EqualValues(expectedConfig, config)
+	suite.EqualValues(suite.expectedConfig, config)
 }
 
 func (suite *AgentCmdTestSuite) TestAgentIDLoaded() {

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -83,7 +83,7 @@ func (suite *AgentCmdTestSuite) TestConfigFromFlags() {
 		"--subscription-discovery-period=900s",
 		"--server-url=http://serverurl",
 		"--api-key=some-api-key",
-		"--agent-id=some-agent-id",
+		"--force-agent-id=some-agent-id",
 	})
 
 	_ = suite.cmd.Execute()
@@ -104,7 +104,7 @@ func (suite *AgentCmdTestSuite) TestConfigFromEnv() {
 	os.Setenv("TRENTO_SUBSCRIPTION_DISCOVERY_PERIOD", "900s")
 	os.Setenv("TRENTO_SERVER_URL", "http://serverurl")
 	os.Setenv("TRENTO_API_KEY", "some-api-key")
-	os.Setenv("TRENTO_AGENT_ID", "some-agent-id")
+	os.Setenv("TRENTO_FORCE_AGENT_ID", "some-agent-id")
 
 	_ = suite.cmd.Execute()
 

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -6,16 +6,45 @@ import (
 	"testing"
 	"time"
 
+	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/suite"
 	"github.com/trento-project/agent/internal/agent"
 	"github.com/trento-project/agent/internal/discovery"
 	"github.com/trento-project/agent/internal/discovery/collector"
+	"github.com/trento-project/agent/test/helpers"
 )
+
+const hostname = "some-hostname"
+
+// nolint
+var expectedConfig = &agent.Config{
+	AgentID:      "some-agent-id",
+	InstanceName: hostname,
+	DiscoveriesConfig: &discovery.DiscoveriesConfig{
+		SSHAddress: "some-ssh-address",
+		DiscoveriesPeriodsConfig: &discovery.DiscoveriesPeriodConfig{
+			Cluster:      10 * time.Second,
+			SAPSystem:    10 * time.Second,
+			Cloud:        10 * time.Second,
+			Host:         10 * time.Second,
+			Subscription: 900 * time.Second,
+		},
+		CollectorConfig: &collector.Config{
+			ServerURL: "http://serverurl",
+			APIKey:    "some-api-key",
+			AgentID:   "some-agent-id",
+		},
+	},
+	FactsEngineEnabled: false,
+	FactsServiceURL:    "amqp://guest:guest@localhost:5672",
+	PluginsFolder:      "/usr/etc/trento/plugins/",
+}
 
 type AgentCmdTestSuite struct {
 	suite.Suite
-	cmd *cobra.Command
+	cmd        *cobra.Command
+	fileSystem afero.Fs
 }
 
 func TestAgentCmdTestSuite(t *testing.T) {
@@ -41,38 +70,7 @@ func (suite *AgentCmdTestSuite) SetupTest() {
 	cmd.SetOut(&b)
 
 	suite.cmd = cmd
-}
-
-func (suite *AgentCmdTestSuite) TearDownTest() {
-	_ = suite.cmd.Execute()
-
-	expectedConfig := &agent.Config{
-		InstanceName: "some-hostname",
-		DiscoveriesConfig: &discovery.DiscoveriesConfig{
-			SSHAddress: "some-ssh-address",
-			DiscoveriesPeriodsConfig: &discovery.DiscoveriesPeriodConfig{
-				Cluster:      10 * time.Second,
-				SAPSystem:    10 * time.Second,
-				Cloud:        10 * time.Second,
-				Host:         10 * time.Second,
-				Subscription: 900 * time.Second,
-			},
-			CollectorConfig: &collector.Config{
-				ServerURL: "http://serverurl",
-				APIKey:    "some-api-key",
-				AgentID:   "",
-			},
-		},
-		FactsEngineEnabled: false,
-		FactsServiceURL:    "amqp://guest:guest@localhost:5672",
-		PluginsFolder:      "/usr/etc/trento/plugins/",
-	}
-
-	config, err := LoadConfig()
-	config.InstanceName = "some-hostname"
-	suite.NoError(err)
-
-	suite.EqualValues(expectedConfig, config)
+	suite.fileSystem = helpers.MockMachineIDFile()
 }
 
 func (suite *AgentCmdTestSuite) TestConfigFromFlags() {
@@ -86,7 +84,16 @@ func (suite *AgentCmdTestSuite) TestConfigFromFlags() {
 		"--subscription-discovery-period=900s",
 		"--server-url=http://serverurl",
 		"--api-key=some-api-key",
+		"--agent-id=some-agent-id",
 	})
+
+	_ = suite.cmd.Execute()
+
+	config, err := LoadConfig(suite.fileSystem)
+	config.InstanceName = hostname
+	suite.NoError(err)
+
+	suite.EqualValues(expectedConfig, config)
 }
 
 func (suite *AgentCmdTestSuite) TestConfigFromEnv() {
@@ -98,8 +105,40 @@ func (suite *AgentCmdTestSuite) TestConfigFromEnv() {
 	os.Setenv("TRENTO_SUBSCRIPTION_DISCOVERY_PERIOD", "900s")
 	os.Setenv("TRENTO_SERVER_URL", "http://serverurl")
 	os.Setenv("TRENTO_API_KEY", "some-api-key")
+	os.Setenv("TRENTO_AGENT_ID", "some-agent-id")
+
+	_ = suite.cmd.Execute()
+
+	config, err := LoadConfig(suite.fileSystem)
+	config.InstanceName = hostname
+	suite.NoError(err)
+
+	suite.EqualValues(expectedConfig, config)
 }
 
 func (suite *AgentCmdTestSuite) TestConfigFromFile() {
 	os.Setenv("TRENTO_CONFIG", "../test/fixtures/config/agent.yaml")
+
+	_ = suite.cmd.Execute()
+
+	config, err := LoadConfig(suite.fileSystem)
+	config.InstanceName = hostname
+	suite.NoError(err)
+
+	suite.EqualValues(expectedConfig, config)
+}
+
+func (suite *AgentCmdTestSuite) TestAgentIDLoaded() {
+	suite.cmd.SetArgs([]string{
+		"start",
+		"--ssh-address=some-ssh-address",
+		"--api-key=some-api-key",
+	})
+
+	_ = suite.cmd.Execute()
+
+	config, err := LoadConfig(suite.fileSystem)
+	suite.NoError(err)
+	suite.Equal(helpers.DummyAgentID, config.AgentID)
+	suite.Equal(helpers.DummyAgentID, config.DiscoveriesConfig.CollectorConfig.AgentID)
 }

--- a/cmd/id.go
+++ b/cmd/id.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"os"
 
+	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/trento-project/agent/internal/agent"
 )
@@ -12,7 +13,7 @@ func NewAgentIDCmd() *cobra.Command {
 		Use:   "id",
 		Short: "Print the agent identifier",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			agentID, err := agent.GetAgentID()
+			agentID, err := agent.GetAgentID(afero.NewOsFs())
 			if err != nil {
 				return err
 			}

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -114,9 +114,9 @@ func NewStartCmd() *cobra.Command {
 	}
 
 	startCmd.Flags().
-		String("agent-id", "", "Agent ID. Used to mock the real ID for development purposes")
+		String("force-agent-id", "", "Agent ID. Used to mock the real ID for development purposes")
 	err = startCmd.Flags().
-		MarkHidden("agent-id")
+		MarkHidden("force-agent-id")
 	if err != nil {
 		panic(err)
 	}

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -3,13 +3,8 @@ package agent
 import (
 	"testing"
 
-	"github.com/spf13/afero"
 	"github.com/stretchr/testify/suite"
-)
-
-const (
-	DummyMachineID = "dummy-machine-id"
-	DummyAgentID   = "779cdd70-e9e2-58ca-b18a-bf3eb3f71244"
+	"github.com/trento-project/agent/test/helpers"
 )
 
 type AgentTestSuite struct {
@@ -20,19 +15,10 @@ func TestAgentTestSuite(t *testing.T) {
 	suite.Run(t, new(AgentTestSuite))
 }
 
-func (suite *AgentTestSuite) SetupSuite() {
-	fileSystem = afero.NewMemMapFs()
-
-	err := afero.WriteFile(fileSystem, machineIDPath, []byte(DummyMachineID), 0644)
-
-	if err != nil {
-		panic(err)
-	}
-}
-
 func (suite *AgentTestSuite) TestAgentGetAgentID() {
-	agentID, err := GetAgentID()
+	fileSystem := helpers.MockMachineIDFile()
+	agentID, err := GetAgentID(fileSystem)
 
 	suite.NoError(err)
-	suite.Equal(DummyAgentID, agentID)
+	suite.Equal(helpers.DummyAgentID, agentID)
 }

--- a/test/fixtures/config/agent.yaml
+++ b/test/fixtures/config/agent.yaml
@@ -6,4 +6,4 @@ sapsystem-discovery-period: 10s
 subscription-discovery-period: 900s
 server-url: http://serverurl
 api-key: some-api-key
-agent-id: some-agent-id
+force-agent-id: some-agent-id

--- a/test/fixtures/config/agent.yaml
+++ b/test/fixtures/config/agent.yaml
@@ -6,3 +6,4 @@ sapsystem-discovery-period: 10s
 subscription-discovery-period: 900s
 server-url: http://serverurl
 api-key: some-api-key
+agent-id: some-agent-id

--- a/test/helpers/filesystem.go
+++ b/test/helpers/filesystem.go
@@ -1,0 +1,25 @@
+package helpers
+
+import (
+	"github.com/spf13/afero"
+)
+
+const (
+	DummyMachineID = "dummy-machine-id"
+	DummyAgentID   = "779cdd70-e9e2-58ca-b18a-bf3eb3f71244"
+
+	machineIDPath = "/etc/machine-id"
+)
+
+// MockMachineIDFile mocks the /etc/machine-id file to have a known value
+func MockMachineIDFile() afero.Fs {
+	fileSystem := afero.NewMemMapFs()
+
+	err := afero.WriteFile(fileSystem, machineIDPath, []byte(DummyMachineID), 0644)
+
+	if err != nil {
+		panic(err)
+	}
+
+	return fileSystem
+}


### PR DESCRIPTION
Add a new hidden `agent-id` flag to have the option to fake the agent id.
This comes handy during development/testing, as you can have predefined IDs, for whatever need you have.

I have added some dependency injection with Afero to manage the filesystem in the `GetAgentID` function. Not so nice to be passing this value all over the places, but well, it makes testing way better.

PD: Finally, I have changed the horrible testing of the `config_test.go` file using the teardown :facepalm: 