### PR TITLE
Add configuration options to NewFactValue

### DIFF
--- a/internal/factsengine/gatherers/xml.go
+++ b/internal/factsengine/gatherers/xml.go
@@ -20,7 +20,7 @@ func parseXMLToFactValueMap(xmlContent []byte, elementsToList map[string]bool) (
 
 	mapValue := map[string]interface{}(mv)
 	updatedMap := convertListElements(mapValue, elementsToList)
-	factValue, err := entities.NewFactValueWithDefaultConf(updatedMap)
+	factValue, err := entities.NewFactValue(updatedMap, entities.WithStringConversion())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/factsengine/gatherers/xml.go
+++ b/internal/factsengine/gatherers/xml.go
@@ -20,7 +20,7 @@ func parseXMLToFactValueMap(xmlContent []byte, elementsToList map[string]bool) (
 
 	mapValue := map[string]interface{}(mv)
 	updatedMap := convertListElements(mapValue, elementsToList)
-	factValue, err := entities.NewFactValue(updatedMap)
+	factValue, err := entities.NewFactValueWithDefaultConf(updatedMap)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/factsengine/entities/fact_value.go
+++ b/pkg/factsengine/entities/fact_value.go
@@ -41,13 +41,13 @@ type FactValue interface {
 	AsInterface() interface{}
 }
 
-// NewFactValueWithConf constructs a FactValue from a nested interface with a provided configuration
-func NewFactValueWithConf(factInterface interface{}, conf *Conf) (FactValue, error) {
+// NewFactValue constructs a FactValue from a nested interface with a provided configuration
+func NewFactValue(factInterface interface{}, conf *Conf) (FactValue, error) {
 	switch value := factInterface.(type) {
 	case []interface{}:
 		newList := []FactValue{}
 		for _, value := range value {
-			newValue, err := NewFactValueWithConf(value, conf)
+			newValue, err := NewFactValue(value, conf)
 			if err != nil {
 				return nil, err
 			}
@@ -57,7 +57,7 @@ func NewFactValueWithConf(factInterface interface{}, conf *Conf) (FactValue, err
 	case map[string]interface{}:
 		newMap := make(map[string]FactValue)
 		for key, mapValue := range value {
-			newValue, err := NewFactValueWithConf(mapValue, conf)
+			newValue, err := NewFactValue(mapValue, conf)
 			if err != nil {
 				return nil, err
 			}
@@ -80,10 +80,10 @@ func NewFactValueWithConf(factInterface interface{}, conf *Conf) (FactValue, err
 	}
 }
 
-// NewFactValue constructs a FactValue from a nested interface.
-func NewFactValue(factInterface interface{}) (FactValue, error) {
+// NewFactValueWithDefaultConf constructs a FactValue from a nested interface.
+func NewFactValueWithDefaultConf(factInterface interface{}) (FactValue, error) {
 	conf := NewDefaultConf()
-	return NewFactValueWithConf(factInterface, &conf)
+	return NewFactValue(factInterface, &conf)
 }
 
 type FactValueInt struct {

--- a/pkg/factsengine/entities/fact_value.go
+++ b/pkg/factsengine/entities/fact_value.go
@@ -25,17 +25,17 @@ type conf struct {
 	stringConversion bool
 }
 
-type Option func(f *conf)
+type FactValueOption func(f *conf)
 
 // WithSnakeCaseKeys converts map keys to snake_case
-func WithSnakeCaseKeys() Option {
+func WithSnakeCaseKeys() FactValueOption {
 	return func(c *conf) {
 		c.snakeCaseKeys = true
 	}
 }
 
 // WithStringConversion enables string automatic conversion to numeric fact values
-func WithStringConversion() Option {
+func WithStringConversion() FactValueOption {
 	return func(c *conf) {
 		c.stringConversion = true
 	}
@@ -51,7 +51,7 @@ type FactValue interface {
 }
 
 // NewFactValue constructs a FactValue from a nested interface.
-func NewFactValue(factInterface interface{}, opts ...Option) (FactValue, error) {
+func NewFactValue(factInterface interface{}, opts ...FactValueOption) (FactValue, error) {
 	conf := &conf{}
 	for _, applyOpt := range opts {
 		applyOpt(conf)

--- a/pkg/factsengine/entities/fact_value.go
+++ b/pkg/factsengine/entities/fact_value.go
@@ -20,23 +20,23 @@ var ValueNotFoundError = FactGatheringError{
 	Message: "error getting value",
 }
 
-type Conf struct {
+type conf struct {
 	snakeCaseKeys    bool
 	stringConversion bool
 }
 
-type Option func(f *Conf)
+type Option func(f *conf)
 
 // WithSnakeCaseKeys converts map keys to snake_case
 func WithSnakeCaseKeys() Option {
-	return func(c *Conf) {
+	return func(c *conf) {
 		c.snakeCaseKeys = true
 	}
 }
 
 // WithStringConversion enables string automatic conversion to numeric fact values
 func WithStringConversion() Option {
-	return func(c *Conf) {
+	return func(c *conf) {
 		c.stringConversion = true
 	}
 }
@@ -52,7 +52,7 @@ type FactValue interface {
 
 // NewFactValue constructs a FactValue from a nested interface.
 func NewFactValue(factInterface interface{}, opts ...Option) (FactValue, error) {
-	conf := &Conf{}
+	conf := &conf{}
 	for _, applyOpt := range opts {
 		applyOpt(conf)
 	}

--- a/pkg/factsengine/entities/fact_value.go
+++ b/pkg/factsengine/entities/fact_value.go
@@ -62,9 +62,10 @@ func NewFactValueWithConf(factInterface interface{}, conf *Conf) (FactValue, err
 				return nil, err
 			}
 			if conf.SnakeCaseKeys {
-				key = strcase.ToSnake(key)
+				newMap[strcase.ToSnake(key)] = newValue
+			} else {
+				newMap[key] = newValue
 			}
-			newMap[key] = newValue
 		}
 		return &FactValueMap{Value: newMap}, nil
 	case bool, int, int32, int64, uint, uint32, uint64, float32, float64:

--- a/pkg/factsengine/entities/fact_value_test.go
+++ b/pkg/factsengine/entities/fact_value_test.go
@@ -16,7 +16,7 @@ func TestFactValueTestSuite(t *testing.T) {
 	suite.Run(t, new(FactValueTestSuite))
 }
 
-func (suite *FactValueTestSuite) TestNewFactValue() {
+func (suite *FactValueTestSuite) TestNewFactValueWithDefaultConf() {
 	cases := []struct {
 		description string
 		factValue   interface{}
@@ -89,7 +89,7 @@ func (suite *FactValueTestSuite) TestNewFactValue() {
 
 	for _, tt := range cases {
 		suite.T().Run(tt.description, func(t *testing.T) {
-			factValue, err := entities.NewFactValue(tt.factValue)
+			factValue, err := entities.NewFactValueWithDefaultConf(tt.factValue)
 
 			suite.Equal(tt.expected, factValue)
 			suite.Equal(tt.err, err)
@@ -97,7 +97,7 @@ func (suite *FactValueTestSuite) TestNewFactValue() {
 	}
 }
 
-func (suite *FactValueTestSuite) TestNewFactValueWithConf() {
+func (suite *FactValueTestSuite) TestNewFactValue() {
 	inputFactValue := map[string]interface{}{
 		"some Key":    "value",
 		"MyCamelCase": []interface{}{"string", "2", []interface{}{"1.5"}},
@@ -111,7 +111,7 @@ func (suite *FactValueTestSuite) TestNewFactValueWithConf() {
 		SnakeCaseKeys:    true,
 	}
 
-	factValue, err := entities.NewFactValueWithConf(inputFactValue, conf)
+	factValue, err := entities.NewFactValue(inputFactValue, conf)
 
 	expected := &entities.FactValueMap{
 		Value: map[string]entities.FactValue{

--- a/pkg/factsengine/entities/fact_value_test.go
+++ b/pkg/factsengine/entities/fact_value_test.go
@@ -16,7 +16,7 @@ func TestFactValueTestSuite(t *testing.T) {
 	suite.Run(t, new(FactValueTestSuite))
 }
 
-func (suite *FactValueTestSuite) TestNewFactValueWithDefaultConf() {
+func (suite *FactValueTestSuite) TestNewFactValueWithStringConversion() {
 	cases := []struct {
 		description string
 		factValue   interface{}
@@ -89,7 +89,7 @@ func (suite *FactValueTestSuite) TestNewFactValueWithDefaultConf() {
 
 	for _, tt := range cases {
 		suite.T().Run(tt.description, func(t *testing.T) {
-			factValue, err := entities.NewFactValueWithDefaultConf(tt.factValue)
+			factValue, err := entities.NewFactValue(tt.factValue, entities.WithStringConversion())
 
 			suite.Equal(tt.expected, factValue)
 			suite.Equal(tt.err, err)
@@ -97,7 +97,7 @@ func (suite *FactValueTestSuite) TestNewFactValueWithDefaultConf() {
 	}
 }
 
-func (suite *FactValueTestSuite) TestNewFactValue() {
+func (suite *FactValueTestSuite) TestNewFactValueWithSnakeCaseKeys() {
 	inputFactValue := map[string]interface{}{
 		"some Key":    "value",
 		"MyCamelCase": []interface{}{"string", "2", []interface{}{"1.5"}},
@@ -106,12 +106,9 @@ func (suite *FactValueTestSuite) TestNewFactValue() {
 		},
 	}
 
-	conf := &entities.Conf{
-		StringConversion: false,
-		SnakeCaseKeys:    true,
-	}
-
-	factValue, err := entities.NewFactValue(inputFactValue, conf)
+	factValue, err := entities.NewFactValue(
+		inputFactValue,
+		entities.WithSnakeCaseKeys())
 
 	expected := &entities.FactValueMap{
 		Value: map[string]entities.FactValue{

--- a/pkg/factsengine/entities/fact_value_test.go
+++ b/pkg/factsengine/entities/fact_value_test.go
@@ -97,6 +97,42 @@ func (suite *FactValueTestSuite) TestNewFactValue() {
 	}
 }
 
+func (suite *FactValueTestSuite) TestNewFactValueWithConf() {
+	inputFactValue := map[string]interface{}{
+		"some Key":    "value",
+		"MyCamelCase": []interface{}{"string", "2", []interface{}{"1.5"}},
+		"map": map[string]interface{}{
+			"int": 5,
+		},
+	}
+
+	conf := &entities.Conf{
+		StringConversion: false,
+		SnakeCaseKeys:    true,
+	}
+
+	factValue, err := entities.NewFactValueWithConf(inputFactValue, conf)
+
+	expected := &entities.FactValueMap{
+		Value: map[string]entities.FactValue{
+			"some_key": &entities.FactValueString{Value: "value"},
+			"my_camel_case": &entities.FactValueList{
+				Value: []entities.FactValue{
+					&entities.FactValueString{Value: "string"},
+					&entities.FactValueString{Value: "2"},
+					&entities.FactValueList{Value: []entities.FactValue{
+						&entities.FactValueString{Value: "1.5"},
+					}},
+				}},
+			"map": &entities.FactValueMap{Value: map[string]entities.FactValue{
+				"int": &entities.FactValueInt{Value: 5},
+			}},
+		}}
+
+	suite.Equal(expected, factValue)
+	suite.NoError(err)
+}
+
 func (suite *FactValueTestSuite) TestFactValueAsInterface() {
 	cases := []struct {
 		description string


### PR DESCRIPTION
Create `NewFactValueWithConf` to enable configuration of the `NewFactValue` function.
Initially only `SnakeCaseKeys` and `StringConversion` options are added