### PR TITLE
Gatherers versioning

### DIFF
--- a/internal/factsengine/factsengine_integration_test.go
+++ b/internal/factsengine/factsengine_integration_test.go
@@ -82,7 +82,7 @@ func (s *FactsEngineIntegrationTestGatherer) Gather(requests []entities.FactRequ
 func (suite *FactsEngineIntegrationTestSuite) TestFactsEngineIntegration() {
 	agentID := "some-agent"
 
-	gathererRegistry := gatherers.NewRegistry(gatherers.Tree{
+	gathererRegistry := gatherers.NewRegistry(gatherers.FactGatherersTree{
 		"integration": map[string]gatherers.FactGatherer{
 			"v1": NewFactsEngineIntegrationTestGatherer(),
 		},

--- a/internal/factsengine/factsengine_integration_test.go
+++ b/internal/factsengine/factsengine_integration_test.go
@@ -82,8 +82,10 @@ func (s *FactsEngineIntegrationTestGatherer) Gather(requests []entities.FactRequ
 func (suite *FactsEngineIntegrationTestSuite) TestFactsEngineIntegration() {
 	agentID := "some-agent"
 
-	gathererRegistry := gatherers.NewRegistry(map[string]gatherers.FactGatherer{
-		"integration": NewFactsEngineIntegrationTestGatherer(),
+	gathererRegistry := gatherers.NewRegistry(gatherers.Tree{
+		"integration": map[string]gatherers.FactGatherer{
+			"v1": NewFactsEngineIntegrationTestGatherer(),
+		},
 	})
 
 	engine := NewFactsEngine(agentID, suite.factsEngineService, *gathererRegistry)

--- a/internal/factsengine/gatherers/gatherer.go
+++ b/internal/factsengine/gatherers/gatherer.go
@@ -8,25 +8,61 @@ type FactGatherer interface {
 	Gather(factsRequests []entities.FactRequest) ([]entities.Fact, error)
 }
 
-func StandardGatherers() map[string]FactGatherer {
-	return map[string]FactGatherer{
-		CibAdminGathererName:        NewDefaultCibAdminGatherer(),
-		CorosyncCmapCtlGathererName: NewDefaultCorosyncCmapctlGatherer(),
-		CorosyncConfGathererName:    NewDefaultCorosyncConfGatherer(),
-		DirScanGathererName:         NewDefaultDirScanGatherer(),
-		FstabGathererName:           NewDefaultFstabGatherer(),
-		GroupsGathererName:          NewDefaultGroupsGatherer(),
-		HostsFileGathererName:       NewDefaultHostsFileGatherer(),
-		PackageVersionGathererName:  NewDefaultPackageVersionGatherer(),
-		PasswdGathererName:          NewDefaultPasswdGatherer(),
-		SapControlGathererName:      NewDefaultSapControlGatherer(),
-		SapHostCtrlGathererName:     NewDefaultSapHostCtrlGatherer(),
-		SapProfilesGathererName:     NewDefaultSapProfilesGatherer(),
-		SaptuneGathererName:         NewDefaultSaptuneGatherer(),
-		SBDConfigGathererName:       NewDefaultSBDGatherer(),
-		SBDDumpGathererName:         NewDefaultSBDDumpGatherer(),
-		SysctlGathererName:          NewDefaultSysctlGatherer(),
-		SystemDGathererName:         NewDefaultSystemDGatherer(),
-		VerifyPasswordGathererName:  NewDefaultPasswordGatherer(),
+func StandardGatherers() Tree {
+	return Tree{
+		CibAdminGathererName: map[string]FactGatherer{
+			"v1": NewDefaultCibAdminGatherer(),
+		},
+		CorosyncCmapCtlGathererName: map[string]FactGatherer{
+			"v1": NewDefaultCorosyncCmapctlGatherer(),
+		},
+		CorosyncConfGathererName: map[string]FactGatherer{
+			"v1": NewDefaultCorosyncConfGatherer(),
+		},
+		DirScanGathererName: map[string]FactGatherer{
+			"v1": NewDefaultDirScanGatherer(),
+		},
+		FstabGathererName: map[string]FactGatherer{
+			"v1": NewDefaultFstabGatherer(),
+		},
+		GroupsGathererName: map[string]FactGatherer{
+			"v1": NewDefaultGroupsGatherer(),
+		},
+		HostsFileGathererName: map[string]FactGatherer{
+			"v1": NewDefaultHostsFileGatherer(),
+		},
+		PackageVersionGathererName: map[string]FactGatherer{
+			"v1": NewDefaultPackageVersionGatherer(),
+		},
+		PasswdGathererName: map[string]FactGatherer{
+			"v1": NewDefaultPasswdGatherer(),
+		},
+		SapControlGathererName: map[string]FactGatherer{
+			"v1": NewDefaultSapControlGatherer(),
+		},
+		SapHostCtrlGathererName: map[string]FactGatherer{
+			"v1": NewDefaultSapHostCtrlGatherer(),
+		},
+		SapProfilesGathererName: map[string]FactGatherer{
+			"v1": NewDefaultSapProfilesGatherer(),
+		},
+		SaptuneGathererName: map[string]FactGatherer{
+			"v1": NewDefaultSaptuneGatherer(),
+		},
+		SBDConfigGathererName: map[string]FactGatherer{
+			"v1": NewDefaultSBDGatherer(),
+		},
+		SBDDumpGathererName: map[string]FactGatherer{
+			"v1": NewDefaultSBDDumpGatherer(),
+		},
+		SysctlGathererName: map[string]FactGatherer{
+			"v1": NewDefaultSysctlGatherer(),
+		},
+		SystemDGathererName: map[string]FactGatherer{
+			"v1": NewDefaultSystemDGatherer(),
+		},
+		VerifyPasswordGathererName: map[string]FactGatherer{
+			"v1": NewDefaultPasswordGatherer(),
+		},
 	}
 }

--- a/internal/factsengine/gatherers/gatherer.go
+++ b/internal/factsengine/gatherers/gatherer.go
@@ -8,8 +8,8 @@ type FactGatherer interface {
 	Gather(factsRequests []entities.FactRequest) ([]entities.Fact, error)
 }
 
-func StandardGatherers() Tree {
-	return Tree{
+func StandardGatherers() FactGatherersTree {
+	return FactGatherersTree{
 		CibAdminGathererName: map[string]FactGatherer{
 			"v1": NewDefaultCibAdminGatherer(),
 		},

--- a/internal/factsengine/gatherers/plugin.go
+++ b/internal/factsengine/gatherers/plugin.go
@@ -22,8 +22,8 @@ type PluginLoaders map[string]PluginLoader
 func GetGatherersFromPlugins(
 	loaders PluginLoaders,
 	pluginsFolder string,
-) (Tree, error) {
-	pluginFactGatherers := make(Tree)
+) (FactGatherersTree, error) {
+	pluginFactGatherers := make(FactGatherersTree)
 	log.Debugf("Loading plugins...")
 
 	plugins, err := filepath.Glob(fmt.Sprintf("%s/*", pluginsFolder))

--- a/internal/factsengine/gatherers/plugin.go
+++ b/internal/factsengine/gatherers/plugin.go
@@ -11,6 +11,8 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+const defaultPluginVersion = "v1"
+
 type PluginLoader interface {
 	Load(pluginPath string) (FactGatherer, error)
 }
@@ -20,8 +22,8 @@ type PluginLoaders map[string]PluginLoader
 func GetGatherersFromPlugins(
 	loaders PluginLoaders,
 	pluginsFolder string,
-) (map[string]FactGatherer, error) {
-	pluginFactGatherers := make(map[string]FactGatherer)
+) (Tree, error) {
+	pluginFactGatherers := make(Tree)
 	log.Debugf("Loading plugins...")
 
 	plugins, err := filepath.Glob(fmt.Sprintf("%s/*", pluginsFolder))
@@ -43,7 +45,9 @@ func GetGatherersFromPlugins(
 
 		name := path.Base(filePath)
 		name = strings.TrimSuffix(name, path.Ext(name))
-		pluginFactGatherers[name] = loadedPlugin
+		pluginFactGatherers[name] = map[string]FactGatherer{
+			defaultPluginVersion: loadedPlugin,
+		}
 		log.Debugf("Plugin %s loaded properly", filePath)
 	}
 

--- a/internal/factsengine/gatherers/plugin_test.go
+++ b/internal/factsengine/gatherers/plugin_test.go
@@ -53,9 +53,14 @@ func (suite *PluginTestSuite) TestPluginLoadPlugins() {
 
 	plugin1Name := path.Base(plugin1.Name())
 	plugin2Name := path.Base(plugin2.Name())
-	expectedGatherers := map[string]gatherers.FactGatherer{
-		plugin1Name: &mocks.FactGatherer{},
-		plugin2Name: &mocks.FactGatherer{},
+
+	expectedGatherers := gatherers.Tree{
+		plugin1Name: map[string]gatherers.FactGatherer{
+			"v1": &mocks.FactGatherer{},
+		},
+		plugin2Name: map[string]gatherers.FactGatherer{
+			"v1": &mocks.FactGatherer{},
+		},
 	}
 
 	suite.NoError(err)
@@ -78,7 +83,7 @@ func (suite *PluginTestSuite) TestPluginLoadPluginsError() {
 
 	loadedPlugins, err := gatherers.GetGatherersFromPlugins(loaders, pluginsFolder)
 
-	expectedGatherers := map[string]gatherers.FactGatherer{}
+	expectedGatherers := gatherers.Tree{}
 
 	suite.NoError(err)
 	suite.Equal(expectedGatherers, loadedPlugins)

--- a/internal/factsengine/gatherers/plugin_test.go
+++ b/internal/factsengine/gatherers/plugin_test.go
@@ -54,7 +54,7 @@ func (suite *PluginTestSuite) TestPluginLoadPlugins() {
 	plugin1Name := path.Base(plugin1.Name())
 	plugin2Name := path.Base(plugin2.Name())
 
-	expectedGatherers := gatherers.Tree{
+	expectedGatherers := gatherers.FactGatherersTree{
 		plugin1Name: map[string]gatherers.FactGatherer{
 			"v1": &mocks.FactGatherer{},
 		},
@@ -83,7 +83,7 @@ func (suite *PluginTestSuite) TestPluginLoadPluginsError() {
 
 	loadedPlugins, err := gatherers.GetGatherersFromPlugins(loaders, pluginsFolder)
 
-	expectedGatherers := gatherers.Tree{}
+	expectedGatherers := gatherers.FactGatherersTree{}
 
 	suite.NoError(err)
 	suite.Equal(expectedGatherers, loadedPlugins)

--- a/internal/factsengine/gatherers/registry.go
+++ b/internal/factsengine/gatherers/registry.go
@@ -1,32 +1,72 @@
 package gatherers
 
-import "github.com/pkg/errors"
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+type GathererNotFoundError struct {
+	Name string
+}
+
+func (e *GathererNotFoundError) Error() string {
+	return fmt.Sprintf("gatherer %s not found", e.Name)
+}
+
+// map[gathererName]map[GathererVersion]Gatherer
+type Tree map[string]map[string]FactGatherer
 
 type Registry struct {
-	gatherers map[string]FactGatherer
+	gatherers Tree
+}
+
+func NewRegistry(gatherers Tree) *Registry {
+	return &Registry{
+		gatherers: gatherers,
+	}
 }
 
 func (m *Registry) GetGatherer(name string) (FactGatherer, error) {
-	if g, found := m.gatherers[name]; found {
+	gathererName, version, err := extractVersionAndGathererName(name)
+	if err != nil {
+		return nil, err
+	}
+	if version == "" {
+		latestVersion, err := m.getLatestVersionForGatherer(name)
+		if err != nil {
+			return nil, err
+		}
+		version = latestVersion
+	}
+
+	if g, found := m.gatherers[gathererName][version]; found {
 		return g, nil
 	}
-	return nil, errors.Errorf("gatherer %s not found", name)
+	return nil, &GathererNotFoundError{Name: name}
 }
 
 func (m *Registry) AvailableGatherers() []string {
 	gatherersList := []string{}
 
-	for gatherer := range m.gatherers {
-		gatherersList = append(gatherersList, gatherer)
+	for gatherer, versions := range m.gatherers {
+		gathererVersions := []string{}
+		for v := range versions {
+			gathererVersions = append(gathererVersions, v)
+		}
+		gatherersList = append(
+			gatherersList,
+			fmt.Sprintf("%s - %s", gatherer, strings.Join(gathererVersions, "/")),
+		)
 	}
 
 	return gatherersList
 }
 
 // This is not safe, please not use concurrently.
-func (m *Registry) AddGatherers(gatherers map[string]FactGatherer) {
-	maps := []map[string]FactGatherer{m.gatherers, gatherers}
-	result := make(map[string]FactGatherer)
+func (m *Registry) AddGatherers(gatherers Tree) {
+	maps := []Tree{m.gatherers, gatherers}
+	result := make(Tree)
 
 	for _, m := range maps {
 		for k, v := range m {
@@ -36,8 +76,32 @@ func (m *Registry) AddGatherers(gatherers map[string]FactGatherer) {
 	m.gatherers = result
 }
 
-func NewRegistry(gatherers map[string]FactGatherer) *Registry {
-	return &Registry{
-		gatherers: gatherers,
+func (m *Registry) getLatestVersionForGatherer(name string) (string, error) {
+	availableGatherers, found := m.gatherers[name]
+	if !found {
+		return "", &GathererNotFoundError{Name: name}
 	}
+	versions := []string{}
+	for v := range availableGatherers {
+		versions = append(versions, v)
+	}
+
+	sort.Strings(versions)
+
+	return versions[len(versions)-1], nil
+}
+
+func extractVersionAndGathererName(gathererName string) (string, string, error) {
+	parts := strings.Split(gathererName, "@")
+	if len(parts) == 1 {
+		// no version found, just gatherer name
+		return parts[0], "", nil
+	}
+	if len(parts) != 2 {
+		return "", "", fmt.Errorf(
+			"could not extract the gatherer version from %s, version should follow <gathererName>@<version> syntax",
+			gathererName,
+		)
+	}
+	return parts[0], parts[1], nil
 }

--- a/internal/factsengine/gatherers/registry.go
+++ b/internal/factsengine/gatherers/registry.go
@@ -54,6 +54,7 @@ func (m *Registry) AvailableGatherers() []string {
 		for v := range versions {
 			gathererVersions = append(gathererVersions, v)
 		}
+		sort.Strings(gathererVersions)
 		gatherersList = append(
 			gatherersList,
 			fmt.Sprintf("%s - %s", gatherer, strings.Join(gathererVersions, "/")),

--- a/internal/factsengine/gatherers/registry_test.go
+++ b/internal/factsengine/gatherers/registry_test.go
@@ -18,14 +18,14 @@ func TestRegistryTest(t *testing.T) {
 }
 
 func (suite *RegistryTest) TestRegistryAddAndGetGatherers() {
-	registry := gatherers.NewRegistry(gatherers.Tree{
+	registry := gatherers.NewRegistry(gatherers.FactGatherersTree{
 		gatherers.CorosyncConfGathererName: map[string]gatherers.FactGatherer{
 			"v1": &mocks.FactGatherer{},
 			"v2": &mocks.FactGatherer{},
 		},
 	})
 
-	registry.AddGatherers(gatherers.Tree{
+	registry.AddGatherers(gatherers.FactGatherersTree{
 		"test": map[string]gatherers.FactGatherer{
 			"v1": &mocks.FactGatherer{},
 			"v2": &mocks.FactGatherer{},
@@ -51,7 +51,7 @@ func (suite *RegistryTest) TestRegistryAddAndGetGatherers() {
 }
 
 func (suite *RegistryTest) TestRegistryGetGathererInvalidGathererFormat() {
-	registry := gatherers.NewRegistry(gatherers.Tree{
+	registry := gatherers.NewRegistry(gatherers.FactGatherersTree{
 		gatherers.CorosyncConfGathererName: map[string]gatherers.FactGatherer{
 			"v1": &mocks.FactGatherer{},
 			"v2": &mocks.FactGatherer{},
@@ -64,7 +64,7 @@ func (suite *RegistryTest) TestRegistryGetGathererInvalidGathererFormat() {
 }
 
 func (suite *RegistryTest) TestRegistryGetGathererNotFoundWithoutVersion() {
-	registry := gatherers.NewRegistry(gatherers.Tree{
+	registry := gatherers.NewRegistry(gatherers.FactGatherersTree{
 		gatherers.CorosyncConfGathererName: map[string]gatherers.FactGatherer{
 			"v1": &mocks.FactGatherer{},
 			"v2": &mocks.FactGatherer{},
@@ -77,7 +77,7 @@ func (suite *RegistryTest) TestRegistryGetGathererNotFoundWithoutVersion() {
 }
 
 func (suite *RegistryTest) TestRegistryGetGathererNotFoundWithVersion() {
-	registry := gatherers.NewRegistry(gatherers.Tree{
+	registry := gatherers.NewRegistry(gatherers.FactGatherersTree{
 		gatherers.CorosyncConfGathererName: map[string]gatherers.FactGatherer{
 			"v1": &mocks.FactGatherer{},
 			"v2": &mocks.FactGatherer{},
@@ -91,7 +91,7 @@ func (suite *RegistryTest) TestRegistryGetGathererNotFoundWithVersion() {
 
 func (suite *RegistryTest) TestRegistryGetGathererFoundWithVersion() {
 	expectedGatherer := &mocks.FactGatherer{}
-	registry := gatherers.NewRegistry(gatherers.Tree{
+	registry := gatherers.NewRegistry(gatherers.FactGatherersTree{
 		"other": map[string]gatherers.FactGatherer{
 			"v1": expectedGatherer,
 			"v2": &mocks.FactGatherer{},
@@ -106,7 +106,7 @@ func (suite *RegistryTest) TestRegistryGetGathererFoundWithVersion() {
 
 func (suite *RegistryTest) TestRegistryGetGathererFoundWithoutVersion() {
 	expectedGatherer := gatherers.NewDefaultFstabGatherer()
-	registry := gatherers.NewRegistry(gatherers.Tree{
+	registry := gatherers.NewRegistry(gatherers.FactGatherersTree{
 		"other": map[string]gatherers.FactGatherer{
 			"v1": &mocks.FactGatherer{},
 			"v2": expectedGatherer,

--- a/internal/factsengine/gatherers/registry_test.go
+++ b/internal/factsengine/gatherers/registry_test.go
@@ -17,28 +17,29 @@ func TestRegistryTest(t *testing.T) {
 	suite.Run(t, new(RegistryTest))
 }
 
-func (suite *RegistryTest) RegistryTestGetGatherer() {
-	registry := gatherers.NewRegistry(map[string]gatherers.FactGatherer{
-		gatherers.CorosyncConfGathererName: gatherers.NewDefaultCorosyncConfGatherer(),
+func (suite *RegistryTest) TestRegistryAddAndGetGatherers() {
+	registry := gatherers.NewRegistry(gatherers.Tree{
+		gatherers.CorosyncConfGathererName: map[string]gatherers.FactGatherer{
+			"v1": &mocks.FactGatherer{},
+			"v2": &mocks.FactGatherer{},
+		},
 	})
 
-	r, err := registry.GetGatherer(gatherers.CorosyncConfGathererName)
-	expectedGatherer := gatherers.NewDefaultCorosyncConfGatherer()
-
-	suite.NoError(err)
-	suite.Equal(expectedGatherer, r)
-}
-
-func (suite *RegistryTest) RegistryTestAddGatherers() {
-	registry := gatherers.NewRegistry(map[string]gatherers.FactGatherer{
-		gatherers.CorosyncConfGathererName: gatherers.NewDefaultCorosyncConfGatherer(),
+	registry.AddGatherers(gatherers.Tree{
+		"test": map[string]gatherers.FactGatherer{
+			"v1": &mocks.FactGatherer{},
+			"v2": &mocks.FactGatherer{},
+		},
+		"test2": map[string]gatherers.FactGatherer{
+			"v1": &mocks.FactGatherer{},
+		},
 	})
 
-	registry.AddGatherers(map[string]gatherers.FactGatherer{
-		"test": &mocks.FactGatherer{},
-	})
-
-	expectedGatherers := []string{gatherers.CorosyncConfGathererName, "test"}
+	expectedGatherers := []string{
+		"corosync.conf - v1/v2",
+		"test - v1/v2",
+		"test2 - v1",
+	}
 
 	// we sort the array in order to have consistency in the tests
 	// map keys are not ordered ofc
@@ -49,25 +50,71 @@ func (suite *RegistryTest) RegistryTestAddGatherers() {
 	suite.Equal(expectedGatherers, result)
 }
 
-func (suite *RegistryTest) TestFactsEngineGetGathererNotFound() {
-	registry := gatherers.NewRegistry(map[string]gatherers.FactGatherer{
-		gatherers.CorosyncConfGathererName: gatherers.NewDefaultCorosyncConfGatherer(),
+func (suite *RegistryTest) TestRegistryGetGathererInvalidGathererFormat() {
+	registry := gatherers.NewRegistry(gatherers.Tree{
+		gatherers.CorosyncConfGathererName: map[string]gatherers.FactGatherer{
+			"v1": &mocks.FactGatherer{},
+			"v2": &mocks.FactGatherer{},
+		},
 	})
+
+	_, err := registry.GetGatherer("other@v2@v2")
+
+	suite.EqualError(err, "could not extract the gatherer version from other@v2@v2, version should follow <gathererName>@<version> syntax")
+}
+
+func (suite *RegistryTest) TestRegistryGetGathererNotFoundWithoutVersion() {
+	registry := gatherers.NewRegistry(gatherers.Tree{
+		gatherers.CorosyncConfGathererName: map[string]gatherers.FactGatherer{
+			"v1": &mocks.FactGatherer{},
+			"v2": &mocks.FactGatherer{},
+		},
+	})
+
 	_, err := registry.GetGatherer("other")
 
 	suite.EqualError(err, "gatherer other not found")
 }
 
-func (suite *RegistryTest) RegistryTestAvailableGatherers() {
-	registry := gatherers.NewRegistry(map[string]gatherers.FactGatherer{
-		"rdummyGatherer1": &mocks.FactGatherer{},
-		"dummyGatherer2":  &mocks.FactGatherer{},
-		"errorGatherer":   &mocks.FactGatherer{},
+func (suite *RegistryTest) TestRegistryGetGathererNotFoundWithVersion() {
+	registry := gatherers.NewRegistry(gatherers.Tree{
+		gatherers.CorosyncConfGathererName: map[string]gatherers.FactGatherer{
+			"v1": &mocks.FactGatherer{},
+			"v2": &mocks.FactGatherer{},
+		},
 	})
 
-	gatherers := registry.AvailableGatherers()
+	_, err := registry.GetGatherer("other@v1")
 
-	expectedGatherers := []string{"dummyGatherer1", "dummyGatherer2", "errorGatherer"}
+	suite.EqualError(err, "gatherer other@v1 not found")
+}
 
-	suite.ElementsMatch(expectedGatherers, gatherers)
+func (suite *RegistryTest) TestRegistryGetGathererFoundWithVersion() {
+	expectedGatherer := &mocks.FactGatherer{}
+	registry := gatherers.NewRegistry(gatherers.Tree{
+		"other": map[string]gatherers.FactGatherer{
+			"v1": expectedGatherer,
+			"v2": &mocks.FactGatherer{},
+		},
+	})
+
+	result, err := registry.GetGatherer("other@v1")
+
+	suite.NoError(err)
+	suite.Equal(expectedGatherer, result)
+}
+
+func (suite *RegistryTest) TestRegistryGetGathererFoundWithoutVersion() {
+	expectedGatherer := gatherers.NewDefaultFstabGatherer()
+	registry := gatherers.NewRegistry(gatherers.Tree{
+		"other": map[string]gatherers.FactGatherer{
+			"v1": &mocks.FactGatherer{},
+			"v2": expectedGatherer,
+		},
+	})
+
+	result, err := registry.GetGatherer("other")
+
+	suite.NoError(err)
+	suite.Equal(expectedGatherer, result)
 }

--- a/internal/factsengine/gathering_test.go
+++ b/internal/factsengine/gathering_test.go
@@ -67,7 +67,7 @@ func (suite *GatheringTestSuite) TestGatheringGatherFacts() {
 			},
 		}, nil).Times(1)
 
-	registry := gatherers.NewRegistry(gatherers.Tree{
+	registry := gatherers.NewRegistry(gatherers.FactGatherersTree{
 		"dummyGatherer1": map[string]gatherers.FactGatherer{
 			"v1": dummyGathererOne,
 		},
@@ -137,7 +137,7 @@ func (suite *GatheringTestSuite) TestFactsEngineGatherFactsGathererNotFound() {
 			},
 		}, nil).Times(1)
 
-	registry := gatherers.NewRegistry(gatherers.Tree{
+	registry := gatherers.NewRegistry(gatherers.FactGatherersTree{
 		"dummyGatherer1": map[string]gatherers.FactGatherer{
 			"v1": dummyGathererOne,
 		},
@@ -196,7 +196,7 @@ func (suite *GatheringTestSuite) TestFactsEngineGatherFactsErrorGathering() {
 	errorGatherer.On("Gather", mock.Anything).
 		Return(nil, &entities.FactGatheringError{Type: "dummy-type", Message: "some error"}).Times(1)
 
-	registry := gatherers.NewRegistry(gatherers.Tree{
+	registry := gatherers.NewRegistry(gatherers.FactGatherersTree{
 		"dummyGatherer1": map[string]gatherers.FactGatherer{
 			"v1": dummyGathererOne,
 		},

--- a/internal/factsengine/gathering_test.go
+++ b/internal/factsengine/gathering_test.go
@@ -67,9 +67,13 @@ func (suite *GatheringTestSuite) TestGatheringGatherFacts() {
 			},
 		}, nil).Times(1)
 
-	registry := gatherers.NewRegistry(map[string]gatherers.FactGatherer{
-		"dummyGatherer1": dummyGathererOne,
-		"dummyGatherer2": dummyGathererTwo,
+	registry := gatherers.NewRegistry(gatherers.Tree{
+		"dummyGatherer1": map[string]gatherers.FactGatherer{
+			"v1": dummyGathererOne,
+		},
+		"dummyGatherer2": map[string]gatherers.FactGatherer{
+			"v1": dummyGathererTwo,
+		},
 	})
 
 	factResults, err := gatherFacts(suite.executionID, suite.agentID, suite.groupID, &factsRequest, *registry)
@@ -133,9 +137,13 @@ func (suite *GatheringTestSuite) TestFactsEngineGatherFactsGathererNotFound() {
 			},
 		}, nil).Times(1)
 
-	registry := gatherers.NewRegistry(map[string]gatherers.FactGatherer{
-		"dummyGatherer1": dummyGathererOne,
-		"dummyGatherer2": dummyGathererTwo,
+	registry := gatherers.NewRegistry(gatherers.Tree{
+		"dummyGatherer1": map[string]gatherers.FactGatherer{
+			"v1": dummyGathererOne,
+		},
+		"dummyGatherer2": map[string]gatherers.FactGatherer{
+			"v1": dummyGathererTwo,
+		},
 	})
 
 	factResults, err := gatherFacts(suite.executionID, suite.agentID, suite.groupID, &factsRequest, *registry)
@@ -188,9 +196,13 @@ func (suite *GatheringTestSuite) TestFactsEngineGatherFactsErrorGathering() {
 	errorGatherer.On("Gather", mock.Anything).
 		Return(nil, &entities.FactGatheringError{Type: "dummy-type", Message: "some error"}).Times(1)
 
-	registry := gatherers.NewRegistry(map[string]gatherers.FactGatherer{
-		"dummyGatherer1": dummyGathererOne,
-		"errorGatherer":  errorGatherer,
+	registry := gatherers.NewRegistry(gatherers.Tree{
+		"dummyGatherer1": map[string]gatherers.FactGatherer{
+			"v1": dummyGathererOne,
+		},
+		"errorGatherer": map[string]gatherers.FactGatherer{
+			"v1": errorGatherer,
+		},
 	})
 
 	factResults, err := gatherFacts(suite.executionID, suite.agentID, suite.groupID, &factsRequest, *registry)


### PR DESCRIPTION
This PR aims to provide a versioning mechanism for gatherers.

The gatherers are expected to have version in the form of `v<VERSION_NUMBER>`, where `version number` is an integer starting from 1, the default version for all gatherers.

The gatherer version is extracted from the gatherer name, in the form of `<gatherer_name>@<version>`, when no version is provided, the latest version will be used. 

Latest version means the higher version number available.

If a gatherer is not found a certain version (or not found at all), the standard gatherer not found error is returned.

The gatherer versioning follows a tree-like structure, you can see an example in the `StandardGatherers` implementation.

```
{
   "gatherer_name": { 
       "gatherer_version": TheGathererInstance,
       "another_gatherer_version": AnotherGathererInstance,
   },
}
```
Plugins by default will be on the `v1` version.

In the future we could opt for a semantic versioning system, without breaking the current versioning system.