### PR TITLE
Make `corosynccmapctl` gatherer output a map structure

### DIFF
--- a/internal/factsengine/gatherers/corosynccmapctl.go
+++ b/internal/factsengine/gatherers/corosynccmapctl.go
@@ -9,8 +9,7 @@ import (
 )
 
 const (
-	CorosyncCmapCtlGathererName  = "corosync-cmapctl"
-	corosyncCmapCtlparsingRegexp = `(?m)^(\S*)\s\(\S*\)\s=\s(.*)$`
+	CorosyncCmapCtlGathererName = "corosync-cmapctl"
 )
 
 // nolint:gochecknoglobals
@@ -70,7 +69,7 @@ func corosyncCmapctlOutputToMap(corosyncCmapctlOutput string) *entities.FactValu
 				currentMap.Value[key] = &entities.FactValueMap{Value: make(map[string]entities.FactValue)}
 			}
 
-			cursor = currentMap.Value[key].(*entities.FactValueMap)
+			cursor = currentMap.Value[key].(*entities.FactValueMap) //nolint:forcetypeassert
 		}
 	}
 

--- a/internal/factsengine/gatherers/corosynccmapctl.go
+++ b/internal/factsengine/gatherers/corosynccmapctl.go
@@ -86,14 +86,15 @@ func (s *CorosyncCmapctlGatherer) Gather(factsRequests []entities.FactRequest) (
 		return nil, CorosyncCmapCtlCommandError.Wrap(err.Error())
 	}
 
-	results := corosyncCmapctlOutputToMap(string(corosyncCmapctl))
+	corosyncCmapctlMap := corosyncCmapctlOutputToMap(string(corosyncCmapctl))
 
 	for _, factReq := range factsRequests {
 		var fact entities.Fact
 
-		value, err := results.GetValue(factReq.Argument)
-
-		if err == nil {
+		if len(factReq.Argument) == 0 {
+			log.Error(CorosyncCmapCtlMissingArgument.Message)
+			fact = entities.NewFactGatheredWithError(factReq, &CorosyncCmapCtlMissingArgument)
+		} else if value, err := corosyncCmapctlMap.GetValue(factReq.Argument); err == nil {
 			fact = entities.NewFactGatheredWithRequest(factReq, value)
 		} else {
 			gatheringError := CorosyncCmapCtlValueNotFound.Wrap(factReq.Argument)

--- a/internal/factsengine/gatherers/corosynccmapctl_test.go
+++ b/internal/factsengine/gatherers/corosynccmapctl_test.go
@@ -136,29 +136,14 @@ func (suite *CorosyncCmapctlTestSuite) TestCorosyncCmapctlGatherer() {
 
 	factRequests := []entities.FactRequest{
 		{
-			Name:     "quorum_provider",
+			Name:     "nodes",
 			Gatherer: "corosync-cmapctl",
-			Argument: "quorum.provider",
+			Argument: "nodelist.node",
 		},
 		{
 			Name:     "totem_max_messages",
 			Gatherer: "corosync-cmapctl",
 			Argument: "runtime.config.totem.max_messages",
-		},
-		{
-			Name:     "totem_transport",
-			Gatherer: "corosync-cmapctl",
-			Argument: "totem.transport",
-		},
-		{
-			Name:     "votequorum_two_node",
-			Gatherer: "corosync-cmapctl",
-			Argument: "runtime.votequorum.two_node",
-		},
-		{
-			Name:     "totem_consensus",
-			Gatherer: "corosync-cmapctl",
-			Argument: "runtime.config.totem.consensus",
 		},
 	}
 
@@ -166,24 +151,27 @@ func (suite *CorosyncCmapctlTestSuite) TestCorosyncCmapctlGatherer() {
 
 	expectedResults := []entities.Fact{
 		{
-			Name:  "quorum_provider",
-			Value: &entities.FactValueString{Value: "corosync_votequorum"},
+			Name: "nodes",
+			Value: &entities.FactValueMap{
+				Value: map[string]entities.FactValue{
+					"0": &entities.FactValueMap{
+						Value: map[string]entities.FactValue{
+							"nodeid":     &entities.FactValueInt{Value: 1},
+							"ring0_addr": &entities.FactValueString{Value: "10.80.1.11"},
+						},
+					},
+					"1": &entities.FactValueMap{
+						Value: map[string]entities.FactValue{
+							"nodeid":     &entities.FactValueInt{Value: 2},
+							"ring0_addr": &entities.FactValueString{Value: "10.80.1.12"},
+						},
+					},
+				},
+			},
 		},
 		{
 			Name:  "totem_max_messages",
 			Value: &entities.FactValueInt{Value: 20},
-		},
-		{
-			Name:  "totem_transport",
-			Value: &entities.FactValueString{Value: "udpu"},
-		},
-		{
-			Name:  "votequorum_two_node",
-			Value: &entities.FactValueInt{Value: 1},
-		},
-		{
-			Name:  "totem_consensus",
-			Value: &entities.FactValueInt{Value: 36000},
 		},
 	}
 

--- a/internal/factsengine/gatherers/corosynccmapctl_test.go
+++ b/internal/factsengine/gatherers/corosynccmapctl_test.go
@@ -136,14 +136,24 @@ func (suite *CorosyncCmapctlTestSuite) TestCorosyncCmapctlGatherer() {
 
 	factRequests := []entities.FactRequest{
 		{
-			Name:     "nodes",
+			Name:     "simple_value",
+			Gatherer: "corosync-cmapctl",
+			Argument: "runtime.config.totem.max_messages",
+		},
+		{
+			Name:     "brackets_in_value_field",
+			Gatherer: "corosync-cmapctl",
+			Argument: "runtime.totem.pg.mrp.srp.members.1.ip",
+		},
+		{
+			Name:     "map_of_nodes",
 			Gatherer: "corosync-cmapctl",
 			Argument: "nodelist.node",
 		},
 		{
-			Name:     "totem_max_messages",
+			Name:     "nested_map_and_primitive_value",
 			Gatherer: "corosync-cmapctl",
-			Argument: "runtime.config.totem.max_messages",
+			Argument: "runtime.services.cmap",
 		},
 	}
 
@@ -151,7 +161,15 @@ func (suite *CorosyncCmapctlTestSuite) TestCorosyncCmapctlGatherer() {
 
 	expectedResults := []entities.Fact{
 		{
-			Name: "nodes",
+			Name:  "simple_value",
+			Value: &entities.FactValueInt{Value: 20},
+		},
+		{
+			Name:  "brackets_in_value_field",
+			Value: &entities.FactValueString{Value: "r(0) ip(10.80.1.11) "},
+		},
+		{
+			Name: "map_of_nodes",
 			Value: &entities.FactValueMap{
 				Value: map[string]entities.FactValue{
 					"0": &entities.FactValueMap{
@@ -170,8 +188,18 @@ func (suite *CorosyncCmapctlTestSuite) TestCorosyncCmapctlGatherer() {
 			},
 		},
 		{
-			Name:  "totem_max_messages",
-			Value: &entities.FactValueInt{Value: 20},
+			Name: "nested_map_and_primitive_value",
+			Value: &entities.FactValueMap{
+				Value: map[string]entities.FactValue{
+					"0": &entities.FactValueMap{
+						Value: map[string]entities.FactValue{
+							"rx": &entities.FactValueInt{Value: 3},
+							"tx": &entities.FactValueInt{Value: 2},
+						},
+					},
+					"service_id": &entities.FactValueInt{Value: 0},
+				},
+			},
 		},
 	}
 


### PR DESCRIPTION
Adds the ability for the `corosynccmapctl` gatherer to output a map structure.

e.g. given the following output from `corosync-cmapctl`:
```
nodelist.local_node_pos (u32) = 1
nodelist.node.0.nodeid (u32) = 1
nodelist.node.0.ring0_addr (str) = 10.80.1.11
nodelist.node.1.nodeid (u32) = 2
nodelist.node.1.ring0_addr (str) = 10.80.1.12
```

If a `FactRequest` with `Argument` = `"nodelist.node"` is requested, then the following structure is returned:
```go
{
	Name: "nodes",
	Value: &entities.FactValueMap{
		Value: map[string]entities.FactValue{
			"0": &entities.FactValueMap{
				Value: map[string]entities.FactValue{
					"nodeid":     &entities.FactValueInt{Value: 1},
					"ring0_addr": &entities.FactValueString{Value: "10.80.1.11"},
				},
			},
			"1": &entities.FactValueMap{
				Value: map[string]entities.FactValue{
					"nodeid":     &entities.FactValueInt{Value: 2},
					"ring0_addr": &entities.FactValueString{Value: "10.80.1.12"},
				},
			},
		},
	},
}
```

If a `FactRequest` with `Argument` = a leaf of the output tree e.g. `nodelist.local_node_pos`, then the value is returned:

```go
{
	Name:  "local_node_pos",
	Value: &entities.FactValueInt{Value: 1},
}
```