### PR TITLE
Add argument validation for gatherers that require it

### DIFF
--- a/internal/factsengine/gatherers/corosynccmapctl.go
+++ b/internal/factsengine/gatherers/corosynccmapctl.go
@@ -60,7 +60,7 @@ func (s *CorosyncCmapctlGatherer) Gather(factsRequests []entities.FactRequest) (
 	for _, factReq := range factsRequests {
 		var fact entities.Fact
 
-		if len(factReq.Argument) < 1 {
+		if len(factReq.Argument) == 0 {
 			log.Error(CorosyncCmapCtlMissingArgument.Message)
 			fact = entities.NewFactGatheredWithError(factReq, &CorosyncCmapCtlMissingArgument)
 		} else if value, ok := corosyncCmapctlMap[factReq.Argument]; ok {

--- a/internal/factsengine/gatherers/corosynccmapctl.go
+++ b/internal/factsengine/gatherers/corosynccmapctl.go
@@ -24,6 +24,11 @@ var (
 		Type:    "corosync-cmapctl-command-error",
 		Message: "error while executing corosynccmap-ctl",
 	}
+
+	CorosyncCmapCtlMissingArgument = entities.FactGatheringError{
+		Type:    "corosync-cmapctl-missing-argument",
+		Message: "missing required argument",
+	}
 )
 
 type CorosyncCmapctlGatherer struct {
@@ -55,7 +60,10 @@ func (s *CorosyncCmapctlGatherer) Gather(factsRequests []entities.FactRequest) (
 	for _, factReq := range factsRequests {
 		var fact entities.Fact
 
-		if value, ok := corosyncCmapctlMap[factReq.Argument]; ok {
+		if len(factReq.Argument) < 1 {
+			log.Error(CorosyncCmapCtlMissingArgument.Message)
+			fact = entities.NewFactGatheredWithError(factReq, &CorosyncCmapCtlMissingArgument)
+		} else if value, ok := corosyncCmapctlMap[factReq.Argument]; ok {
 			fact = entities.NewFactGatheredWithRequest(factReq, entities.ParseStringToFactValue(fmt.Sprint(value)))
 		} else {
 			gatheringError := CorosyncCmapCtlValueNotFound.Wrap(factReq.Argument)

--- a/internal/factsengine/gatherers/corosynccmapctl_test.go
+++ b/internal/factsengine/gatherers/corosynccmapctl_test.go
@@ -26,7 +26,51 @@ func (suite *CorosyncCmapctlTestSuite) SetupTest() {
 	suite.mockExecutor = new(utilsMocks.CommandExecutor)
 }
 
-func (suite *CorosyncCmapctlTestSuite) TestCorosyncCmapctlGathererMissingFact() {
+func (suite *CorosyncCmapctlTestSuite) TestCorosyncCmapctlGathererNoArgumentProvided() {
+	mockOutputFile, _ := os.Open(helpers.GetFixturePath("gatherers/corosynccmap-ctl.output"))
+	mockOutput, _ := io.ReadAll(mockOutputFile)
+	suite.mockExecutor.On("Exec", "corosync-cmapctl", "-b").Return(mockOutput, nil)
+
+	c := gatherers.NewCorosyncCmapctlGatherer(suite.mockExecutor)
+
+	factRequests := []entities.FactRequest{
+		{
+			Name:     "no_argument_fact",
+			Gatherer: "corosync-cmapctl",
+		},
+		{
+			Name:     "empty_argument_fact",
+			Gatherer: "corosync-cmapctl",
+			Argument: "",
+		},
+	}
+
+	factResults, err := c.Gather(factRequests)
+
+	expectedResults := []entities.Fact{
+		{
+			Name:  "no_argument_fact",
+			Value: nil,
+			Error: &entities.FactGatheringError{
+				Message: "missing required argument",
+				Type:    "corosync-cmapctl-missing-argument",
+			},
+		},
+		{
+			Name:  "empty_argument_fact",
+			Value: nil,
+			Error: &entities.FactGatheringError{
+				Message: "missing required argument",
+				Type:    "corosync-cmapctl-missing-argument",
+			},
+		},
+	}
+
+	suite.NoError(err)
+	suite.ElementsMatch(expectedResults, factResults)
+}
+
+func (suite *CorosyncCmapctlTestSuite) TestCorosyncCmapctlGathererNonExistingKey() {
 	mockOutputFile, _ := os.Open(helpers.GetFixturePath("gatherers/corosynccmap-ctl.output"))
 	mockOutput, _ := io.ReadAll(mockOutputFile)
 	suite.mockExecutor.On("Exec", "corosync-cmapctl", "-b").Return(mockOutput, nil)

--- a/internal/factsengine/gatherers/packageversion.go
+++ b/internal/factsengine/gatherers/packageversion.go
@@ -16,6 +16,7 @@ var (
 		Type:    "package-version-cmd-error",
 		Message: "error getting version of package",
 	}
+
 	PackageVersionMissingArgument = entities.FactGatheringError{
 		Type:    "package-version-missing-argument",
 		Message: "missing required argument",

--- a/internal/factsengine/gatherers/packageversion.go
+++ b/internal/factsengine/gatherers/packageversion.go
@@ -16,6 +16,10 @@ var (
 		Type:    "package-version-cmd-error",
 		Message: "error getting version of package",
 	}
+	PackageVersionMissingArgument = entities.FactGatheringError{
+		Type:    "package-version-missing-argument",
+		Message: "missing required argument",
+	}
 )
 
 type PackageVersionGatherer struct {
@@ -38,6 +42,13 @@ func (g *PackageVersionGatherer) Gather(factsRequests []entities.FactRequest) ([
 
 	for _, factReq := range factsRequests {
 		var fact entities.Fact
+		if len(factReq.Argument) < 1 {
+			log.Error(PackageVersionMissingArgument.Message)
+			fact = entities.NewFactGatheredWithError(factReq, &PackageVersionMissingArgument)
+			facts = append(facts, fact)
+			continue
+		}
+
 		version, err := g.executor.Exec(
 			"rpm", "-q", "--qf", "%{VERSION}", factReq.Argument)
 		if err != nil {

--- a/internal/factsengine/gatherers/packageversion.go
+++ b/internal/factsengine/gatherers/packageversion.go
@@ -43,7 +43,7 @@ func (g *PackageVersionGatherer) Gather(factsRequests []entities.FactRequest) ([
 
 	for _, factReq := range factsRequests {
 		var fact entities.Fact
-		if len(factReq.Argument) < 1 {
+		if len(factReq.Argument) == 0 {
 			log.Error(PackageVersionMissingArgument.Message)
 			fact = entities.NewFactGatheredWithError(factReq, &PackageVersionMissingArgument)
 			facts = append(facts, fact)

--- a/internal/factsengine/gatherers/saphostctrl.go
+++ b/internal/factsengine/gatherers/saphostctrl.go
@@ -33,14 +33,17 @@ var (
 		Type:    "saphostctrl-cmd-error",
 		Message: "error executing saphostctrl command",
 	}
+
 	SapHostCtrlUnsupportedFunction = entities.FactGatheringError{
 		Type:    "saphostctrl-webmethod-error",
 		Message: "requested webmethod not supported",
 	}
+
 	SapHostCtrlParseError = entities.FactGatheringError{
 		Type:    "saphostctrl-parse-error",
 		Message: "error while parsing saphostctrl output",
 	}
+
 	SapHostCtrlMissingArgument = entities.FactGatheringError{
 		Type:    "saphostctrl-missing-argument",
 		Message: "missing required argument",

--- a/internal/factsengine/gatherers/saphostctrl.go
+++ b/internal/factsengine/gatherers/saphostctrl.go
@@ -41,6 +41,10 @@ var (
 		Type:    "saphostctrl-parse-error",
 		Message: "error while parsing saphostctrl output",
 	}
+	SapHostCtrlMissingArgument = entities.FactGatheringError{
+		Type:    "saphostctrl-missing-argument",
+		Message: "missing required argument",
+	}
 )
 
 type SapHostCtrlGatherer struct {
@@ -63,8 +67,10 @@ func (g *SapHostCtrlGatherer) Gather(factsRequests []entities.FactRequest) ([]en
 
 	for _, factReq := range factsRequests {
 		var fact entities.Fact
-
-		if factValue, err := handleWebmethod(g.executor, factReq.Argument); err != nil {
+		if len(factReq.Argument) < 1 {
+			log.Error(SapHostCtrlMissingArgument.Message)
+			fact = entities.NewFactGatheredWithError(factReq, &SapHostCtrlMissingArgument)
+		} else if factValue, err := handleWebmethod(g.executor, factReq.Argument); err != nil {
 			fact = entities.NewFactGatheredWithError(factReq, err)
 		} else {
 			fact = entities.NewFactGatheredWithRequest(factReq, factValue)

--- a/internal/factsengine/gatherers/saphostctrl.go
+++ b/internal/factsengine/gatherers/saphostctrl.go
@@ -70,7 +70,7 @@ func (g *SapHostCtrlGatherer) Gather(factsRequests []entities.FactRequest) ([]en
 
 	for _, factReq := range factsRequests {
 		var fact entities.Fact
-		if len(factReq.Argument) < 1 {
+		if len(factReq.Argument) == 0 {
 			log.Error(SapHostCtrlMissingArgument.Message)
 			fact = entities.NewFactGatheredWithError(factReq, &SapHostCtrlMissingArgument)
 		} else if factValue, err := handleWebmethod(g.executor, factReq.Argument); err != nil {

--- a/internal/factsengine/gatherers/sbd.go
+++ b/internal/factsengine/gatherers/sbd.go
@@ -55,7 +55,7 @@ func (g *SBDGatherer) Gather(factsRequests []entities.FactRequest) ([]entities.F
 	for _, requestedFact := range factsRequests {
 		var fact entities.Fact
 
-		if len(requestedFact.Argument) < 1 {
+		if len(requestedFact.Argument) == 0 {
 			log.Error(SBDConfigMissingArgument.Message)
 			fact = entities.NewFactGatheredWithError(requestedFact, &SBDConfigMissingArgument)
 		} else if value, found := conf[requestedFact.Argument]; found {

--- a/internal/factsengine/gatherers/sbd.go
+++ b/internal/factsengine/gatherers/sbd.go
@@ -21,6 +21,11 @@ var (
 		Type:    "sbd-config-value-not-found",
 		Message: "requested field value not found",
 	}
+
+	SBDConfigMissingArgument = entities.FactGatheringError{
+		Type:    "sbd-config-missing-argument",
+		Message: "missing required argument",
+	}
 )
 
 type SBDGatherer struct {
@@ -49,7 +54,11 @@ func (g *SBDGatherer) Gather(factsRequests []entities.FactRequest) ([]entities.F
 
 	for _, requestedFact := range factsRequests {
 		var fact entities.Fact
-		if value, found := conf[requestedFact.Argument]; found {
+
+		if len(requestedFact.Argument) < 1 {
+			log.Error(SBDConfigMissingArgument.Message)
+			fact = entities.NewFactGatheredWithError(requestedFact, &SBDConfigMissingArgument)
+		} else if value, found := conf[requestedFact.Argument]; found {
 			fact = entities.NewFactGatheredWithRequest(requestedFact, entities.ParseStringToFactValue(value))
 		} else {
 			gatheringError := SBDConfigValueNotFoundError.Wrap(requestedFact.Argument)

--- a/internal/factsengine/gatherers/sbd_test.go
+++ b/internal/factsengine/gatherers/sbd_test.go
@@ -17,6 +17,46 @@ func TestSBDGathererTestSuite(t *testing.T) {
 	suite.Run(t, new(SBDGathererTestSuite))
 }
 
+func (suite *SBDGathererTestSuite) TestConfigFileNoArgumentProvided() {
+	requestedFacts := []entities.FactRequest{
+		{
+			Name:     "no_argument_fact",
+			Gatherer: "sbd_config",
+		},
+		{
+			Name:     "empty_argument_fact",
+			Gatherer: "sbd_config",
+			Argument: "",
+		},
+	}
+
+	gatherer := gatherers.NewSBDGatherer(helpers.GetFixturePath("discovery/cluster/sbd/sbd_config"))
+
+	gatheredFacts, err := gatherer.Gather(requestedFacts)
+
+	expectedFacts := []entities.Fact{
+		{
+			Name:  "no_argument_fact",
+			Value: nil,
+			Error: &entities.FactGatheringError{
+				Type:    "sbd-config-missing-argument",
+				Message: "missing required argument",
+			},
+		},
+		{
+			Name:  "empty_argument_fact",
+			Value: nil,
+			Error: &entities.FactGatheringError{
+				Type:    "sbd-config-missing-argument",
+				Message: "missing required argument",
+			},
+		},
+	}
+
+	suite.NoError(err)
+	suite.ElementsMatch(expectedFacts, gatheredFacts)
+}
+
 func (suite *SBDGathererTestSuite) TestConfigFileCouldNotBeRead() {
 	requestedFacts := []entities.FactRequest{}
 

--- a/internal/factsengine/gatherers/systemd.go
+++ b/internal/factsengine/gatherers/systemd.go
@@ -72,6 +72,9 @@ func (g *SystemDGatherer) Gather(factsRequests []entities.FactRequest) ([]entiti
 
 	services := []string{}
 	for _, factReq := range factsRequests {
+		if len(factReq.Argument) < 1 {
+			continue
+		}
 		services = append(services, completeServiceName(factReq.Argument))
 	}
 
@@ -99,9 +102,5 @@ func (g *SystemDGatherer) Gather(factsRequests []entities.FactRequest) ([]entiti
 }
 
 func completeServiceName(service string) string {
-	if len(service) < 1 {
-		return ""
-	}
-
 	return fmt.Sprintf("%s.service", service)
 }

--- a/internal/factsengine/gatherers/systemd.go
+++ b/internal/factsengine/gatherers/systemd.go
@@ -72,7 +72,7 @@ func (g *SystemDGatherer) Gather(factsRequests []entities.FactRequest) ([]entiti
 
 	services := []string{}
 	for _, factReq := range factsRequests {
-		if len(factReq.Argument) < 1 {
+		if len(factReq.Argument) == 0 {
 			continue
 		}
 		services = append(services, completeServiceName(factReq.Argument))
@@ -86,7 +86,7 @@ func (g *SystemDGatherer) Gather(factsRequests []entities.FactRequest) ([]entiti
 	}
 
 	for index, factReq := range factsRequests {
-		if len(factReq.Argument) < 1 {
+		if len(factReq.Argument) == 0 {
 			log.Error(SystemDMissingArgument.Message)
 			fact := entities.NewFactGatheredWithError(factReq, &SystemDMissingArgument)
 			facts = append(facts, fact)

--- a/internal/factsengine/gatherers/systemd_test.go
+++ b/internal/factsengine/gatherers/systemd_test.go
@@ -21,6 +21,55 @@ func TestSystemDTestSuite(t *testing.T) {
 	suite.Run(t, new(SystemDTestSuite))
 }
 
+func (suite *SystemDTestSuite) TestSystemDNoArgumentProvided() {
+	mockConnector := new(mocks.DbusConnector)
+
+	mockConnector.On("ListUnitsByNamesContext", mock.Anything, []string{}).Return(
+		nil, nil)
+
+	s := gatherers.NewSystemDGatherer(mockConnector, true)
+
+	factRequests := []entities.FactRequest{
+		{
+			Name:     "no_argument_fact",
+			Gatherer: "systemd",
+			CheckID:  "check1",
+		},
+		{
+			Name:     "empty_argument_fact",
+			Gatherer: "systemd",
+			Argument: "",
+			CheckID:  "check2",
+		},
+	}
+
+	factResults, err := s.Gather(factRequests)
+
+	expectedResults := []entities.Fact{
+		{
+			Name:    "no_argument_fact",
+			CheckID: "check1",
+			Value:   nil,
+			Error: &entities.FactGatheringError{
+				Message: "missing required argument",
+				Type:    "systemd-missing-argument",
+			},
+		},
+		{
+			Name:    "empty_argument_fact",
+			CheckID: "check2",
+			Value:   nil,
+			Error: &entities.FactGatheringError{
+				Message: "missing required argument",
+				Type:    "systemd-missing-argument",
+			},
+		},
+	}
+
+	suite.NoError(err)
+	suite.ElementsMatch(expectedResults, factResults)
+}
+
 func (suite *SystemDTestSuite) TestSystemDGather() {
 	mockConnector := new(mocks.DbusConnector)
 


### PR DESCRIPTION
This PR adds argument checks for gatherers which require it. When either no argument is provided or an empty (`""`) argument is provided, the gathers that require an argument should fail gracefully.

Example:

```
➜  ~ ./trento-agent facts gather --gatherer package_version
INFO[2022-12-27 16:01:09] Using config file: /etc/trento/agent.yaml    
INFO[2022-12-27 16:01:09] loading plugins                              
INFO[2022-12-27 16:01:09] Starting package_version facts gathering process 
ERRO[2022-12-27 16:01:09] missing required argument                    
INFO[2022-12-27 16:01:09] Requested package_version facts gathered     
INFO[2022-12-27 16:01:09] Gathered fact for "package_version" with argument "": 
INFO[2022-12-27 16:01:09] {
  "Name": "",
  "CheckID": "",
  "Value": null,
  "Error": {
    "Message": "missing required argument",
    "Type": "package-version-missing-argument"
  }
} 
```
and
```
➜  ~ ./trento-agent facts gather --gatherer package_version --argument ""
INFO[2022-12-27 16:01:15] Using config file: /etc/trento/agent.yaml    
INFO[2022-12-27 16:01:15] loading plugins                              
INFO[2022-12-27 16:01:15] Starting package_version facts gathering process 
ERRO[2022-12-27 16:01:15] missing required argument                    
INFO[2022-12-27 16:01:15] Requested package_version facts gathered     
INFO[2022-12-27 16:01:15] Gathered fact for "package_version" with argument "": 
INFO[2022-12-27 16:01:15] {
  "Name": "",
  "CheckID": "",
  "Value": null,
  "Error": {
    "Message": "missing required argument",
    "Type": "package-version-missing-argument"
  }
} 
```