### PR TITLE
Sapservices gatherer 

### DIFF
--- a/internal/factsengine/gatherers/gatherer.go
+++ b/internal/factsengine/gatherers/gatherer.go
@@ -49,6 +49,9 @@ func StandardGatherers() FactGatherersTree {
 		SapProfilesGathererName: map[string]FactGatherer{
 			"v1": NewDefaultSapProfilesGatherer(),
 		},
+		SapServicesGathererName: map[string]FactGatherer{
+			"v1": NewDefaultSapServicesGatherer(),
+		},
 		SaptuneGathererName: map[string]FactGatherer{
 			"v1": NewDefaultSaptuneGatherer(),
 		},

--- a/internal/factsengine/gatherers/sapservices.go
+++ b/internal/factsengine/gatherers/sapservices.go
@@ -1,0 +1,180 @@
+package gatherers
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/afero"
+	"github.com/trento-project/agent/pkg/factsengine/entities"
+)
+
+type SapServicesStartupKind string
+
+const (
+	SapServicesSystemdStartup  SapServicesStartupKind = "systemctl"
+	SapServicesSapstartStartup SapServicesStartupKind = "sapstartsrv"
+	sapServicesDefaultPath                            = "/usr/sap/sapservices"
+	SapServicesGathererName                           = "sapservices"
+)
+
+// nolint:gochecknoglobals
+var (
+	SapServicesParsingError = entities.FactGatheringError{
+		Type:    "sap-services-parsing-error",
+		Message: "error parsing the sap services file",
+	}
+	SapServicesFileError = entities.FactGatheringError{
+		Type:    "sap-services-parsing-error",
+		Message: "error reading the sap services file",
+	}
+	SapstartSIDExtractionPattern = regexp.MustCompile(`(?s)pf=([^[:space:]]+)/(.*?)_`)
+	SystemdSIDExtractionPattern  = regexp.MustCompile(`(?s)start SAP(.*?)_.* `)
+)
+
+type SapServicesEntry struct {
+	SID     string                 `json:"sid"`
+	Kind    SapServicesStartupKind `json:"kind"`
+	Content string                 `json:"content"`
+}
+
+func systemdStartup(sapServicesContent string) bool {
+	return strings.Contains(sapServicesContent, "systemctl")
+}
+
+func sapstartStartup(sapServicesContent string) bool {
+	return strings.Contains(sapServicesContent, "sapstartsrv")
+}
+
+func extractSIDFromSystemdService(sapServicesContent string) string {
+	matches := SystemdSIDExtractionPattern.FindStringSubmatch(sapServicesContent)
+	if len(matches) != 2 {
+		return ""
+	}
+	return matches[1]
+}
+
+func extractSIDFromSapstartService(sapServicesContent string) string {
+	matches := SapstartSIDExtractionPattern.FindStringSubmatch(sapServicesContent)
+	if len(matches) != 2 {
+		return ""
+	}
+	return matches[1]
+}
+
+type SapServices struct {
+	fs               afero.Fs
+	servicesFilePath string
+}
+
+func NewSapServicesGatherer(servicesFilePath string, fs afero.Fs) *SapServices {
+	return &SapServices{
+		servicesFilePath: servicesFilePath,
+		fs:               fs,
+	}
+}
+
+func NewDefaultSapServicesGatherer() *SapServices {
+	return &SapServices{servicesFilePath: sapServicesDefaultPath, fs: afero.NewOsFs()}
+}
+
+func (s *SapServices) Gather(factsRequests []entities.FactRequest) ([]entities.Fact, error) {
+	facts := []entities.Fact{}
+	log.Infof("Starting %s facts gathering process", SapServicesGathererName)
+
+	entries, err := s.getSapServicesFileEntries()
+	if err != nil {
+		return nil, err
+	}
+
+	factValues, err := convertSapServicesEntriesToFactValue(entries)
+	if err != nil {
+		return nil, SapServicesParsingError.Wrap(err.Error())
+	}
+
+	for _, requestedFact := range factsRequests {
+		fact := entities.NewFactGatheredWithRequest(requestedFact, factValues)
+
+		facts = append(facts, fact)
+	}
+
+	log.Infof("Requested %s facts gathered", SapServicesGathererName)
+	return facts, nil
+}
+
+func (s *SapServices) getSapServicesFileEntries() ([]SapServicesEntry, error) {
+	f, err := s.fs.Open(s.servicesFilePath)
+	if err != nil {
+		return nil, SapServicesFileError.Wrap(err.Error())
+	}
+
+	defer func() {
+		err := f.Close()
+		if err != nil {
+			log.Error(err)
+		}
+	}()
+
+	fileScanner := bufio.NewScanner(f)
+	fileScanner.Split(bufio.ScanLines)
+
+	var entries []SapServicesEntry
+
+	for fileScanner.Scan() {
+		scannedLine := fileScanner.Text()
+		if strings.HasPrefix(scannedLine, "#") || scannedLine == "" {
+			continue
+		}
+		entry := SapServicesEntry{}
+		entry.Content = scannedLine
+
+		if systemdStartup(scannedLine) {
+			entry.Kind = SapServicesSystemdStartup
+			sid := extractSIDFromSystemdService(scannedLine)
+			if sid == "" {
+				return nil, SapServicesParsingError.Wrap(
+					fmt.Sprintf("could not extract sid from systemd sap services entry: %s", scannedLine),
+				)
+			}
+			entry.SID = sid
+		}
+
+		if sapstartStartup(scannedLine) {
+			entry.Kind = SapServicesSapstartStartup
+			sid := extractSIDFromSapstartService(scannedLine)
+			if sid == "" {
+				return nil, SapServicesParsingError.Wrap(
+					fmt.Sprintf("could not extract sid from sapstartsrv sap services entry: %s", scannedLine),
+				)
+			}
+			entry.SID = sid
+		}
+
+		if entry.Kind == "" {
+			// the line is not a recognized entry
+			continue
+		}
+
+		entries = append(entries, entry)
+	}
+
+	return entries, nil
+}
+
+func convertSapServicesEntriesToFactValue(entries []SapServicesEntry) (entities.FactValue, error) {
+	marshalled, err := json.Marshal(&entries)
+	if err != nil {
+		return nil, err
+	}
+
+	var unmarshalled []interface{}
+	err = json.Unmarshal(marshalled, &unmarshalled)
+	if err != nil {
+		return nil, err
+	}
+
+	return entities.NewFactValue(unmarshalled, entities.WithStringConversion())
+}

--- a/internal/factsengine/gatherers/sapservices.go
+++ b/internal/factsengine/gatherers/sapservices.go
@@ -25,13 +25,13 @@ const (
 var (
 	SapServicesParsingError = entities.FactGatheringError{
 		Type:    "sap-services-parsing-error",
-		Message: "error parsing the sap services file",
+		Message: "error parsing the sapservices file",
 	}
 	SapServicesFileError = entities.FactGatheringError{
-		Type:    "sap-services-parsing-error",
-		Message: "error reading the sap services file",
+		Type:    "sap-services-reading-error",
+		Message: "error reading the sapservices file",
 	}
-	SapstartSIDExtractionPattern = regexp.MustCompile(`(?s)pf=([^[:space:]]+)/(.*?)_.*_.*`)
+	SapstartSIDExtractionPattern = regexp.MustCompile(`(?s)pf=[^[:space:]]+/(.*?)_.*_.*`)
 	SystemdSIDExtractionPattern  = regexp.MustCompile(`(?s)start SAP(.*?)_.*`)
 )
 
@@ -59,10 +59,10 @@ func extractSIDFromSystemdService(sapServicesContent string) string {
 
 func extractSIDFromSapstartService(sapServicesContent string) string {
 	matches := SapstartSIDExtractionPattern.FindStringSubmatch(sapServicesContent)
-	if len(matches) != 3 {
+	if len(matches) != 2 {
 		return ""
 	}
-	return matches[2]
+	return matches[1]
 }
 
 type SapServices struct {
@@ -137,7 +137,7 @@ func (s *SapServices) getSapServicesFileEntries() ([]SapServicesEntry, error) {
 			extractedSID := extractSIDFromSystemdService(scannedLine)
 			if extractedSID == "" {
 				return nil, SapServicesParsingError.Wrap(
-					fmt.Sprintf("could not extract sid from systemd sap services entry: %s", scannedLine),
+					fmt.Sprintf("could not extract sid from systemd SAP services entry: %s", scannedLine),
 				)
 			}
 			sid = extractedSID
@@ -148,7 +148,7 @@ func (s *SapServices) getSapServicesFileEntries() ([]SapServicesEntry, error) {
 			extractedSID := extractSIDFromSapstartService(scannedLine)
 			if extractedSID == "" {
 				return nil, SapServicesParsingError.Wrap(
-					fmt.Sprintf("could not extract sid from sapstartsrv sap services entry: %s", scannedLine),
+					fmt.Sprintf("could not extract sid from sapstartsrv SAP services entry: %s", scannedLine),
 				)
 			}
 			sid = extractedSID

--- a/internal/factsengine/gatherers/sapservices.go
+++ b/internal/factsengine/gatherers/sapservices.go
@@ -32,7 +32,7 @@ var (
 		Message: "error reading the sap services file",
 	}
 	SapstartSIDExtractionPattern = regexp.MustCompile(`(?s)pf=([^[:space:]]+)/(.*?)_`)
-	SystemdSIDExtractionPattern  = regexp.MustCompile(`(?s)start SAP(.*?)_.* `)
+	SystemdSIDExtractionPattern  = regexp.MustCompile(`(?s)start SAP(.*?)_.*`)
 )
 
 type SapServicesEntry struct {
@@ -59,10 +59,10 @@ func extractSIDFromSystemdService(sapServicesContent string) string {
 
 func extractSIDFromSapstartService(sapServicesContent string) string {
 	matches := SapstartSIDExtractionPattern.FindStringSubmatch(sapServicesContent)
-	if len(matches) != 2 {
+	if len(matches) != 3 {
 		return ""
 	}
-	return matches[1]
+	return matches[2]
 }
 
 type SapServices struct {
@@ -125,7 +125,7 @@ func (s *SapServices) getSapServicesFileEntries() ([]SapServicesEntry, error) {
 
 	for fileScanner.Scan() {
 		scannedLine := fileScanner.Text()
-		if strings.HasPrefix(scannedLine, "#") || scannedLine == "" {
+		if strings.HasPrefix(scannedLine, "#") || strings.HasPrefix(scannedLine, "//") || scannedLine == "" {
 			continue
 		}
 		entry := SapServicesEntry{}

--- a/internal/factsengine/gatherers/sapservices_test.go
+++ b/internal/factsengine/gatherers/sapservices_test.go
@@ -1,0 +1,83 @@
+package gatherers_test
+
+import (
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/suite"
+	"github.com/trento-project/agent/internal/factsengine/gatherers"
+	"github.com/trento-project/agent/pkg/factsengine/entities"
+)
+
+type SapServicesGathererSuite struct {
+	suite.Suite
+}
+
+func TestSapServicesGathererSuite(t *testing.T) {
+	suite.Run(t, new(SapServicesGathererSuite))
+}
+
+func (s *SapServicesGathererSuite) TestGatheringFileNotFound() {
+	tFs := afero.NewMemMapFs()
+	g := gatherers.NewSapServicesGatherer("/usr/sap/sapservices", tFs)
+
+	fr := []entities.FactRequest{
+		{
+			Name:     "sapservices",
+			CheckID:  "check1",
+			Gatherer: "sapservices",
+		},
+	}
+
+	result, err := g.Gather(fr)
+	s.Nil(result)
+	s.EqualError(err, "fact gathering error: sap-services-parsing-error - error reading the sap services file: open /usr/sap/sapservices: file does not exist")
+}
+
+func (s *SapServicesGathererSuite) TestGatheringSIDNotIdentifiedSystemd() {
+	tFs := afero.NewMemMapFs()
+	_ = afero.WriteFile(tFs, "/usr/sap/sapservices", []byte(`
+#!/bin/sh
+limit.descriptors=1048576
+systemctl --no-ask-password start SAPS41_40 
+systemctl --no-ask-password start SADS41_41
+`), 0777)
+
+	fr := []entities.FactRequest{
+		{
+			Name:     "sapservices",
+			CheckID:  "check1",
+			Gatherer: "sapservices",
+		},
+	}
+
+	g := gatherers.NewSapServicesGatherer("/usr/sap/sapservices", tFs)
+	result, err := g.Gather(fr)
+	s.Nil(result)
+	s.EqualError(err, "fact gathering error: sap-services-parsing-error - error parsing the sap services file: could not extract sid from systemd sap services entry: systemctl --no-ask-password start SADS41_41")
+
+}
+
+func (s *SapServicesGathererSuite) TestGatheringSIDNotIdentifiedSapstart() {
+	tFs := afero.NewMemMapFs()
+	_ = afero.WriteFile(tFs, "/usr/sap/sapservices", []byte(`
+#!/bin/sh
+limit.descriptors=1048576
+LD_LIBRARY_PATH=/usr/sap/HS1/HDB11/exe:$LD_LIBRARY_PATH;export LD_LIBRARY_PATH;/usr/sap/HS1/HDB11/exe/sapstartsrv pf=/usr/sap/HS1/SYS/profile/HS1HDB11_s41db -D -u hs1adm
+LD_LIBRARY_PATH=/usr/sap/S41/ASCS41/exe:$LD_LIBRARY_PATH; export LD_LIBRARY_PATH; /usr/sap/S41/ASCS41/exe/sapstartsrv pf=/usr/sap/S41/SYS/profile/S41_ASCS41_s41app -D -u s41adm
+LD_LIBRARY_PATH=/usr/sap/S41/D40/exe:$LD_LIBRARY_PATH; export LD_LIBRARY_PATH; /usr/sap/S41/D40/exe/sapstartsrv pf=/usr/sap/S41/SYS/profile/S41_D40_s41app -D -u s41adm
+`), 0777)
+
+	fr := []entities.FactRequest{
+		{
+			Name:     "sapservices",
+			CheckID:  "check1",
+			Gatherer: "sapservices",
+		},
+	}
+
+	g := gatherers.NewSapServicesGatherer("/usr/sap/sapservices", tFs)
+	result, err := g.Gather(fr)
+	s.Nil(result)
+	s.EqualError(err, "fact gathering error: sap-services-parsing-error - error parsing the sap services file: could not extract sid from sapstartsrv sap services entry: LD_LIBRARY_PATH=/usr/sap/HS1/HDB11/exe:$LD_LIBRARY_PATH;export LD_LIBRARY_PATH;/usr/sap/HS1/HDB11/exe/sapstartsrv pf=/usr/sap/HS1/SYS/profile/HS1HDB11_s41db -D -u hs1adm")
+}

--- a/internal/factsengine/gatherers/sapservices_test.go
+++ b/internal/factsengine/gatherers/sapservices_test.go
@@ -17,7 +17,7 @@ func TestSapServicesGathererSuite(t *testing.T) {
 	suite.Run(t, new(SapServicesGathererSuite))
 }
 
-func (s *SapServicesGathererSuite) TestGatheringFileNotFound() {
+func (s *SapServicesGathererSuite) TestSapServicesGathererFileNotFound() {
 	tFs := afero.NewMemMapFs()
 	g := gatherers.NewSapServicesGatherer("/usr/sap/sapservices", tFs)
 
@@ -31,10 +31,10 @@ func (s *SapServicesGathererSuite) TestGatheringFileNotFound() {
 
 	result, err := g.Gather(fr)
 	s.Nil(result)
-	s.EqualError(err, "fact gathering error: sap-services-parsing-error - error reading the sap services file: open /usr/sap/sapservices: file does not exist")
+	s.EqualError(err, "fact gathering error: sap-services-reading-error - error reading the sapservices file: open /usr/sap/sapservices: file does not exist")
 }
 
-func (s *SapServicesGathererSuite) TestGatheringSIDNotIdentifiedSystemd() {
+func (s *SapServicesGathererSuite) TestSapServicesGathererSIDNotIdentifiedSystemd() {
 	tFs := afero.NewMemMapFs()
 	_ = afero.WriteFile(tFs, "/usr/sap/sapservices", []byte(`
 #!/bin/sh
@@ -54,11 +54,11 @@ systemctl --no-ask-password start SADS41_41
 	g := gatherers.NewSapServicesGatherer("/usr/sap/sapservices", tFs)
 	result, err := g.Gather(fr)
 	s.Nil(result)
-	s.EqualError(err, "fact gathering error: sap-services-parsing-error - error parsing the sap services file: could not extract sid from systemd sap services entry: systemctl --no-ask-password start SADS41_41")
+	s.EqualError(err, "fact gathering error: sap-services-parsing-error - error parsing the sapservices file: could not extract sid from systemd SAP services entry: systemctl --no-ask-password start SADS41_41")
 
 }
 
-func (s *SapServicesGathererSuite) TestGatheringSIDNotIdentifiedSapstart() {
+func (s *SapServicesGathererSuite) TestSapServicesGathererSIDNotIdentifiedSapstart() {
 	tFs := afero.NewMemMapFs()
 	_ = afero.WriteFile(tFs, "/usr/sap/sapservices", []byte(`
 #!/bin/sh
@@ -79,10 +79,10 @@ LD_LIBRARY_PATH=/usr/sap/S41/D40/exe:$LD_LIBRARY_PATH; export LD_LIBRARY_PATH; /
 	g := gatherers.NewSapServicesGatherer("/usr/sap/sapservices", tFs)
 	result, err := g.Gather(fr)
 	s.Nil(result)
-	s.EqualError(err, "fact gathering error: sap-services-parsing-error - error parsing the sap services file: could not extract sid from sapstartsrv sap services entry: LD_LIBRARY_PATH=/usr/sap/HS1/HDB11/exe:$LD_LIBRARY_PATH;export LD_LIBRARY_PATH;/usr/sap/HS1/HDB11/exe/sapstartsrv pf=/usr/sap/HS1/SYS/profile/HS1HDB11_s41db -D -u hs1adm")
+	s.EqualError(err, "fact gathering error: sap-services-parsing-error - error parsing the sapservices file: could not extract sid from sapstartsrv SAP services entry: LD_LIBRARY_PATH=/usr/sap/HS1/HDB11/exe:$LD_LIBRARY_PATH;export LD_LIBRARY_PATH;/usr/sap/HS1/HDB11/exe/sapstartsrv pf=/usr/sap/HS1/SYS/profile/HS1HDB11_s41db -D -u hs1adm")
 }
 
-func (s *SapServicesGathererSuite) TestGatheringSuccessSapstart() {
+func (s *SapServicesGathererSuite) TestSapServicesGathererSuccessSapstart() { //nolint:dupl
 	tFs := afero.NewMemMapFs()
 	_ = afero.WriteFile(tFs, "/usr/sap/sapservices", []byte(`
 #!/bin/sh
@@ -129,7 +129,7 @@ LD_LIBRARY_PATH=/usr/sap/S41/ASCS41/exe:$LD_LIBRARY_PATH; export LD_LIBRARY_PATH
 	s.EqualValues(expectedFacts, result)
 }
 
-func (s *SapServicesGathererSuite) TestGatheringSuccessSystemd() {
+func (s *SapServicesGathererSuite) TestSapServicesGathererSuccessSystemd() { //nolint:dupl
 	tFs := afero.NewMemMapFs()
 	_ = afero.WriteFile(tFs, "/usr/sap/sapservices", []byte(`
 #!/bin/sh

--- a/internal/factsengine/gatherers/sapservices_test.go
+++ b/internal/factsengine/gatherers/sapservices_test.go
@@ -81,3 +81,97 @@ LD_LIBRARY_PATH=/usr/sap/S41/D40/exe:$LD_LIBRARY_PATH; export LD_LIBRARY_PATH; /
 	s.Nil(result)
 	s.EqualError(err, "fact gathering error: sap-services-parsing-error - error parsing the sap services file: could not extract sid from sapstartsrv sap services entry: LD_LIBRARY_PATH=/usr/sap/HS1/HDB11/exe:$LD_LIBRARY_PATH;export LD_LIBRARY_PATH;/usr/sap/HS1/HDB11/exe/sapstartsrv pf=/usr/sap/HS1/SYS/profile/HS1HDB11_s41db -D -u hs1adm")
 }
+
+func (s *SapServicesGathererSuite) TestGatheringSuccessSapstart() {
+	tFs := afero.NewMemMapFs()
+	_ = afero.WriteFile(tFs, "/usr/sap/sapservices", []byte(`
+#!/bin/sh
+limit.descriptors=1048576
+LD_LIBRARY_PATH=/usr/sap/HS1/HDB11/exe:$LD_LIBRARY_PATH;export LD_LIBRARY_PATH;/usr/sap/HS1/HDB11/exe/sapstartsrv pf=/usr/sap/HS1/SYS/profile/HS1_HDB11_s41db -D -u hs1adm
+LD_LIBRARY_PATH=/usr/sap/S41/ASCS41/exe:$LD_LIBRARY_PATH; export LD_LIBRARY_PATH; /usr/sap/S41/ASCS41/exe/sapstartsrv pf=/usr/sap/S41/SYS/profile/S41_ASCS41_s41app -D -u s41adm
+`), 0777)
+
+	fr := []entities.FactRequest{
+		{
+			Name:     "sapservices",
+			CheckID:  "check1",
+			Gatherer: "sapservices",
+		},
+	}
+
+	expectedFacts := []entities.Fact{
+		{
+			Name:    "sapservices",
+			CheckID: "check1",
+			Value: &entities.FactValueList{
+				Value: []entities.FactValue{
+					&entities.FactValueMap{
+						Value: map[string]entities.FactValue{
+							"sid":     &entities.FactValueString{Value: "HS1"},
+							"kind":    &entities.FactValueString{Value: "sapstartsrv"},
+							"content": &entities.FactValueString{Value: "LD_LIBRARY_PATH=/usr/sap/HS1/HDB11/exe:$LD_LIBRARY_PATH;export LD_LIBRARY_PATH;/usr/sap/HS1/HDB11/exe/sapstartsrv pf=/usr/sap/HS1/SYS/profile/HS1_HDB11_s41db -D -u hs1adm"},
+						},
+					},
+					&entities.FactValueMap{
+						Value: map[string]entities.FactValue{
+							"sid":     &entities.FactValueString{Value: "S41"},
+							"kind":    &entities.FactValueString{Value: "sapstartsrv"},
+							"content": &entities.FactValueString{Value: "LD_LIBRARY_PATH=/usr/sap/S41/ASCS41/exe:$LD_LIBRARY_PATH; export LD_LIBRARY_PATH; /usr/sap/S41/ASCS41/exe/sapstartsrv pf=/usr/sap/S41/SYS/profile/S41_ASCS41_s41app -D -u s41adm"},
+						},
+					},
+				},
+			},
+		},
+	}
+	g := gatherers.NewSapServicesGatherer("/usr/sap/sapservices", tFs)
+	result, err := g.Gather(fr)
+	s.NoError(err)
+	s.EqualValues(expectedFacts, result)
+}
+
+func (s *SapServicesGathererSuite) TestGatheringSuccessSystemd() {
+	tFs := afero.NewMemMapFs()
+	_ = afero.WriteFile(tFs, "/usr/sap/sapservices", []byte(`
+#!/bin/sh
+limit.descriptors=1048576
+systemctl --no-ask-password start SAPS41_40
+systemctl --no-ask-password start SAPS42_41
+`), 0777)
+
+	fr := []entities.FactRequest{
+		{
+			Name:     "sapservices",
+			CheckID:  "check1",
+			Gatherer: "sapservices",
+		},
+	}
+
+	expectedFacts := []entities.Fact{
+		{
+			Name:    "sapservices",
+			CheckID: "check1",
+			Value: &entities.FactValueList{
+				Value: []entities.FactValue{
+					&entities.FactValueMap{
+						Value: map[string]entities.FactValue{
+							"sid":     &entities.FactValueString{Value: "S41"},
+							"kind":    &entities.FactValueString{Value: "systemctl"},
+							"content": &entities.FactValueString{Value: "systemctl --no-ask-password start SAPS41_40"},
+						},
+					},
+					&entities.FactValueMap{
+						Value: map[string]entities.FactValue{
+							"sid":     &entities.FactValueString{Value: "S42"},
+							"kind":    &entities.FactValueString{Value: "systemctl"},
+							"content": &entities.FactValueString{Value: "systemctl --no-ask-password start SAPS42_41"},
+						},
+					},
+				},
+			},
+		},
+	}
+	g := gatherers.NewSapServicesGatherer("/usr/sap/sapservices", tFs)
+	result, err := g.Gather(fr)
+	s.NoError(err)
+	s.EqualValues(expectedFacts, result)
+}


### PR DESCRIPTION
Gatherer for sapservices file, by default `/usr/sap/sapservices`.

Return each entry of sapservices file as a map, with the kind of startup system used, `systemd` or `sapservices`