### PR TITLE
Refactor NewSAPSystemsList to have a default function

### DIFF
--- a/internal/core/sapsystem/sapsystem.go
+++ b/internal/core/sapsystem/sapsystem.go
@@ -81,22 +81,29 @@ func Md5sum(data string) string {
 	return fmt.Sprintf("%x", md5.Sum([]byte(data))) //nolint:gosec
 }
 
+func NewDefaultSAPSystemsList() (SAPSystemsList, error) {
+	return NewSAPSystemsList(
+		afero.NewOsFs(),
+		utils.Executor{},
+		sapcontrolapi.WebServiceUnix{},
+	)
+}
+
 func NewSAPSystemsList(
+	fs afero.Fs,
 	executor utils.CommandExecutor,
 	webService sapcontrolapi.WebServiceConnector,
 ) (SAPSystemsList, error) {
-
 	var systems = SAPSystemsList{}
 
-	appFS := afero.NewOsFs()
-	systemPaths, err := FindSystems(appFS)
+	systemPaths, err := FindSystems(fs)
 	if err != nil {
 		return systems, errors.Wrap(err, "Error walking the path")
 	}
 
 	// Find systems
 	for _, sysPath := range systemPaths {
-		system, err := NewSAPSystem(appFS, executor, webService, sysPath)
+		system, err := NewSAPSystem(fs, executor, webService, sysPath)
 		if err != nil {
 			log.Printf("Error discovering a SAP system: %s", err)
 			continue

--- a/internal/discovery/sapsystem.go
+++ b/internal/discovery/sapsystem.go
@@ -6,9 +6,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"github.com/trento-project/agent/internal/core/sapsystem"
-	"github.com/trento-project/agent/internal/core/sapsystem/sapcontrolapi"
 	"github.com/trento-project/agent/internal/discovery/collector"
-	"github.com/trento-project/agent/pkg/utils"
 )
 
 const SAPDiscoveryID string = "sap_system_discovery"
@@ -37,7 +35,7 @@ func (d SAPSystemsDiscovery) GetInterval() time.Duration {
 }
 
 func (d SAPSystemsDiscovery) Discover() (string, error) {
-	systems, err := sapsystem.NewSAPSystemsList(utils.Executor{}, sapcontrolapi.WebServiceUnix{})
+	systems, err := sapsystem.NewDefaultSAPSystemsList()
 
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Following the same approach we use in the gatherers code, refactor `NewSAPSystemsList` function to accept the afero filesystem as variable, and create a `NewDefault` function.
This allows us to test the function