### PR TITLE
Fix verify_password gatherer for scenarios where there is not hash

### DIFF
--- a/internal/factsengine/gatherers/verifypassword.go
+++ b/internal/factsengine/gatherers/verifypassword.go
@@ -18,8 +18,9 @@ const (
 
 // nolint:gochecknoglobals
 var (
-	checkableUsernames = []string{"hacluster"}
-	unsafePasswords    = []string{"linux"}
+	checkableUsernames   = []string{"hacluster"}
+	unsafePasswords      = []string{"linux"}
+	passwordNotSetValues = []string{"!", "*"}
 )
 
 // nolint:gochecknoglobals
@@ -27,6 +28,16 @@ var (
 	VerifyPasswordInvalidUsername = entities.FactGatheringError{
 		Type:    "verify-password-invalid-username",
 		Message: "requested user is not whitelisted for password check",
+	}
+
+	VerifyPasswordShadowError = entities.FactGatheringError{
+		Type:    "verify-password-shadow-error",
+		Message: "error getting shadow output",
+	}
+
+	VerifyPasswordPasswordNotSet = entities.FactGatheringError{
+		Type:    "verify-password-password-not-set",
+		Message: "password authentication not set for user",
 	}
 
 	VerifyPasswordCryptError = entities.FactGatheringError{
@@ -59,17 +70,26 @@ func (g *VerifyPasswordGatherer) Gather(factsRequests []entities.FactRequest) ([
 	for _, factReq := range factsRequests {
 		if !utils.Contains(checkableUsernames, factReq.Argument) {
 			gatheringError := VerifyPasswordInvalidUsername.Wrap(factReq.Argument)
-			fact := entities.NewFactGatheredWithError(factReq, gatheringError)
-			facts = append(facts, fact)
+			log.Error(gatheringError)
+			facts = append(facts, entities.NewFactGatheredWithError(factReq, gatheringError))
 			continue
 		}
 		username := factReq.Argument
 
-		salt, hash, err := g.getSalt(username)
+		hash, err := g.getHash(username)
 		if err != nil {
-			log.Error(err)
+			gatheringError := VerifyPasswordShadowError.Wrap(err.Error())
+			log.Error(gatheringError)
+			facts = append(facts, entities.NewFactGatheredWithError(factReq, gatheringError))
+			continue
+		} else if utils.Contains(passwordNotSetValues, hash) {
+			gatheringError := VerifyPasswordPasswordNotSet.Wrap(username)
+			log.Error(gatheringError)
+			facts = append(facts, entities.NewFactGatheredWithError(factReq, gatheringError))
+			continue
 		}
-		log.Debugf("Obtained salt using user %s: %s", username, salt)
+
+		log.Debugf("Obtained hash using user %s: %s", username, hash)
 
 		crypter := sha512crypt.New()
 		isPasswordWeak := false
@@ -83,7 +103,7 @@ func (g *VerifyPasswordGatherer) Gather(factsRequests []entities.FactRequest) ([
 				break
 			}
 			if !errors.Is(matchErr, crypt.ErrKeyMismatch) {
-				gatheringError = VerifyPasswordCryptError.Wrap(username)
+				gatheringError = VerifyPasswordCryptError.Wrap(username).Wrap(matchErr.Error())
 				break
 			}
 		}
@@ -103,13 +123,16 @@ func (g *VerifyPasswordGatherer) Gather(factsRequests []entities.FactRequest) ([
 	return facts, nil
 }
 
-func (g *VerifyPasswordGatherer) getSalt(user string) ([]byte, string, error) {
+func (g *VerifyPasswordGatherer) getHash(user string) (string, error) {
 	shadow, err := g.executor.Exec("getent", "shadow", user)
 	if err != nil {
-		return nil, "", errors.Wrap(err, "Error getting salt")
+		return "", errors.Wrap(err, "Error getting hash")
 	}
-	salt := strings.Split(string(shadow), "$")[2]
-	hash := strings.Split(string(shadow), ":")[1]
 
-	return []byte(fmt.Sprintf("$6$%s", salt)), hash, nil
+	fields := strings.Split(string(shadow), ":")
+	if len(fields) != 9 {
+		return "", fmt.Errorf("shadow output does not have 9 fields: %s", string(shadow))
+	}
+
+	return fields[1], nil
 }

--- a/internal/factsengine/gatherers/verifypassword_test.go
+++ b/internal/factsengine/gatherers/verifypassword_test.go
@@ -88,7 +88,7 @@ func (suite *PasswordTestSuite) TestPasswordGatherNotEqual() {
 	suite.ElementsMatch(expectedResults, factResults)
 }
 
-func (suite *PasswordTestSuite) TestPasswordGatherNotEncrypted() {
+func (suite *PasswordTestSuite) TestPasswordGatherNoPassword() {
 	shadow := []byte("hacluster:!:19029::::::")
 
 	suite.mockExecutor.On("Exec", "getent", "shadow", "hacluster").Return(


### PR DESCRIPTION
https://bugzilla.suse.com/show_bug.cgi?id=1217543

```
>  panic: runtime error: index out of range [2] with length 1
> 
> goroutine 264 [running]:
>  github.com/trento-project/agent/internal/factsengine/gatherers.(VerifyPasswordGatherer).getSalt(0xc000484030, {0xc0005ab5a0, 0x9})
>  github.com/trento-project/agent/internal/factsengine/gatherers/verifypassword.go:111 +0x21c
>  github.com/trento-project/agent/internal/factsengine/gatherers.(VerifyPasswordGatherer).Gather(0xc000484030?, {0xc00030f100, 0x1, 0x1?})
>  github.com/trento-project/agent/internal/factsengine/gatherers/verifypassword.go:68 +0x1e5
>  github.com/trento-project/agent/internal/factsengine.gatherFacts.func1()
>  github.com/trento-project/agent/internal/factsengine/gathering.go:44 +0xb9
>  golang.org/x/sync/errgroup.(Group).Go.func1()
>  golang.org/x/[sync@v0.2.0](mailto:sync@v0.2.0)/errgroup/errgroup.go:75 +0x64
>  created by golang.org/x/sync/errgroup.(Group).Go
>  golang.org/x/[sync@v0.2.0](mailto:sync@v0.2.0)/errgroup/errgroup.go:72 +0xa5
```