### PR TITLE
Add reviewers to dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -4,7 +4,11 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    reviewers:
+      - "trento-project/maintainers"
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
       interval: "daily"
+    reviewers:
+      - "trento-project/maintainers"


### PR DESCRIPTION
By having the review branch protection, we need to review dependabot PRs. This PR automatically adds all the maintainers to the review.