### PR TITLE
Ignore extra output when comparing versions with zypper

### DIFF
--- a/internal/factsengine/gatherers/packageversion.go
+++ b/internal/factsengine/gatherers/packageversion.go
@@ -117,7 +117,10 @@ func executeZypperVersionCmpCommand(
 	}
 
 	versionCmpResult := strings.TrimRight(string(zypperOutput), "\n")
-	result, err := strconv.ParseInt(versionCmpResult, 10, 32)
+	outputParts := strings.Split(versionCmpResult, "\n")
+	comparisonResult := outputParts[len(outputParts)-1]
+
+	result, err := strconv.ParseInt(comparisonResult, 10, 32)
 	if err != nil {
 		gatheringError := PackageVersionRpmCommandError.Wrap(err.Error())
 		log.Error(gatheringError)

--- a/internal/factsengine/gatherers/packageversion_test.go
+++ b/internal/factsengine/gatherers/packageversion_test.go
@@ -105,6 +105,12 @@ func (suite *PackageVersionTestSuite) TestPackageVersionGather() {
 	suite.mockExecutor.On("Exec", "/usr/bin/zypper", "--terse", "versioncmp", "2.4.6", "2.4.5").Return(
 		[]byte("1\n"), nil)
 
+	versionComparisonOutputWithWarningFile, _ :=
+		os.Open(helpers.GetFixturePath("gatherers/versioncmp-with-warning.output"))
+	versionComparisonOutputWithWarning, _ := io.ReadAll(versionComparisonOutputWithWarningFile)
+	suite.mockExecutor.On("Exec", "/usr/bin/zypper", "--terse", "versioncmp", "1.5.2", "1.5.2").Return(
+		versionComparisonOutputWithWarning, nil)
+
 	p := gatherers.NewPackageVersionGatherer(suite.mockExecutor)
 
 	factRequests := []entities.FactRequest{
@@ -149,6 +155,12 @@ func (suite *PackageVersionTestSuite) TestPackageVersionGather() {
 			Gatherer: "package_version",
 			Argument: "awk",
 			CheckID:  "check7",
+		},
+		{
+			Name:     "sbd_same_version_with_warning",
+			Gatherer: "package_version",
+			Argument: "sbd,1.5.2",
+			CheckID:  "check8",
 		},
 	}
 
@@ -231,6 +243,11 @@ func (suite *PackageVersionTestSuite) TestPackageVersionGather() {
 				},
 			},
 			CheckID: "check7",
+		},
+		{
+			Name:    "sbd_same_version_with_warning",
+			Value:   &entities.FactValueInt{Value: 0},
+			CheckID: "check8",
 		},
 	}
 

--- a/test/fixtures/gatherers/versioncmp-with-warning.output
+++ b/test/fixtures/gatherers/versioncmp-with-warning.output
@@ -1,0 +1,4 @@
+Warning: The /etc/products.d/baseproduct symlink is dangling or missing!
+The link must point to your core products .prod file in /etc/products.d.
+
+0


### PR DESCRIPTION
This PR makes sure to ignore extra output of the zypper versioncmp command so that we can only take into account the actual comparinson result.

ie when the /etc/products.d/baseproduct symlink is missing a warning is returned in the output of a version comparison, breaking the parsing of the comparison value (expected to be -1, 0, 1)

```bash
$ zypper --terse versioncmp 1.5.2 1.5.2
Warning: The /etc/products.d/baseproduct symlink is dangling or missing!
The link must point to your core products .prod file in /etc/products.d.

0
```