### PR TITLE
Send an empty payload if a cluster was not found

### DIFF
--- a/internal/discovery/mocks/discovered_cluster_mock.go
+++ b/internal/discovery/mocks/discovered_cluster_mock.go
@@ -6,7 +6,7 @@ import (
 	"github.com/trento-project/agent/test/helpers"
 )
 
-func NewDiscoveredClusterMock() cluster.Cluster {
+func NewDiscoveredClusterMock() *cluster.Cluster {
 	cluster, _ := cluster.NewClusterWithDiscoveryTools(&cluster.DiscoveryTools{
 		CibAdmPath:      helpers.GetFixturePath("discovery/cluster/fake_cibadmin.sh"),
 		CrmmonAdmPath:   helpers.GetFixturePath("discovery/cluster/fake_crm_mon.sh"),


### PR DESCRIPTION
This PR sends an empty payload if a cluster was not found, instead of returning from the discovery loop.
This is useful in the delta deregistration to remove a host from a cluster if previously it was part of it.