### PR TITLE
Cibadmin meta attributes to list

### DIFF
--- a/internal/factsengine/gatherers/cibadmin.go
+++ b/internal/factsengine/gatherers/cibadmin.go
@@ -47,7 +47,7 @@ func (g *CibAdminGatherer) Gather(factsRequests []entities.FactRequest) ([]entit
 
 	elementsToList := map[string]bool{"primitive": true, "clone": true, "master": true, "group": true,
 		"nvpair": true, "op": true, "rsc_location": true, "rsc_order": true,
-		"rsc_colocation": true, "cluster_property_set": true}
+		"rsc_colocation": true, "cluster_property_set": true, "meta_attributes": true}
 
 	factValueMap, err := parseXMLToFactValueMap(cibadmin, elementsToList)
 	if err != nil {

--- a/internal/factsengine/gatherers/cibadmin_test.go
+++ b/internal/factsengine/gatherers/cibadmin_test.go
@@ -107,6 +107,12 @@ func (suite *CibAdminTestSuite) TestCibAdminGather() {
 			Argument: "cib.configuration.resources.primitive.0",
 			CheckID:  "check4",
 		},
+		{
+			Name:     "meta_attributes",
+			Gatherer: "cibadmin",
+			Argument: "cib.configuration.rsc_defaults.meta_attributes",
+			CheckID:  "check5",
+		},
 	}
 
 	factResults, err := p.Gather(factRequests)
@@ -163,6 +169,37 @@ func (suite *CibAdminTestSuite) TestCibAdminGather() {
 				},
 			},
 			CheckID: "check4",
+		},
+		{
+			Name: "meta_attributes",
+			Value: &entities.FactValueList{
+				Value: []entities.FactValue{
+					&entities.FactValueMap{
+						Value: map[string]entities.FactValue{
+							"id": &entities.FactValueString{Value: "rsc-options"},
+							"nvpair": &entities.FactValueList{
+								Value: []entities.FactValue{
+									&entities.FactValueMap{
+										Value: map[string]entities.FactValue{
+											"id":    &entities.FactValueString{Value: "rsc-options-resource-stickiness"},
+											"name":  &entities.FactValueString{Value: "resource-stickiness"},
+											"value": &entities.FactValueInt{Value: 1000},
+										},
+									},
+									&entities.FactValueMap{
+										Value: map[string]entities.FactValue{
+											"id":    &entities.FactValueString{Value: "rsc-options-migration-threshold"},
+											"name":  &entities.FactValueString{Value: "migration-threshold"},
+											"value": &entities.FactValueInt{Value: 5000},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			CheckID: "check5",
 		},
 	}
 


### PR DESCRIPTION
The `meta_attributes` entry can be there more than once (even though it looks like an exception, as entries finishing with `s` are unique).
This started happening in 15SP4 using `ha-cluster-init` tool to create the cluster.
So now the `meta_attributes` will be converted to a list always to avoid divergencies.

Example output:
```
[
  #{
    "id": "build-resource-defaults",
    "nvpair": [
      #{
        "id": "build-resource-stickiness",
        "name": "resource-stickiness",
        "value": 1
      }
    ]
  },
  #{
    "id": "rsc-options",
    "nvpair": [
      #{
        "id": "rsc-options-migration-threshold",
        "name": "migration-threshold",
        "value": 5000
      },
      #{
        "id": "rsc-options-resource-stickiness",
        "name": "resource-stickiness",
        "value": 1000
      }
    ]
  }
] 

```