### PR TITLE
Add .tool-versions file

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+golang 1.18.1
+mockery 2.32.3


### PR DESCRIPTION
Add .tool-versions file.
This way we use the same version of golang and mockery