### PR TITLE
Use json.RawMessage type to avoid unnecessary json.Unmarshal

### DIFF
--- a/internal/discovery/saptune.go
+++ b/internal/discovery/saptune.go
@@ -61,9 +61,9 @@ func (d SaptuneDiscovery) Discover() (string, error) {
 	default:
 		saptuneData, _ := saptuneRetriever.RunCommandJSON("status")
 
-		if !isValidJSON(saptuneData) {
+		if ok, err := isValidJSON(saptuneData); !ok {
 			saptuneData = nil
-			log.Error("Error while parsing saptune status JSON")
+			log.Error("Error while parsing saptune status JSON: %w", err)
 		}
 
 		saptunePayload = SaptuneDiscoveryPayload{
@@ -82,7 +82,8 @@ func (d SaptuneDiscovery) Discover() (string, error) {
 	return "Saptune data discovery completed", nil
 }
 
-func isValidJSON(data json.RawMessage) bool {
+func isValidJSON(data json.RawMessage) (bool, error) {
 	var i interface{}
-	return json.Unmarshal(data, &i) == nil
+	err := json.Unmarshal(data, &i)
+	return err == nil, err
 }


### PR DESCRIPTION
This PR changes the SaptuneDiscoveryPayload struct to avoid the usage of `interface{}` type and `json.Unmarshal`. Instead we use a `json.RawMessage` that prevents the payload from being quoted.