### PR TITLE
Update saptune discovery interval

### DIFF
--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -59,7 +59,7 @@ func (suite *AgentCmdTestSuite) SetupTest() {
 				Cloud:        10 * time.Second,
 				Host:         10 * time.Second,
 				Subscription: 900 * time.Second,
-				Saptune:      10 * time.Second,
+				Saptune:      900 * time.Second,
 			},
 			CollectorConfig: &collector.Config{
 				ServerURL: "http://serverurl",
@@ -80,7 +80,7 @@ func (suite *AgentCmdTestSuite) TestConfigFromFlags() {
 		"--sapsystem-discovery-period=10s",
 		"--host-discovery-period=10s",
 		"--subscription-discovery-period=900s",
-		"--saptune-discovery-period=10s",
+		"--saptune-discovery-period=900s",
 		"--server-url=http://serverurl",
 		"--api-key=some-api-key",
 		"--force-agent-id=some-agent-id",
@@ -102,7 +102,7 @@ func (suite *AgentCmdTestSuite) TestConfigFromEnv() {
 	os.Setenv("TRENTO_SAPSYSTEM_DISCOVERY_PERIOD", "10s")
 	os.Setenv("TRENTO_HOST_DISCOVERY_PERIOD", "10s")
 	os.Setenv("TRENTO_SUBSCRIPTION_DISCOVERY_PERIOD", "900s")
-	os.Setenv("TRENTO_SAPTUNE_DISCOVERY_PERIOD", "10s")
+	os.Setenv("TRENTO_SAPTUNE_DISCOVERY_PERIOD", "900s")
 	os.Setenv("TRENTO_SERVER_URL", "http://serverurl")
 	os.Setenv("TRENTO_API_KEY", "some-api-key")
 	os.Setenv("TRENTO_FORCE_AGENT_ID", "some-agent-id")

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -109,7 +109,7 @@ func NewStartCmd() *cobra.Command {
 			&saptuneDiscoveryPeriod,
 			"saptune-discovery-period",
 			"",
-			10*time.Second,
+			900*time.Second,
 			"Saptune discovery mechanism loop period in seconds",
 		)
 

--- a/packaging/config/agent.yaml
+++ b/packaging/config/agent.yaml
@@ -61,6 +61,15 @@
 
 ###############################################################################
 
+## Saptune discovery period configures the tick interval for the saptune
+## discovery loop.
+## Time unit is seconds
+## Defaults to 900.
+
+# saptune-discovery-period: 900s
+
+###############################################################################
+
 ## Application log level
 ## Allowed values: error, warn, info, debug
 ## defaults to info

--- a/test/fixtures/config/agent.yaml
+++ b/test/fixtures/config/agent.yaml
@@ -3,7 +3,7 @@ cluster-discovery-period: 10s
 host-discovery-period: 10s
 sapsystem-discovery-period: 10s
 subscription-discovery-period: 900s
-saptune-discovery-period: 10s
+saptune-discovery-period: 900s
 server-url: http://serverurl
 api-key: some-api-key
 force-agent-id: some-agent-id


### PR DESCRIPTION
This PR:
 - adjusts the saptune discovery interval from 10s to 900s by default
 - includes an example on how to override the default in the bundled configuration