### PR TITLE
Add version comparison functionality for package_version

### DIFF
--- a/internal/factsengine/gatherers/packageversion.go
+++ b/internal/factsengine/gatherers/packageversion.go
@@ -16,9 +16,14 @@ const (
 
 // nolint:gochecknoglobals
 var (
-	PackageVersionCommandError = entities.FactGatheringError{
-		Type:    "package-version-cmd-error",
+	PackageVersionRpmCommandError = entities.FactGatheringError{
+		Type:    "package-version-rpm-cmd-error",
 		Message: "error while fetching package version",
+	}
+
+	PackageVersionZypperCommandError = entities.FactGatheringError{
+		Type:    "package-version-zypper-cmd-error",
+		Message: "error while executing zypper",
 	}
 
 	PackageVersionMissingArgument = entities.FactGatheringError{
@@ -96,14 +101,14 @@ func executeZypperVersionCmpCommand(
 ) (int, *entities.FactGatheringError) {
 	zypperOutput, err := executor.Exec("/usr/bin/zypper", "--terse", "versioncmp", comparedVersion, installedVersion)
 	if err != nil {
-		gatheringError := PackageVersionCommandError.Wrap(err.Error())
+		gatheringError := PackageVersionZypperCommandError.Wrap(err.Error())
 		log.Error(gatheringError)
 		return invalidVersionCompare, gatheringError
 	}
 
 	result, err := strconv.ParseInt(string(zypperOutput), 10, 32)
 	if err != nil {
-		gatheringError := PackageVersionCommandError.Wrap(err.Error())
+		gatheringError := PackageVersionRpmCommandError.Wrap(err.Error())
 		log.Error(gatheringError)
 		return invalidVersionCompare, gatheringError
 	}
@@ -117,7 +122,7 @@ func executeRpmVersionRetrieveCommand(
 ) (string, *entities.FactGatheringError) {
 	rpmOutput, err := executor.Exec("/usr/bin/rpm", "-q", "--qf", "%{VERSION}", packageName)
 	if err != nil {
-		gatheringError := PackageVersionCommandError.Wrap(string(rpmOutput) + err.Error())
+		gatheringError := PackageVersionRpmCommandError.Wrap(string(rpmOutput) + err.Error())
 		log.Error(gatheringError)
 		return "", gatheringError
 	}

--- a/internal/factsengine/gatherers/packageversion.go
+++ b/internal/factsengine/gatherers/packageversion.go
@@ -1,6 +1,9 @@
 package gatherers
 
 import (
+	"strconv"
+	"strings"
+
 	log "github.com/sirupsen/logrus"
 	"github.com/trento-project/agent/pkg/factsengine/entities"
 	"github.com/trento-project/agent/pkg/utils"
@@ -8,13 +11,14 @@ import (
 
 const (
 	PackageVersionGathererName = "package_version"
+	invalidVersionCompare      = -2
 )
 
 // nolint:gochecknoglobals
 var (
 	PackageVersionCommandError = entities.FactGatheringError{
 		Type:    "package-version-cmd-error",
-		Message: "error getting version of package",
+		Message: "error while fetching package version",
 	}
 
 	PackageVersionMissingArgument = entities.FactGatheringError{
@@ -50,19 +54,73 @@ func (g *PackageVersionGatherer) Gather(factsRequests []entities.FactRequest) ([
 			continue
 		}
 
-		version, err := g.executor.Exec(
-			"rpm", "-q", "--qf", "%{VERSION}", factReq.Argument)
-		if err != nil {
-			gatheringError := PackageVersionCommandError.Wrap(factReq.Argument)
-			log.Error(gatheringError)
-			fact = entities.NewFactGatheredWithError(factReq, gatheringError)
-		} else {
-			fact = entities.NewFactGatheredWithRequest(factReq, &entities.FactValueString{Value: (string(version))})
+		packageName := factReq.Argument
+		requestedVersion := ""
+		if strings.Contains(factReq.Argument, ",") {
+			arguments := strings.SplitN(factReq.Argument, ",", 2)
+			packageName = arguments[0]
+			requestedVersion = arguments[1]
 		}
 
+		installedVersion, err := executeRpmVersionRetrieveCommand(g.executor, packageName)
+		if err != nil {
+			fact = entities.NewFactGatheredWithError(factReq, err)
+			facts = append(facts, fact)
+			continue
+		}
+
+		if requestedVersion != "" {
+			comparisonResult, err := executeZypperVersionCmpCommand(g.executor, installedVersion, requestedVersion)
+			if err != nil {
+				fact = entities.NewFactGatheredWithError(factReq, err)
+				facts = append(facts, fact)
+				continue
+			}
+			fact = entities.NewFactGatheredWithRequest(factReq, &entities.FactValueInt{Value: comparisonResult})
+			facts = append(facts, fact)
+			continue
+		}
+
+		fact = entities.NewFactGatheredWithRequest(factReq, &entities.FactValueString{Value: installedVersion})
 		facts = append(facts, fact)
 	}
 
 	log.Infof("Requested %s facts gathered", PackageVersionGathererName)
 	return facts, nil
+}
+
+func executeZypperVersionCmpCommand(
+	executor utils.CommandExecutor,
+	installedVersion string,
+	comparedVersion string,
+) (int, *entities.FactGatheringError) {
+	zypperOutput, err := executor.Exec("/usr/bin/zypper", "--terse", "versioncmp", comparedVersion, installedVersion)
+	if err != nil {
+		gatheringError := PackageVersionCommandError.Wrap(err.Error())
+		log.Error(gatheringError)
+		return invalidVersionCompare, gatheringError
+	}
+
+	result, err := strconv.ParseInt(string(zypperOutput), 10, 32)
+	if err != nil {
+		gatheringError := PackageVersionCommandError.Wrap(err.Error())
+		log.Error(gatheringError)
+		return invalidVersionCompare, gatheringError
+	}
+
+	return int(result), nil
+}
+
+func executeRpmVersionRetrieveCommand(
+	executor utils.CommandExecutor,
+	packageName string,
+) (string, *entities.FactGatheringError) {
+	rpmOutput, err := executor.Exec("/usr/bin/rpm", "-q", "--qf", "%{VERSION}", packageName)
+	if err != nil {
+		gatheringError := PackageVersionCommandError.Wrap(string(rpmOutput) + err.Error())
+		log.Error(gatheringError)
+		return "", gatheringError
+	}
+
+	return string(rpmOutput), nil
 }

--- a/internal/factsengine/gatherers/packageversion_test.go
+++ b/internal/factsengine/gatherers/packageversion_test.go
@@ -151,12 +151,15 @@ func (suite *PackageVersionTestSuite) TestPackageVersionGather() {
 	suite.ElementsMatch(expectedResults, factResults)
 }
 
-func (suite *PackageVersionTestSuite) TestPackageVersionGatherMissingPackageError() {
+func (suite *PackageVersionTestSuite) TestPackageVersionGatherErrors() {
 	suite.mockExecutor.On("Exec", "/usr/bin/rpm", "-q", "--qf", "%{VERSION}", "sbd").Return(
 		[]byte("package sbd is not installed"), errors.New(""))
 	suite.mockExecutor.On("Exec", "/usr/bin/rpm", "-q", "--qf", "%{VERSION}", "pacemake").Return(
 		[]byte("package pacemake is not installed"), errors.New(""))
-
+	suite.mockExecutor.On("Exec", "/usr/bin/rpm", "-q", "--qf", "%{VERSION}", "corosync").Return(
+		[]byte("2.4.5"), nil)
+	suite.mockExecutor.On("Exec", "/usr/bin/zypper", "--terse", "versioncmp", "1.2.3", "2.4.5").Return(
+		[]byte(""), errors.New("zypper: command not found"))
 	p := gatherers.NewPackageVersionGatherer(suite.mockExecutor)
 
 	factRequests := []entities.FactRequest{
@@ -172,6 +175,12 @@ func (suite *PackageVersionTestSuite) TestPackageVersionGatherMissingPackageErro
 			Argument: "pacemake",
 			CheckID:  "check2",
 		},
+		{
+			Name:     "corosync_compare",
+			Gatherer: "package_version",
+			Argument: "corosync,1.2.3",
+			CheckID:  "check3",
+		},
 	}
 
 	factResults, err := p.Gather(factRequests)
@@ -182,7 +191,7 @@ func (suite *PackageVersionTestSuite) TestPackageVersionGatherMissingPackageErro
 			Value: nil,
 			Error: &entities.FactGatheringError{
 				Message: "error while fetching package version: package sbd is not installed",
-				Type:    "package-version-cmd-error",
+				Type:    "package-version-rpm-cmd-error",
 			},
 			CheckID: "check1",
 		},
@@ -191,9 +200,18 @@ func (suite *PackageVersionTestSuite) TestPackageVersionGatherMissingPackageErro
 			Value: nil,
 			Error: &entities.FactGatheringError{
 				Message: "error while fetching package version: package pacemake is not installed",
-				Type:    "package-version-cmd-error",
+				Type:    "package-version-rpm-cmd-error",
 			},
 			CheckID: "check2",
+		},
+		{
+			Name:  "corosync_compare",
+			Value: nil,
+			Error: &entities.FactGatheringError{
+				Message: "error while executing zypper: zypper: command not found",
+				Type:    "package-version-zypper-cmd-error",
+			},
+			CheckID: "check3",
 		},
 	}
 

--- a/internal/factsengine/gatherers/packageversion_test.go
+++ b/internal/factsengine/gatherers/packageversion_test.go
@@ -24,7 +24,7 @@ func (suite *PackageVersionTestSuite) SetupTest() {
 }
 
 func (suite *PackageVersionTestSuite) TestPackageVersionGathererNoArgumentProvided() {
-	suite.mockExecutor.On("Exec", "rpm", "-q", "--qf", "%{VERSION}", "").Return(
+	suite.mockExecutor.On("Exec", "/usr/bin/rpm", "-q", "--qf", "%{VERSION}", "").Return(
 		[]byte("rpm: no arguments given for query"), nil)
 
 	p := gatherers.NewPackageVersionGatherer(suite.mockExecutor)
@@ -71,10 +71,16 @@ func (suite *PackageVersionTestSuite) TestPackageVersionGathererNoArgumentProvid
 }
 
 func (suite *PackageVersionTestSuite) TestPackageVersionGather() {
-	suite.mockExecutor.On("Exec", "rpm", "-q", "--qf", "%{VERSION}", "corosync").Return(
+	suite.mockExecutor.On("Exec", "/usr/bin/rpm", "-q", "--qf", "%{VERSION}", "corosync").Return(
 		[]byte("2.4.5"), nil)
-	suite.mockExecutor.On("Exec", "rpm", "-q", "--qf", "%{VERSION}", "pacemaker").Return(
+	suite.mockExecutor.On("Exec", "/usr/bin/rpm", "-q", "--qf", "%{VERSION}", "pacemaker").Return(
 		[]byte("2.0.5+20201202.ba59be712"), nil)
+	suite.mockExecutor.On("Exec", "/usr/bin/zypper", "--terse", "versioncmp", "2.4.4", "2.4.5").Return(
+		[]byte("-1"), nil)
+	suite.mockExecutor.On("Exec", "/usr/bin/zypper", "--terse", "versioncmp", "2.4.5", "2.4.5").Return(
+		[]byte("0"), nil)
+	suite.mockExecutor.On("Exec", "/usr/bin/zypper", "--terse", "versioncmp", "2.4.6", "2.4.5").Return(
+		[]byte("1"), nil)
 
 	p := gatherers.NewPackageVersionGatherer(suite.mockExecutor)
 
@@ -91,6 +97,24 @@ func (suite *PackageVersionTestSuite) TestPackageVersionGather() {
 			Argument: "pacemaker",
 			CheckID:  "check2",
 		},
+		{
+			Name:     "corosync_same_version",
+			Gatherer: "package_version",
+			Argument: "corosync,2.4.5",
+			CheckID:  "check3",
+		},
+		{
+			Name:     "corosync_older_than_installed",
+			Gatherer: "package_version",
+			Argument: "corosync,2.4.4",
+			CheckID:  "check4",
+		},
+		{
+			Name:     "corosync_newer_than_installed",
+			Gatherer: "package_version",
+			Argument: "corosync,2.4.6",
+			CheckID:  "check5",
+		},
 	}
 
 	factResults, err := p.Gather(factRequests)
@@ -106,6 +130,21 @@ func (suite *PackageVersionTestSuite) TestPackageVersionGather() {
 			Value:   &entities.FactValueString{Value: "2.0.5+20201202.ba59be712"},
 			CheckID: "check2",
 		},
+		{
+			Name:    "corosync_same_version",
+			Value:   &entities.FactValueInt{Value: 0},
+			CheckID: "check3",
+		},
+		{
+			Name:    "corosync_older_than_installed",
+			Value:   &entities.FactValueInt{Value: -1},
+			CheckID: "check4",
+		},
+		{
+			Name:    "corosync_newer_than_installed",
+			Value:   &entities.FactValueInt{Value: 1},
+			CheckID: "check5",
+		},
 	}
 
 	suite.NoError(err)
@@ -113,18 +152,18 @@ func (suite *PackageVersionTestSuite) TestPackageVersionGather() {
 }
 
 func (suite *PackageVersionTestSuite) TestPackageVersionGatherMissingPackageError() {
-	suite.mockExecutor.On("Exec", "rpm", "-q", "--qf", "%{VERSION}", "corosync").Return(
-		[]byte("2.4.5"), nil)
-	suite.mockExecutor.On("Exec", "rpm", "-q", "--qf", "%{VERSION}", "pacemake").Return(
-		[]byte("Error getting version of package: pacemake\n"), errors.New("some error"))
+	suite.mockExecutor.On("Exec", "/usr/bin/rpm", "-q", "--qf", "%{VERSION}", "sbd").Return(
+		[]byte("package sbd is not installed"), errors.New(""))
+	suite.mockExecutor.On("Exec", "/usr/bin/rpm", "-q", "--qf", "%{VERSION}", "pacemake").Return(
+		[]byte("package pacemake is not installed"), errors.New(""))
 
 	p := gatherers.NewPackageVersionGatherer(suite.mockExecutor)
 
 	factRequests := []entities.FactRequest{
 		{
-			Name:     "corosync",
+			Name:     "sbd_compare_version",
 			Gatherer: "package_version",
-			Argument: "corosync",
+			Argument: "sbd,1.2.3",
 			CheckID:  "check1",
 		},
 		{
@@ -139,15 +178,19 @@ func (suite *PackageVersionTestSuite) TestPackageVersionGatherMissingPackageErro
 
 	expectedResults := []entities.Fact{
 		{
-			Name:    "corosync",
-			Value:   &entities.FactValueString{Value: "2.4.5"},
+			Name:  "sbd_compare_version",
+			Value: nil,
+			Error: &entities.FactGatheringError{
+				Message: "error while fetching package version: package sbd is not installed",
+				Type:    "package-version-cmd-error",
+			},
 			CheckID: "check1",
 		},
 		{
 			Name:  "pacemaker",
 			Value: nil,
 			Error: &entities.FactGatheringError{
-				Message: "error getting version of package: pacemake",
+				Message: "error while fetching package version: package pacemake is not installed",
 				Type:    "package-version-cmd-error",
 			},
 			CheckID: "check2",


### PR DESCRIPTION
This PR allows the `package_version` gatherer to be used to compare versions on the agent. This way, we can handle the complexity of comparing RPM package version strings to the OS using `zypper versioncmp` (see `zypper versioncmp --help` for more details).

Notice that this just adds to the existing functionality of requesting package version strings which should still work as it previously did. To request a version comparison, a package name together with a version string needs to be provided in the argument, separated by a coma  (`,`).

The returned value for such requests is a FactValueInt, containing:

 - A value of `0` if the provided version string matches the installed package version for the requested package
 - A value of `-1` if the provided version string is older that what's currently installed.
 - A value of `1` if the provided version string is newer than what's currently installed.

Example on how to collect such facts:

```
factRequests := []entities.FactRequest{
{
	Name:     "corosync_same_version",
	Gatherer: "package_version",
	Argument: "corosync,2.4.5",
	CheckID:  "check1",
},
{
	Name:     "corosync",
	Gatherer: "package_version",
	Argument: "corosync",
	CheckID:  "check2",
},
```


For such requests, the returned values should look like:
```
[]entities.Fact{
{
	Name:    "corosync_same_version",
	Value:   &entities.FactValueInt{Value: 0},
	CheckID: "check3",
},
{
	Name:    "corosync",
	Value:   &entities.FactValueString{Value: "2.4.5"},
	CheckID: "check1",
},
```
Notice how the first fact request asks for `corosync` against `2.4.5`, which will cause that an integer instead of a regular `FactValueString` with a version string. The second one, as it just asks for a package name will return a version string as it did before.