### PR TITLE
Fix cluster_property_set parsing

### DIFF
--- a/internal/factsengine/gatherers/cibadmin.go
+++ b/internal/factsengine/gatherers/cibadmin.go
@@ -46,7 +46,8 @@ func (g *CibAdminGatherer) Gather(factsRequests []entities.FactRequest) ([]entit
 	}
 
 	elementsToList := map[string]bool{"primitive": true, "clone": true, "master": true, "group": true,
-		"nvpair": true, "op": true, "rsc_location": true, "rsc_order": true, "rsc_colocation": true}
+		"nvpair": true, "op": true, "rsc_location": true, "rsc_order": true,
+		"rsc_colocation": true, "cluster_property_set": true}
 
 	factValueMap, err := parseXMLToFactValueMap(cibadmin, elementsToList)
 	if err != nil {

--- a/internal/factsengine/gatherers/cibadmin_test.go
+++ b/internal/factsengine/gatherers/cibadmin_test.go
@@ -92,7 +92,7 @@ func (suite *CibAdminTestSuite) TestCibAdminGather() {
 		{
 			Name:     "nvpair",
 			Gatherer: "cibadmin",
-			Argument: "cib.configuration.crm_config.cluster_property_set.nvpair.0",
+			Argument: "cib.configuration.crm_config.cluster_property_set.0.nvpair.0",
 			CheckID:  "check2",
 		},
 		{


### PR DESCRIPTION
Set `cluster_property_set` as potential list in the cibadmin gatherer.

Related to this comment: https://github.com/trento-project/wanda/pull/160#discussion_r1070967627