### PR TITLE
Add testpackage to golangci

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -45,6 +45,7 @@ linters:
     - unconvert
     - unparam
     - wastedassign
+    - testpackage
 
 issues:
   exclude-rules:


### PR DESCRIPTION
A good reminder that we need to follow the `package_test` rule!
The CI should pass once we have fixed all the packages in other PRs.
If for some reason we need to exclude some package, we can add exceptions, but by general rule, all of them should be compliant.

https://github.com/maratori/testpackage