### PR TITLE
Fix broken zypper output parsing in package_version due to `\n`

### DIFF
--- a/internal/factsengine/gatherers/packageversion.go
+++ b/internal/factsengine/gatherers/packageversion.go
@@ -106,7 +106,8 @@ func executeZypperVersionCmpCommand(
 		return invalidVersionCompare, gatheringError
 	}
 
-	result, err := strconv.ParseInt(string(zypperOutput), 10, 32)
+	versionCmpResult := strings.TrimRight(string(zypperOutput), "\n")
+	result, err := strconv.ParseInt(versionCmpResult, 10, 32)
 	if err != nil {
 		gatheringError := PackageVersionRpmCommandError.Wrap(err.Error())
 		log.Error(gatheringError)

--- a/internal/factsengine/gatherers/packageversion_test.go
+++ b/internal/factsengine/gatherers/packageversion_test.go
@@ -76,11 +76,11 @@ func (suite *PackageVersionTestSuite) TestPackageVersionGather() {
 	suite.mockExecutor.On("Exec", "/usr/bin/rpm", "-q", "--qf", "%{VERSION}", "pacemaker").Return(
 		[]byte("2.0.5+20201202.ba59be712"), nil)
 	suite.mockExecutor.On("Exec", "/usr/bin/zypper", "--terse", "versioncmp", "2.4.4", "2.4.5").Return(
-		[]byte("-1"), nil)
+		[]byte("-1\n"), nil)
 	suite.mockExecutor.On("Exec", "/usr/bin/zypper", "--terse", "versioncmp", "2.4.5", "2.4.5").Return(
-		[]byte("0"), nil)
+		[]byte("0\n"), nil)
 	suite.mockExecutor.On("Exec", "/usr/bin/zypper", "--terse", "versioncmp", "2.4.6", "2.4.5").Return(
-		[]byte("1"), nil)
+		[]byte("1\n"), nil)
 
 	p := gatherers.NewPackageVersionGatherer(suite.mockExecutor)
 


### PR DESCRIPTION
This fixes the version comparison bug on the `package_version` gatherer where the output of zypper with a `\n` breaks it.

Appart from testing manually, I included the newline also in the mock executor. Should be fine now.