### PR TITLE
Trigger golang docs update in ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,6 +21,13 @@ env:
   REPOSITORY: ${{ github.repository }}
 
 jobs:
+  generate-docs:
+    runs-on: ubuntu-20.04
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/main')
+    steps:
+      - name: trigger docs update in sum.golang.org and pkg.go.dev
+        uses: essentialkaos/godoc-action@v1
+
   static-analysis:
     runs-on: ubuntu-20.04
     steps:


### PR DESCRIPTION
Add new job in the CI to trigger the docs update once merged.
https://github.com/marketplace/actions/ek-godoc-action