### PR TITLE
Disable lll linter rule for test files

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -45,3 +45,10 @@ linters:
     - unconvert
     - unparam
     - wastedassign
+
+issues:
+  exclude-rules:
+    # Exclude some linters from running on tests files.
+    - path: _test\.go
+      linters:
+        - lll


### PR DESCRIPTION
Otherwise we end up in a situation where long test strings cause issues in the CI