### PR TITLE
Handle nil value in NewFactValue

### DIFF
--- a/pkg/factsengine/entities/fact_value.go
+++ b/pkg/factsengine/entities/fact_value.go
@@ -89,9 +89,20 @@ func NewFactValue(factInterface interface{}, opts ...FactValueOption) (FactValue
 			return ParseStringToFactValue(value), nil
 		}
 		return &FactValueString{Value: value}, nil
+	case nil:
+		return &FactValueNil{}, nil
 	default:
 		return nil, fmt.Errorf("invalid type: %T for value: %v", value, factInterface)
 	}
+}
+
+type FactValueNil struct{}
+
+func (v *FactValueNil) isFactValue() {}
+
+// AsInterface converts a FactValueNil internal value to an interface{}.
+func (v *FactValueNil) AsInterface() interface{} {
+	return nil
 }
 
 type FactValueInt struct {

--- a/pkg/factsengine/entities/fact_value_test.go
+++ b/pkg/factsengine/entities/fact_value_test.go
@@ -16,6 +16,8 @@ func TestFactValueTestSuite(t *testing.T) {
 	suite.Run(t, new(FactValueTestSuite))
 }
 
+type UnknownType struct{}
+
 func (suite *FactValueTestSuite) TestNewFactValueWithStringConversion() {
 	cases := []struct {
 		description string
@@ -65,25 +67,31 @@ func (suite *FactValueTestSuite) TestNewFactValueWithStringConversion() {
 			err: nil,
 		},
 		{
-			description: "Should fail on basic unknown type",
+			description: "Should construct a nil type to FactValue",
 			factValue:   nil,
+			expected:    &entities.FactValueNil{},
+			err:         nil,
+		},
+		{
+			description: "Should fail on basic unknown type",
+			factValue:   UnknownType{},
 			expected:    nil,
-			err:         fmt.Errorf("invalid type: %T for value: %v", nil, nil),
+			err:         fmt.Errorf("invalid type: %T for value: %v", UnknownType{}, UnknownType{}),
 		},
 		{
 			description: "Should fail if a list contains an unknown type",
-			factValue:   []interface{}{"string", nil},
+			factValue:   []interface{}{"string", UnknownType{}},
 			expected:    nil,
-			err:         fmt.Errorf("invalid type: %T for value: %v", nil, nil),
+			err:         fmt.Errorf("invalid type: %T for value: %v", UnknownType{}, UnknownType{}),
 		},
 		{
 			description: "Should fail if a map contains an unknown type",
 			factValue: map[string]interface{}{
-				"basic": &entities.FactValueString{Value: "basic"},
-				"nil":   nil,
+				"basic": "basic",
+				"nil":   UnknownType{},
 			},
 			expected: nil,
-			err:      fmt.Errorf("invalid type: %T for value: %v", nil, nil),
+			err:      fmt.Errorf("invalid type: %T for value: %v", UnknownType{}, UnknownType{}),
 		},
 	}
 


### PR DESCRIPTION
Handle `nil` value in `NewFactValue`. For instance, the new saptune gatherer can have some null values, so we need to send them as null.
This doesn't mean that in many gatherers, if we get kind of `null` value we don't need to send a fact gathering error.

Fact output example. The `()` is the null value in rhai:
```
#{
  "$schema": "file:///usr/share/saptune/schemas/1.0/saptune_solution_verify.schema.json",
  "argv": "saptune --format json solution verify",
  "command": "solution verify",
  "exit_code": 0,
  "messages": [],
  "pid": 11179,
  "publish_time": "2023-09-26 16:02:18.474",
  "result": #{
    "attentions": [],
    "notes_enabled": [],
    "system_compliance": (),
    "verifications": []
  }
} 
```

# How it was tested

I tested together with wanda and web.
The value arrives properly what we visualize in the frontend as `NULL_VALUE`. I don't know if we need to change something there:

![image](https://github.com/trento-project/agent/assets/36370954/0e5cfbed-720b-4dbc-b9d1-0ea460d4742e)