### PR TITLE
Refactor gatherers package tests

### DIFF
--- a/internal/factsengine/gatherers/corosyncconf_test.go
+++ b/internal/factsengine/gatherers/corosyncconf_test.go
@@ -1,9 +1,10 @@
-package gatherers
+package gatherers_test
 
 import (
 	"testing"
 
 	"github.com/stretchr/testify/suite"
+	"github.com/trento-project/agent/internal/factsengine/gatherers"
 	"github.com/trento-project/agent/pkg/factsengine/entities"
 	"github.com/trento-project/agent/test/helpers"
 )
@@ -16,13 +17,8 @@ func TestCorosyncConfTestSuite(t *testing.T) {
 	suite.Run(t, new(CorosyncConfTestSuite))
 }
 
-func (suite *CorosyncConfTestSuite) TestCorosyncConfDefault() {
-	c := NewDefaultCorosyncConfGatherer()
-	suite.Equal("/etc/corosync/corosync.conf", c.configFile)
-}
-
 func (suite *CorosyncConfTestSuite) TestCorosyncConfBasic() {
-	c := NewCorosyncConfGatherer(helpers.GetFixturePath("gatherers/corosync.conf.basic"))
+	c := gatherers.NewCorosyncConfGatherer(helpers.GetFixturePath("gatherers/corosync.conf.basic"))
 
 	factsRequest := []entities.FactRequest{
 		{
@@ -128,7 +124,7 @@ func (suite *CorosyncConfTestSuite) TestCorosyncConfBasic() {
 }
 
 func (suite *CorosyncConfTestSuite) TestCorosyncConfOneNode() {
-	c := NewCorosyncConfGatherer(helpers.GetFixturePath("gatherers/corosync.conf.one_node"))
+	c := gatherers.NewCorosyncConfGatherer(helpers.GetFixturePath("gatherers/corosync.conf.one_node"))
 
 	factsRequest := []entities.FactRequest{
 		{
@@ -160,7 +156,7 @@ func (suite *CorosyncConfTestSuite) TestCorosyncConfOneNode() {
 }
 
 func (suite *CorosyncConfTestSuite) TestCorosyncConfThreeNodes() {
-	c := NewCorosyncConfGatherer(helpers.GetFixturePath("gatherers/corosync.conf.three_node"))
+	c := gatherers.NewCorosyncConfGatherer(helpers.GetFixturePath("gatherers/corosync.conf.three_node"))
 
 	factsRequest := []entities.FactRequest{
 		{
@@ -202,7 +198,7 @@ func (suite *CorosyncConfTestSuite) TestCorosyncConfThreeNodes() {
 }
 
 func (suite *CorosyncConfTestSuite) TestCorosyncConfFileNotExists() {
-	c := NewCorosyncConfGatherer("not_found")
+	c := gatherers.NewCorosyncConfGatherer("not_found")
 
 	factsRequest := []entities.FactRequest{
 		{
@@ -225,7 +221,7 @@ func (suite *CorosyncConfTestSuite) TestCorosyncConfFileNotExists() {
 }
 
 func (suite *CorosyncConfTestSuite) TestCorosyncConfInvalid() {
-	c := NewCorosyncConfGatherer(helpers.GetFixturePath("gatherers/corosync.conf.invalid"))
+	c := gatherers.NewCorosyncConfGatherer(helpers.GetFixturePath("gatherers/corosync.conf.invalid"))
 
 	factsRequest := []entities.FactRequest{
 		{

--- a/internal/factsengine/gatherers/verifypassword.go
+++ b/internal/factsengine/gatherers/verifypassword.go
@@ -73,7 +73,7 @@ func (g *VerifyPasswordGatherer) Gather(factsRequests []entities.FactRequest) ([
 
 		crypter := sha512crypt.New()
 		isPasswordWeak := false
-		var gatheringError *entities.FactGatheringError = nil
+		var gatheringError *entities.FactGatheringError
 		for _, password := range unsafePasswords {
 			passwordBytes := []byte(password)
 

--- a/internal/factsengine/gatherers/verifypassword_test.go
+++ b/internal/factsengine/gatherers/verifypassword_test.go
@@ -1,9 +1,10 @@
-package gatherers
+package gatherers_test
 
 import (
 	"testing"
 
 	"github.com/stretchr/testify/suite"
+	"github.com/trento-project/agent/internal/factsengine/gatherers"
 	"github.com/trento-project/agent/pkg/factsengine/entities"
 	utilsMocks "github.com/trento-project/agent/pkg/utils/mocks"
 )
@@ -29,7 +30,7 @@ func (suite *PasswordTestSuite) TestPasswordGatherEqual() {
 	suite.mockExecutor.On("Exec", "getent", "shadow", "hacluster").Return(
 		shadow, nil)
 
-	verifyPasswordGatherer := NewVerifyPasswordGatherer(suite.mockExecutor)
+	verifyPasswordGatherer := gatherers.NewVerifyPasswordGatherer(suite.mockExecutor)
 
 	factRequests := []entities.FactRequest{
 		{
@@ -62,7 +63,7 @@ func (suite *PasswordTestSuite) TestPasswordGatherNotEqual() {
 	suite.mockExecutor.On("Exec", "getent", "shadow", "hacluster").Return(
 		shadow, nil)
 
-	verifyPasswordGatherer := NewVerifyPasswordGatherer(suite.mockExecutor)
+	verifyPasswordGatherer := gatherers.NewVerifyPasswordGatherer(suite.mockExecutor)
 
 	factRequests := []entities.FactRequest{
 		{
@@ -93,7 +94,7 @@ func (suite *PasswordTestSuite) TestPasswordGatherCryptError() {
 	suite.mockExecutor.On("Exec", "getent", "shadow", "hacluster").Return(
 		shadow, nil)
 
-	verifyPasswordGatherer := NewVerifyPasswordGatherer(suite.mockExecutor)
+	verifyPasswordGatherer := gatherers.NewVerifyPasswordGatherer(suite.mockExecutor)
 
 	factRequests := []entities.FactRequest{
 		{
@@ -123,7 +124,7 @@ func (suite *PasswordTestSuite) TestPasswordGatherCryptError() {
 }
 
 func (suite *PasswordTestSuite) TestPasswordGatherWrongArguments() {
-	verifyPasswordGatherer := &VerifyPasswordGatherer{} // nolint
+	verifyPasswordGatherer := gatherers.NewVerifyPasswordGatherer(suite.mockExecutor)
 
 	factRequests := []entities.FactRequest{
 		{


### PR DESCRIPTION
Refactor `gatherers` package tests to follow the `package_test` convention.
In this case, we did a good job, since only the `corosyncconf` and `verifypassword` packages had a wrong usage.