### PR TITLE
Fix getValue function when map is empty

### DIFF
--- a/pkg/factsengine/entities/fact_value.go
+++ b/pkg/factsengine/entities/fact_value.go
@@ -193,7 +193,7 @@ func getValue(fact FactValue, values []string) (FactValue, error) {
 		}
 		return getValue(value.Value[listIndex], values[1:])
 	default:
-		return value, nil
+		return nil, fmt.Errorf("requested field value not found")
 	}
 }
 

--- a/pkg/factsengine/entities/fact_value_test.go
+++ b/pkg/factsengine/entities/fact_value_test.go
@@ -182,6 +182,7 @@ func (suite *FactValueTestSuite) TestFactValueMapGetValue() {
 					"value": &entities.FactValueString{Value: "other_value"},
 				},
 			},
+			"empty_entry": &entities.FactValueString{},
 		},
 	}
 
@@ -250,6 +251,15 @@ func (suite *FactValueTestSuite) TestFactValueMapGetValue() {
 			err: &entities.FactGatheringError{
 				Type:    "value-not-found",
 				Message: "error getting value: requested field value not found: map_value.other_value",
+			},
+		},
+		{
+			description: "Should return ValueNotFoundError when value does not exist because the entry is empty",
+			key:         "empty_entry.some_value",
+			expected:    nil,
+			err: &entities.FactGatheringError{
+				Type:    "value-not-found",
+				Message: "error getting value: requested field value not found: empty_entry.some_value",
 			},
 		},
 		{


### PR DESCRIPTION
Fix issue getting the value from a `FactValue` when the required value does not exist.

This happened when you ask some field in a map where this field is an empty value.

PD: Checking coverage, this was the unique untested line, shame on me!