### PR TITLE
[WIP]: Add a sapcontrol gatherer

### DIFF
--- a/internal/factsengine/gatherers/sapcontrol.go
+++ b/internal/factsengine/gatherers/sapcontrol.go
@@ -1,0 +1,177 @@
+package gatherers
+
+import (
+	"regexp"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/trento-project/agent/pkg/factsengine/entities"
+	"github.com/trento-project/agent/pkg/utils"
+)
+
+const (
+	SapControlGathererName = "sapcontrol"
+)
+
+// nolint:gochecknoglobals
+var (
+	sapControlGetProcessListRegexp        = regexp.MustCompile(`^([^,]+),\s+(.+),\s+(.+),\s+(.+),\s+(.+),\s+(.+),\s+(\d+)`)
+	sapControlGetSystemInstanceListRegexp = regexp.MustCompile(`^([^,]+),\s+(\d+),\s+(\d+),\s+(\d+),\s+(.+),\s+(.+),\s+(.+)`)
+)
+
+// nolint:gochecknoglobals
+var whitelistedSapControlWebmethods = map[string]func(string) (entities.FactValue, *entities.FactGatheringError){
+	"CheckHostAgent":        parsecheckHostAgent,
+	"GetProcessList":        parseGetProcessList,
+	"GetSystemInstanceList": parseGetSystemInstanceList,
+}
+
+// nolint:gochecknoglobals
+var (
+	SapControlCommandError = entities.FactGatheringError{
+		Type:    "sapcontrol-cmd-error",
+		Message: "error executing sapcontrol command",
+	}
+
+	SapControlMissingArgument = entities.FactGatheringError{
+		Type:    "sapcontrol-missing-argument",
+		Message: "missing required argument",
+	}
+
+	SapControlUnsupportedFunction = entities.FactGatheringError{
+		Type:    "sapcontrol-webmethod-error",
+		Message: "requested webmethod not supported",
+	}
+
+	SapControlParseError = entities.FactGatheringError{
+		Type:    "sapcontrol-parse-error",
+		Message: "error while parsing sapcontrol output",
+	}
+)
+
+type SapControlGatherer struct {
+	executor utils.CommandExecutor
+}
+
+func NewDefaultSapControlGatherer() *SapControlGatherer {
+	return NewSapControlGatherer(utils.Executor{})
+}
+
+func NewSapControlGatherer(executor utils.CommandExecutor) *SapControlGatherer {
+	return &SapControlGatherer{
+		executor: executor,
+	}
+}
+
+func (s *SapControlGatherer) Gather(factsRequests []entities.FactRequest) ([]entities.Fact, error) {
+	facts := []entities.Fact{}
+	log.Infof("Starting sapcontrol facts gathering process")
+
+	for _, factReq := range factsRequests {
+		var fact entities.Fact
+		if len(factReq.Argument) == 0 {
+			log.Error(SapControlMissingArgument.Message)
+			fact = entities.NewFactGatheredWithError(factReq, &SapControlMissingArgument)
+		} else if factValue, err := handleSapControlWebMethod(s.executor, factReq.Argument); err != nil {
+			fact = entities.NewFactGatheredWithError(factReq, err)
+		} else {
+			fact = entities.NewFactGatheredWithRequest(factReq, factValue)
+		}
+
+		facts = append(facts, fact)
+	}
+
+	log.Infof("Requested %s facts gathered", SapControlGathererName)
+	return facts, nil
+}
+
+func handleSapControlWebMethod(
+	executor utils.CommandExecutor,
+	webMethod string,
+) (entities.FactValue, *entities.FactGatheringError) {
+	webMethodHandler, ok := whitelistedSapControlWebmethods[webMethod]
+
+	if !ok {
+		gatheringError := SapControlUnsupportedFunction.Wrap(webMethod)
+		log.Error(gatheringError)
+		return nil, gatheringError
+	}
+
+	sapcontrol, commandError := executeSapControlCommand(executor, webMethod)
+	if commandError != nil {
+		return nil, commandError
+	}
+
+	return webMethodHandler(sapcontrol)
+}
+
+func executeSapControlCommand(executor utils.CommandExecutor, command string) (string, *entities.FactGatheringError) {
+	sapControlOutput, err := executor.Exec("/usr/sap/hostctrl/exe/sapcontrol", "-nr", "00", "-function", command)
+	if err != nil {
+		gatheringError := SapControlCommandError.Wrap(err.Error())
+		log.Error(gatheringError)
+		return "", gatheringError
+	}
+
+	return string(sapControlOutput), nil
+}
+
+func parsecheckHostAgent(sapControlOutput string) (entities.FactValue, *entities.FactGatheringError) {
+	if sapControlOutput == "" {
+		gatheringError := SapControlParseError.Wrap("empty output")
+		log.Error(gatheringError)
+		return nil, gatheringError
+	} else {
+		return &entities.FactValueBool{Value: (sapControlOutput == "SAPHostAgent Installed\n")}, nil
+	}
+}
+
+func parseGetProcessList(sapControlOutput string) (entities.FactValue, *entities.FactGatheringError) {
+	lines := strings.Split(sapControlOutput, "\n")
+
+	processes := []entities.FactValue{}
+
+	for _, line := range lines {
+		if matches := sapControlGetProcessListRegexp.FindStringSubmatch(line); len(matches) > 0 {
+			process := map[string]entities.FactValue{}
+			process["name"] = &entities.FactValueString{Value: matches[1]}
+			process["description"] = &entities.FactValueString{Value: matches[2]}
+			process["dispstatus"] = &entities.FactValueString{Value: matches[3]}
+			process["textstatus"] = &entities.FactValueString{Value: matches[4]}
+			process["starttime"] = &entities.FactValueString{Value: matches[5]}
+			process["elapsedtime"] = &entities.FactValueString{Value: matches[6]}
+			process["pid"] = entities.ParseStringToFactValue(matches[7])
+			processes = append(processes, &entities.FactValueMap{Value: process})
+		}
+	}
+
+	result := &entities.FactValueList{Value: processes}
+
+	return result, nil
+}
+
+func parseGetSystemInstanceList(sapControlOutput string) (entities.FactValue, *entities.FactGatheringError) {
+	lines := strings.Split(sapControlOutput, "\n")
+
+	instances := []entities.FactValue{}
+
+	for _, line := range lines {
+		if matches := sapControlGetSystemInstanceListRegexp.FindStringSubmatch(line); len(matches) > 0 {
+			instance := map[string]entities.FactValue{}
+
+			instance["hostname"] = &entities.FactValueString{Value: matches[1]}
+			instance["instanceNr"] = &entities.FactValueString{Value: matches[2]}
+			instance["httpPort"] = entities.ParseStringToFactValue(matches[3])
+			instance["httpsPort"] = entities.ParseStringToFactValue(matches[4])
+			instance["startPriority"] = &entities.FactValueString{Value: matches[5]}
+			instance["features"] = &entities.FactValueString{Value: matches[6]}
+			instance["dispstatus"] = &entities.FactValueString{Value: matches[7]}
+
+			instances = append(instances, &entities.FactValueMap{Value: instance})
+		}
+	}
+
+	result := &entities.FactValueList{Value: instances}
+
+	return result, nil
+}

--- a/internal/factsengine/gatherers/sapcontrol_test.go
+++ b/internal/factsengine/gatherers/sapcontrol_test.go
@@ -1,0 +1,306 @@
+package gatherers_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/trento-project/agent/internal/factsengine/gatherers"
+	"github.com/trento-project/agent/pkg/factsengine/entities"
+	utilsMocks "github.com/trento-project/agent/pkg/utils/mocks"
+)
+
+type SapControlTestSuite struct {
+	suite.Suite
+	mockExecutor *utilsMocks.CommandExecutor
+}
+
+func TestSapControlTestSuite(t *testing.T) {
+	suite.Run(t, new(SapControlTestSuite))
+}
+
+func (suite *SapControlTestSuite) SetupTest() {
+	suite.mockExecutor = new(utilsMocks.CommandExecutor)
+}
+
+func (suite *SapControlTestSuite) TestSapControlGathererNoArgumentProvided() {
+	c := gatherers.NewSapControlGatherer(suite.mockExecutor)
+
+	factRequests := []entities.FactRequest{
+		{
+			Name:     "no_argument_fact",
+			Gatherer: "sapcontrol",
+		},
+		{
+			Name:     "empty_argument_fact",
+			Gatherer: "sapcontrol",
+			Argument: "",
+		},
+	}
+
+	factResults, err := c.Gather(factRequests)
+
+	expectedResults := []entities.Fact{
+		{
+			Name:  "no_argument_fact",
+			Value: nil,
+			Error: &entities.FactGatheringError{
+				Message: "missing required argument",
+				Type:    "sapcontrol-missing-argument",
+			},
+		},
+		{
+			Name:  "empty_argument_fact",
+			Value: nil,
+			Error: &entities.FactGatheringError{
+				Message: "missing required argument",
+				Type:    "sapcontrol-missing-argument",
+			},
+		},
+	}
+
+	suite.NoError(err)
+	suite.ElementsMatch(expectedResults, factResults)
+}
+
+func (suite *SapControlTestSuite) TestSapControlGatherCheckHostAgent() {
+	suite.mockExecutor.On("Exec", "/usr/sap/hostctrl/exe/sapcontrol", "-nr", "00", "-function", "CheckHostAgent").Return(
+		[]byte("SAPHostAgent Installed\n"), nil)
+
+	p := gatherers.NewSapControlGatherer(suite.mockExecutor)
+
+	factRequests := []entities.FactRequest{
+		{
+			Name:     "check_host_agent",
+			Gatherer: "sapcontrol",
+			Argument: "CheckHostAgent",
+			CheckID:  "check1",
+		},
+	}
+
+	factResults, err := p.Gather(factRequests)
+
+	expectedResults := []entities.Fact{
+		{
+			Name:    "checkhostagent",
+			CheckID: "check1",
+			Value:   &entities.FactValueBool{Value: true},
+		},
+	}
+
+	suite.NoError(err)
+	suite.ElementsMatch(expectedResults, factResults)
+}
+
+func (suite *SapControlTestSuite) TestSapControlGatherGetProcessList() {
+	suite.mockExecutor.On("Exec", "/usr/sap/hostctrl/exe/sapcontrol", "-nr", "00", "-function", "GetProcessList").Return(
+		[]byte(" \n"+
+			"09.01.2023 13:14:08\n"+
+			"GetProcessList\n"+
+			"OK\n"+
+			"name, description, dispstatus, textstatus, starttime, elapsedtime, pid\n"+
+			"hdbdaemon, HDB Daemon, GREEN, Running, 2022 02 11 18:32:06, 7962:42:02, 7570\n"+
+			"hdbcompileserver, HDB Compileserver, GREEN, Running, 2022 02 11 18:32:26, 7962:41:42, 8073\n"+
+			"hdbindexserver, HDB Indexserver-PRD, GREEN, Running, 2022 02 11 18:32:28, 7962:41:40, 8356\n"+
+			"hdbnameserver, HDB Nameserver, GREEN, Running, 2022 02 11 18:32:07, 7962:42:01, 7588\n"+
+			"hdbpreprocessor, HDB Preprocessor, GREEN, Running, 2022 02 11 18:32:26, 7962:41:42, 8076\n"+
+			"hdbwebdispatcher, HDB Web Dispatcher, GREEN, Running, 2022 02 11 18:32:44, 7962:41:24, 9240\n"+
+			"hdbxsengine, HDB XSEngine-PRD, GREEN, Running, 2022 02 11 18:32:28, 7962:41:40, 8359\n"), nil)
+
+	p := gatherers.NewSapControlGatherer(suite.mockExecutor)
+
+	factRequests := []entities.FactRequest{
+		{
+			Name:     "get_process_list",
+			Gatherer: "sapcontrol",
+			Argument: "GetProcessList",
+			CheckID:  "check2",
+		},
+	}
+
+	factResults, err := p.Gather(factRequests)
+
+	expectedResults := []entities.Fact{
+		{
+			Name:    "get_process_list",
+			CheckID: "check2",
+			Value: &entities.FactValueList{Value: []entities.FactValue{
+				&entities.FactValueMap{Value: map[string]entities.FactValue{
+					"name":        &entities.FactValueString{Value: "hdbdaemon"},
+					"description": &entities.FactValueString{Value: "HDB Daemon"},
+					"dispstatus":  &entities.FactValueString{Value: "GREEN"},
+					"textstatus":  &entities.FactValueString{Value: "Running"},
+					"starttime":   &entities.FactValueString{Value: "2022 02 11 18:32:06"},
+					"elapsedtime": &entities.FactValueString{Value: "7962:42:02"},
+					"pid":         &entities.FactValueInt{Value: 7570},
+				}},
+				&entities.FactValueMap{Value: map[string]entities.FactValue{
+					"name":        &entities.FactValueString{Value: "hdbcompileserver"},
+					"description": &entities.FactValueString{Value: "HDB Compileserver"},
+					"dispstatus":  &entities.FactValueString{Value: "GREEN"},
+					"textstatus":  &entities.FactValueString{Value: "Running"},
+					"starttime":   &entities.FactValueString{Value: "2022 02 11 18:32:26"},
+					"elapsedtime": &entities.FactValueString{Value: "7962:41:42"},
+					"pid":         &entities.FactValueInt{Value: 8073},
+				}},
+				&entities.FactValueMap{Value: map[string]entities.FactValue{
+					"name":        &entities.FactValueString{Value: "hdbindexserver"},
+					"description": &entities.FactValueString{Value: "HDB Indexserver-PRD"},
+					"dispstatus":  &entities.FactValueString{Value: "GREEN"},
+					"textstatus":  &entities.FactValueString{Value: "Running"},
+					"starttime":   &entities.FactValueString{Value: "2022 02 11 18:32:28"},
+					"elapsedtime": &entities.FactValueString{Value: "7962:41:40"},
+					"pid":         &entities.FactValueInt{Value: 8356},
+				}},
+				&entities.FactValueMap{Value: map[string]entities.FactValue{
+					"name":        &entities.FactValueString{Value: "hdbnameserver"},
+					"description": &entities.FactValueString{Value: "HDB Nameserver"},
+					"dispstatus":  &entities.FactValueString{Value: "GREEN"},
+					"textstatus":  &entities.FactValueString{Value: "Running"},
+					"starttime":   &entities.FactValueString{Value: "2022 02 11 18:32:07"},
+					"elapsedtime": &entities.FactValueString{Value: "7962:42:01"},
+					"pid":         &entities.FactValueInt{Value: 7588},
+				}},
+				&entities.FactValueMap{Value: map[string]entities.FactValue{
+					"name":        &entities.FactValueString{Value: "hdbpreprocessor"},
+					"description": &entities.FactValueString{Value: "HDB Preprocessor"},
+					"dispstatus":  &entities.FactValueString{Value: "GREEN"},
+					"textstatus":  &entities.FactValueString{Value: "Running"},
+					"starttime":   &entities.FactValueString{Value: "2022 02 11 18:32:26"},
+					"elapsedtime": &entities.FactValueString{Value: "7962:41:42"},
+					"pid":         &entities.FactValueInt{Value: 8076},
+				}},
+				&entities.FactValueMap{Value: map[string]entities.FactValue{
+					"name":        &entities.FactValueString{Value: "hdbwebdispatcher"},
+					"description": &entities.FactValueString{Value: "HDB Web Dispatcher"},
+					"dispstatus":  &entities.FactValueString{Value: "GREEN"},
+					"textstatus":  &entities.FactValueString{Value: "Running"},
+					"starttime":   &entities.FactValueString{Value: "2022 02 11 18:32:44"},
+					"elapsedtime": &entities.FactValueString{Value: "7962:41:24"},
+					"pid":         &entities.FactValueInt{Value: 9240},
+				}},
+				&entities.FactValueMap{Value: map[string]entities.FactValue{
+					"name":        &entities.FactValueString{Value: "hdbxsengine"},
+					"description": &entities.FactValueString{Value: "HDB XSEngine-PRD"},
+					"dispstatus":  &entities.FactValueString{Value: "GREEN"},
+					"textstatus":  &entities.FactValueString{Value: "Running"},
+					"starttime":   &entities.FactValueString{Value: "2022 02 11 18:32:28"},
+					"elapsedtime": &entities.FactValueString{Value: "7962:41:40"},
+					"pid":         &entities.FactValueInt{Value: 8359},
+				}},
+			}},
+		},
+	}
+
+	suite.NoError(err)
+	suite.ElementsMatch(expectedResults, factResults)
+}
+
+func (suite *SapControlTestSuite) TestSapControlGatherGetSystemInstanceList() {
+	suite.mockExecutor.On("Exec", "/usr/sap/hostctrl/exe/sapcontrol", "-nr", "00", "-function", "GetSystemInstanceList").Return(
+		[]byte(" \n"+
+			"09.01.2023 13:14:15\n"+
+			"GetSystemInstanceList\n"+
+			"OK\n"+
+			"hostname, instanceNr, httpPort, httpsPort, startPriority, features, dispstatus\n"+
+			"somehost-vmhana02, 0, 50013, 50014, 0.3, HDB|HDB_WORKER, GREEN\n"), nil)
+
+	p := gatherers.NewSapControlGatherer(suite.mockExecutor)
+
+	factRequests := []entities.FactRequest{
+		{
+			Name:     "get_system_instance_list",
+			Gatherer: "sapcontrol",
+			Argument: "GetSystemInstanceList",
+			CheckID:  "check2",
+		},
+	}
+
+	factResults, err := p.Gather(factRequests)
+
+	expectedResults := []entities.Fact{
+		{
+			Name:    "get_system_instance_list",
+			CheckID: "check2",
+			Value: &entities.FactValueList{Value: []entities.FactValue{
+				&entities.FactValueMap{Value: map[string]entities.FactValue{
+					"hostname":      &entities.FactValueString{Value: "somehost-vmhana02"},
+					"instanceNr":    &entities.FactValueString{Value: "0"},
+					"startPriority": &entities.FactValueString{Value: "0.3"},
+					"httpPort":      &entities.FactValueInt{Value: 50013},
+					"httpsPort":     &entities.FactValueInt{Value: 50014},
+					"features":      &entities.FactValueString{Value: "HDB|HDB_WORKER"},
+					"dispstatus":    &entities.FactValueString{Value: "GREEN"},
+				}},
+			}},
+		},
+	}
+
+	suite.NoError(err)
+	suite.ElementsMatch(expectedResults, factResults)
+}
+
+func (suite *SapControlTestSuite) TestSapControlGatherError() {
+	suite.mockExecutor.On("Exec", "/usr/sap/hostctrl/exe/sapcontrol", "-nr", "00", "-function", "CheckHostAgent").Return(
+		[]byte(""), nil)
+	suite.mockExecutor.On("Exec", "/usr/sap/hostctrl/exe/sapcontrol", "-nr", "00", "-function", "GetSystemInstanceList").Return(
+		nil, errors.New("some error"))
+
+	p := gatherers.NewSapControlGatherer(suite.mockExecutor)
+
+	factRequests := []entities.FactRequest{
+		{
+			Name:     "check_host_agent",
+			Gatherer: "sapcontrol",
+			Argument: "CheckHostAgent",
+			CheckID:  "check1",
+		},
+		{
+			Name:     "create_snapshot",
+			Gatherer: "sapcontrol",
+			Argument: "CreateSnapshot",
+			CheckID:  "check2",
+		},
+		{
+			Name:     "get_system_instance_list",
+			Gatherer: "sapcontrol",
+			Argument: "GetSystemInstanceList",
+			CheckID:  "check3",
+		},
+	}
+
+	factResults, err := p.Gather(factRequests)
+
+	expectedResults := []entities.Fact{
+		{
+			Name:  "check_host_agent",
+			Value: nil,
+			Error: &entities.FactGatheringError{
+				Message: "error while parsing sapcontrol output: empty output",
+				Type:    "sapcontrol-parse-error",
+			},
+			CheckID: "check1",
+		},
+		{
+			Name:  "create_snapshot",
+			Value: nil,
+			Error: &entities.FactGatheringError{
+				Message: "requested webmethod not supported: CreateSnapshot",
+				Type:    "sapcontrol-webmethod-error",
+			},
+			CheckID: "check2",
+		},
+		{
+			Name:  "get_system_instance_list",
+			Value: nil,
+			Error: &entities.FactGatheringError{
+				Message: "error executing sapcontrol command: some error",
+				Type:    "sapcontrol-cmd-error",
+			},
+			CheckID: "check3",
+		},
+	}
+
+	suite.NoError(err)
+	suite.ElementsMatch(expectedResults, factResults)
+}

--- a/internal/factsengine/gatherers/saphostctrl.go
+++ b/internal/factsengine/gatherers/saphostctrl.go
@@ -22,7 +22,7 @@ var (
 )
 
 // nolint:gochecknoglobals
-var whitelistedWebmethods = map[string]func(string) (entities.FactValue, *entities.FactGatheringError){
+var whitelistedSapHostCtrlWebmethods = map[string]func(string) (entities.FactValue, *entities.FactGatheringError){
 	"Ping":          parsePing,
 	"ListInstances": parseInstances,
 }
@@ -90,7 +90,7 @@ func handleWebmethod(
 	executor utils.CommandExecutor,
 	webMethod string,
 ) (entities.FactValue, *entities.FactGatheringError) {
-	webMethodHandler, ok := whitelistedWebmethods[webMethod]
+	webMethodHandler, ok := whitelistedSapHostCtrlWebmethods[webMethod]
 
 	if !ok {
 		gatheringError := SapHostCtrlUnsupportedFunction.Wrap(webMethod)


### PR DESCRIPTION
This PR adds the `sapcontrol` gatherer:

TODO:
 - Abstract the parsing of the `saphostctrl` to get the list of instances (right now, it has a hardcoded `00` value on the instances passed to `sapcontrol`
 
Whitelisted webmethods:
 - CheckHostAgent
 - GetProcessList
 - GetSystemInstanceList
 
 We are hitting the brake here for a while as it's not clear that we need this right now. Deferring this for a bit might be a good idea regardless as it depends on two topics still being discussed:
 - Multiple arguments support (this would require two arguments, the webmethod and the instance)
 - Dependency between gatherers (though this might be perfectly solvable as @CDimonaco suggested by abstracting the parsing of the `saphostctrl` output as described in the TODO)