### PR TITLE
Products gatherer

### DIFF
--- a/internal/factsengine/gatherers/cibadmin.go
+++ b/internal/factsengine/gatherers/cibadmin.go
@@ -49,7 +49,7 @@ func (g *CibAdminGatherer) Gather(factsRequests []entities.FactRequest) ([]entit
 		"nvpair": true, "op": true, "rsc_location": true, "rsc_order": true,
 		"rsc_colocation": true, "cluster_property_set": true, "meta_attributes": true}
 
-	factValueMap, err := parseXMLToFactValueMap(cibadmin, elementsToList)
+	factValueMap, err := parseXMLToFactValueMap(cibadmin, elementsToList, entities.WithStringConversion())
 	if err != nil {
 		return nil, CibAdminDecodingError.Wrap(err.Error())
 	}

--- a/internal/factsengine/gatherers/gatherer.go
+++ b/internal/factsengine/gatherers/gatherer.go
@@ -46,6 +46,9 @@ func StandardGatherers() FactGatherersTree {
 		PasswdGathererName: map[string]FactGatherer{
 			"v1": NewDefaultPasswdGatherer(),
 		},
+		ProductsGathererName: map[string]FactGatherer{
+			"v1": NewDefaultProductsGatherer(),
+		},
 		SapControlGathererName: map[string]FactGatherer{
 			"v1": NewDefaultSapControlGatherer(),
 		},

--- a/internal/factsengine/gatherers/products.go
+++ b/internal/factsengine/gatherers/products.go
@@ -1,0 +1,110 @@
+package gatherers
+
+import (
+	"path"
+
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/afero"
+	"github.com/trento-project/agent/pkg/factsengine/entities"
+)
+
+const (
+	ProductsGathererName = "products"
+	productsDefaultPath  = "/etc/products.d/"
+)
+
+// nolint:gochecknoglobals
+var (
+	ProductsFolderMissingError = entities.FactGatheringError{
+		Type:    "products-folder-missing-error",
+		Message: "products folder does not exist",
+	}
+
+	ProductsFolderReadingError = entities.FactGatheringError{
+		Type:    "products-folder-reading-error",
+		Message: "error reading the products folder",
+	}
+
+	ProductsFileReadingError = entities.FactGatheringError{
+		Type:    "products-file-reading-error",
+		Message: "error reading the products file",
+	}
+
+	elementsToList = map[string]bool{
+		"distrotarget":      true,
+		"repository":        true,
+		"language":          true,
+		"url":               true,
+		"productdependency": true,
+	}
+)
+
+type ProductsGatherer struct {
+	fs           afero.Fs
+	productsPath string
+}
+
+func NewProductsGatherer(fs afero.Fs, productsPath string) *ProductsGatherer {
+	return &ProductsGatherer{
+		fs:           fs,
+		productsPath: productsPath,
+	}
+}
+
+func NewDefaultProductsGatherer() *ProductsGatherer {
+	return &ProductsGatherer{fs: afero.NewOsFs(), productsPath: productsDefaultPath}
+}
+
+func (g *ProductsGatherer) Gather(factsRequests []entities.FactRequest) ([]entities.Fact, error) {
+	facts := []entities.Fact{}
+	log.Infof("Starting %s facts gathering process", ProductsGathererName)
+
+	if exists, _ := afero.DirExists(g.fs, g.productsPath); !exists {
+		gatheringError := ProductsFolderMissingError.Wrap(g.productsPath)
+		log.Error(gatheringError.Error())
+		return nil, gatheringError
+	}
+
+	productFiles, err := afero.ReadDir(g.fs, g.productsPath)
+	if err != nil {
+		gatheringError := ProductsFolderReadingError.Wrap(g.productsPath).Wrap(err.Error())
+		log.Error(gatheringError.Error())
+		return nil, gatheringError
+	}
+
+	productsFactValueMap := make(map[string]entities.FactValue)
+	for _, productFile := range productFiles {
+		productFileName := productFile.Name()
+		product, err := parseProductFile(g.fs, path.Join(g.productsPath, productFileName))
+		if err != nil {
+			gatheringError := ProductsFileReadingError.Wrap(productFileName).Wrap(err.Error())
+			log.Error(gatheringError.Error())
+			return nil, gatheringError
+		}
+
+		productsFactValueMap[productFileName] = product
+	}
+
+	for _, requestedFact := range factsRequests {
+		facts = append(facts, entities.NewFactGatheredWithRequest(
+			requestedFact, &entities.FactValueMap{Value: productsFactValueMap}))
+	}
+
+	log.Infof("Requested %s facts gathered", ProductsGathererName)
+	return facts, nil
+}
+
+func parseProductFile(fs afero.Fs, productFilePath string) (entities.FactValue, error) {
+	productFile, err := afero.ReadFile(fs, productFilePath)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not open product file")
+	}
+
+	factValueMap, err := parseXMLToFactValueMap(productFile, elementsToList)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not parse product file")
+	}
+
+	return factValueMap, nil
+}

--- a/internal/factsengine/gatherers/products.go
+++ b/internal/factsengine/gatherers/products.go
@@ -31,7 +31,7 @@ var (
 		Message: "error reading the products file",
 	}
 
-	elementsToList = map[string]bool{
+	productsXMLelementsToList = map[string]bool{
 		"distrotarget":      true,
 		"repository":        true,
 		"language":          true,
@@ -101,7 +101,7 @@ func parseProductFile(fs afero.Fs, productFilePath string) (entities.FactValue, 
 		return nil, errors.Wrap(err, "could not open product file")
 	}
 
-	factValueMap, err := parseXMLToFactValueMap(productFile, elementsToList)
+	factValueMap, err := parseXMLToFactValueMap(productFile, productsXMLelementsToList)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not parse product file")
 	}

--- a/internal/factsengine/gatherers/products_test.go
+++ b/internal/factsengine/gatherers/products_test.go
@@ -1,0 +1,183 @@
+package gatherers_test
+
+import (
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/suite"
+	"github.com/trento-project/agent/internal/factsengine/gatherers"
+	"github.com/trento-project/agent/pkg/factsengine/entities"
+)
+
+type ProductsGathererSuite struct {
+	suite.Suite
+	//fs             afero.Fs
+	productsPath string
+}
+
+func TestProductsGathererSuite(t *testing.T) {
+	suite.Run(t, new(ProductsGathererSuite))
+}
+
+func (s *ProductsGathererSuite) SetupTest() {
+	// 	fs := afero.NewMemMapFs()
+	// 	err := fs.MkdirAll("/etc/products.d/", 0644)
+	// 	s.NoError(err)
+
+	// 	err = afero.WriteFile(fs, "/etc/products.d/baseproduct", []byte(`
+	// #!/bin/sh
+	// limit.descriptors=1048576
+	// systemctl --no-ask-password start SAPS41_40
+	// systemctl --no-ask-password start SADS41_41
+	// `), 0777)
+	// 	s.NoError(err)
+
+	// 	s.fs = fs
+	s.productsPath = "/etc/products.d/"
+}
+
+func (s *ProductsGathererSuite) TestProductsGathererFolderMissingError() {
+	fs := afero.NewMemMapFs()
+
+	fr := []entities.FactRequest{
+		{
+			Name:     "missing_folder",
+			Gatherer: "products@v1",
+			CheckID:  "check1",
+		},
+	}
+
+	gatherer := gatherers.NewProductsGatherer(fs, s.productsPath)
+
+	results, err := gatherer.Gather(fr)
+	s.Nil(results)
+	s.EqualError(err, "fact gathering error: products-folder-missing-error - "+
+		"products folder does not exist: /etc/products.d/")
+}
+
+func (s *ProductsGathererSuite) TestProductsGathererReadingError() {
+	fs := afero.NewMemMapFs()
+
+	err := afero.WriteFile(fs, "/etc/products.d/baseproduct", []byte(`
+<?xml version="1.0" encoding="UTF-8"?>
+<product schemeversion="0">
+	<vendor>openSUSE</vendor>
+	<name>Leap</name>
+	<version>15.3</version>
+	<release>2</releas
+`), 0777)
+
+	s.NoError(err)
+
+	fr := []entities.FactRequest{
+		{
+			Name:     "invalid_xml",
+			Gatherer: "products@v1",
+			CheckID:  "check1",
+		},
+	}
+
+	gatherer := gatherers.NewProductsGatherer(fs, s.productsPath)
+
+	results, err := gatherer.Gather(fr)
+	s.Nil(results)
+	s.EqualError(err, "fact gathering error: products-file-reading-error - "+
+		"error reading the products file: baseproduct: could not parse product file: "+
+		"xml.Decoder.Token() - XML syntax error on line 8: unexpected EOF")
+}
+
+func (s *ProductsGathererSuite) TestProductsGathererSuccess() {
+	fs := afero.NewMemMapFs()
+
+	err := afero.WriteFile(fs, "/etc/products.d/baseproduct", []byte(`
+<?xml version="1.0" encoding="UTF-8"?>
+<product schemeversion="0">
+	<vendor>openSUSE</vendor>
+	<name>Leap</name>
+	<version>15.3</version>
+	<release>2</release>
+	<urls>
+		<url name="releasenotes">http://doc.opensuse.org/release-notes-openSUSE.rpm</url>
+	</urls>
+</product>
+`), 0777)
+
+	err = afero.WriteFile(fs, "/etc/products.d/otherproduct", []byte(`
+<?xml version="1.0" encoding="UTF-8"?>
+<product schemeversion="0">
+	<vendor>openSUSE</vendor>
+	<name>Other</name>
+	<version>15.5</version>
+	<release>1</release>
+</product>
+`), 0777)
+
+	s.NoError(err)
+
+	fr := []entities.FactRequest{
+		{
+			Name:     "products",
+			Gatherer: "products@v1",
+			CheckID:  "check1",
+		},
+	}
+
+	gatherer := gatherers.NewProductsGatherer(fs, s.productsPath)
+
+	expectedFacts := []entities.Fact{
+		{
+			Name:    "products",
+			CheckID: "check1",
+			Value: &entities.FactValueMap{
+				Value: map[string]entities.FactValue{
+					"baseproduct": &entities.FactValueMap{
+						Value: map[string]entities.FactValue{
+							"product": &entities.FactValueMap{
+								Value: map[string]entities.FactValue{
+									"schemeversion": &entities.FactValueInt{Value: 0},
+									"vendor":        &entities.FactValueString{Value: "openSUSE"},
+									"name":          &entities.FactValueString{Value: "Leap"},
+									"version":       &entities.FactValueString{Value: "15.3"},
+									"release":       &entities.FactValueString{Value: "2"},
+									"urls": &entities.FactValueMap{
+										Value: map[string]entities.FactValue{
+											"url": &entities.FactValueList{
+												Value: []entities.FactValue{
+													&entities.FactValueMap{
+														Value: map[string]entities.FactValue{
+															"name":  &entities.FactValueString{Value: "releasenotes"},
+															"#text": &entities.FactValueString{Value: "http://doc.opensuse.org/release-notes-openSUSE.rpm"},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					"otherproduct": &entities.FactValueMap{
+						Value: map[string]entities.FactValue{
+							"product": &entities.FactValueMap{
+								Value: map[string]entities.FactValue{
+									"schemeversion": &entities.FactValueInt{Value: 0},
+									"vendor":        &entities.FactValueString{Value: "openSUSE"},
+									"name":          &entities.FactValueString{Value: "Other"},
+									"version":       &entities.FactValueString{Value: "15.5"},
+									"release":       &entities.FactValueString{Value: "1"},
+								},
+							},
+						},
+					},
+				},
+			},
+			Error: nil,
+		},
+	}
+
+	results, err := gatherer.Gather(fr)
+	s.NoError(err)
+	s.EqualValues(expectedFacts, results)
+
+}

--- a/internal/factsengine/gatherers/xml.go
+++ b/internal/factsengine/gatherers/xml.go
@@ -12,7 +12,11 @@ func init() {
 	mxj.PrependAttrWithHyphen(false)
 }
 
-func parseXMLToFactValueMap(xmlContent []byte, elementsToList map[string]bool) (*entities.FactValueMap, error) {
+func parseXMLToFactValueMap(
+	xmlContent []byte,
+	elementsToList map[string]bool,
+	factValueOpts ...entities.FactValueOption) (*entities.FactValueMap, error) {
+
 	mv, err := mxj.NewMapXml(xmlContent)
 	if err != nil {
 		return nil, err
@@ -20,7 +24,7 @@ func parseXMLToFactValueMap(xmlContent []byte, elementsToList map[string]bool) (
 
 	mapValue := map[string]interface{}(mv)
 	updatedMap := convertListElements(mapValue, elementsToList)
-	factValue, err := entities.NewFactValue(updatedMap, entities.WithStringConversion())
+	factValue, err := entities.NewFactValue(updatedMap, factValueOpts...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
`/etc/products.d/` folder products information gatherer.
It walks the path searching for all files and returns the value on them, mapped for file names.
It returns all the fields available in the xml, basically, because it is even easier to return everything rather than picking specific values. <- FYI @abravosuse 

```
#> ./trento-agent facts gather --gatherer products
INFO[2023-10-31 08:44:01] loading plugins                              
INFO[2023-10-31 08:44:01] Starting products facts gathering process    
INFO[2023-10-31 08:44:01] Requested products facts gathered            
INFO[2023-10-31 08:44:01] Gathered fact for "products" with argument "": 
INFO[2023-10-31 08:44:01] Name: 
Check ID: 

Value:

#{
  "Leap.prod": #{
    "product": #{
      "arch": "x86_64",
      "buildconfig": #{
        "create_flavors": "true",
        "producttheme": "openSUSE"
      },
      "codestream": #{
        "endoflife": "2024-11-30",
        "name": "openSUSE Leap 15"
      },
      "cpeid": "cpe:/o:opensuse:leap:15.3",
      "description": "openSUSE Leap 15.3.",
      "endoflife": "2022-11-30",
      ...
      "name": "Leap",
      "productline": "Leap",
      ...
      "release": "2",
      ...
    }
  },
  "baseproduct": #{
    "product": #{
      "arch": "x86_64",
      ...
      "codestream": #{
        "endoflife": "2024-11-30",
        "name": "openSUSE Leap 15"
      },
     ...
      "name": "Leap",
      "productline": "Leap",
      ...
      "vendor": "openSUSE",
      "version": "15.3"
    }
  }
} 

```

The check could simply look like (but you could loop around all the products as well):
```
facts.products.baseproduct.product.vendor == "openSUSE"
```
