### PR TITLE
Print fact gathering error in facts gather cmd call

### DIFF
--- a/cmd/facts.go
+++ b/cmd/facts.go
@@ -110,7 +110,18 @@ func gather(*cobra.Command, []string) {
 
 	value, err := g.Gather(factRequest)
 	if err != nil {
+		log.Errorf("Error gathering fact \"%s\" with argument \"%s\"", gatherer, argument)
 		cleanupAndFatal(err)
+	}
+
+	if len(value) != 1 {
+		log.Printf("No value gathered for \"%s\" with argument \"%s\"", gatherer, argument)
+		return
+	}
+
+	if value[0].Error != nil {
+		log.Errorf("Error gathering fact \"%s\" with argument \"%s\"", gatherer, argument)
+		cleanupAndFatal(value[0].Error)
 	}
 
 	result, err := value[0].Prettify()


### PR DESCRIPTION
While playing a bit with some gatherers, I have noticed that we don't print properly the error message if we have a fact gathering error.

So we move from:

```
INFO[2023-11-28 14:25:43] Starting password verifying facts gathering process 
ERRO[2023-11-28 14:25:43] fact gathering error: verify-password-password-not-set - password authentication not set for user: redis 
INFO[2023-11-28 14:25:43] Requested password verifying facts gathered  
INFO[2023-11-28 14:25:43] Gathered fact for "verify_password" with argument "redis": 
INFO[2023-11-28 14:25:43] Name: redis
Check ID: 

Value:

()  
```

To

```
INFO[2023-11-28 14:37:27] loading plugins                              
INFO[2023-11-28 14:37:27] Starting password verifying facts gathering process 
ERRO[2023-11-28 14:37:27] fact gathering error: verify-password-invalid-username - requested user is not whitelisted for password check: redis 
INFO[2023-11-28 14:37:27] Requested password verifying facts gathered  
ERRO[2023-11-28 14:37:27] Error gathering fact "verify_password" with argument "redis": 
ERRO[2023-11-28 14:37:27] fact gathering error: verify-password-invalid-username - requested user is not whitelisted for password check: redis
```

PD: In this case it logs twice because we have an explicit `log.Error` in the gatherer code, but this doesn't happen always