### PR TITLE
Facts cache

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/trento-project/contracts/go v0.0.0-20230823130307-95ed2147fa9d
 	github.com/vektra/mockery/v2 v2.40.1
 	github.com/wagslane/go-rabbitmq v0.10.0
-	golang.org/x/sync v0.4.0
+	golang.org/x/sync v0.6.0
 	google.golang.org/protobuf v1.31.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -371,6 +371,8 @@ golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.4.0 h1:zxkM55ReGkDlKSM+Fu41A+zmbZuaPVbGMzvvdUPznYQ=
 golang.org/x/sync v0.4.0/go.mod h1:FU7BRWz2tNW+3quACPkgCx/L+uEAv1htQ0V83Z9Rj+Y=
+golang.org/x/sync v0.6.0 h1:5BMeUDZ7vkXGfEr1x9B4bRcTH4lpkTkpdh0T/J+qjbQ=
+golang.org/x/sync v0.6.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190312061237-fead79001313/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/internal/factsengine/factscache/cache.go
+++ b/internal/factsengine/factscache/cache.go
@@ -1,0 +1,68 @@
+package factscache
+
+import (
+	"sync"
+
+	log "github.com/sirupsen/logrus"
+)
+
+type FactsCache struct {
+	entries map[string]Entry
+	lock    sync.Mutex
+}
+
+type Entry struct {
+	content interface{}
+	err     error
+}
+
+func NewFactsCache() *FactsCache {
+	return &FactsCache{
+		entries: make(map[string]Entry),
+		lock:    sync.Mutex{},
+	}
+}
+
+// Entries returns the cached entries list
+func (c *FactsCache) Entries() []string {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	keys := []string{}
+	for key := range c.entries {
+		keys = append(keys, key)
+	}
+	return keys
+}
+
+// GetOrUpdate returns the cached result providing an entry name
+// or runs the updateFunc to generate the entry.
+// It locks its usage, so only one user at a time uses it
+func (c *FactsCache) GetOrUpdate(
+	entry string,
+	udpateFunc func(args ...interface{}) (interface{}, error),
+	updateFuncArgs ...interface{},
+) (interface{}, error) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	cacheEntry, hit := c.entries[entry]
+	if hit {
+		log.Debugf("Value for entry %s already cached", entry)
+		return cacheEntry.content, cacheEntry.err
+	}
+
+	content, err := udpateFunc(updateFuncArgs...)
+	c.entries[entry] = Entry{
+		content: content,
+		err:     err,
+	}
+
+	if err != nil {
+		log.Debugf("New value with error set for entry %s", entry)
+		return content, err
+	}
+
+	log.Debugf("New value for entry %s set", entry)
+	return content, err
+}

--- a/internal/factsengine/factscache/cache.go
+++ b/internal/factsengine/factscache/cache.go
@@ -23,6 +23,26 @@ func NewFactsCache() *FactsCache {
 	}
 }
 
+// GetOrUpdate Runs FactsCache GetOrUpdate with a provided cache
+// If the cache is nil, it runs the function, otherwise it returns
+// from cache
+func GetOrUpdate(
+	cache *FactsCache,
+	entry string,
+	udpateFunc func(args ...interface{}) (interface{}, error),
+	updateFuncArgs ...interface{},
+) (interface{}, error) {
+	if cache == nil {
+		return udpateFunc(updateFuncArgs...)
+	}
+
+	return cache.GetOrUpdate(
+		entry,
+		udpateFunc,
+		updateFuncArgs...,
+	)
+}
+
 // Entries returns the cached entries list
 func (c *FactsCache) Entries() []string {
 	c.lock.Lock()

--- a/internal/factsengine/factscache/cache.go
+++ b/internal/factsengine/factscache/cache.go
@@ -60,7 +60,10 @@ func (c *FactsCache) Entries() []string {
 
 // GetOrUpdate returns the cached result providing an entry name
 // or runs the updateFunc to generate the entry.
-// It locks its usage, so only one user at a time uses it
+// It locks its usage for each used key, returning the same value of the
+// first execution in the additional usages.
+// If other function with a different key is asked, it runs in parallel
+// without blocking.
 func (c *FactsCache) GetOrUpdate(
 	entry string,
 	udpateFunc UpdateCacheFunc,

--- a/internal/factsengine/factscache/cache_test.go
+++ b/internal/factsengine/factscache/cache_test.go
@@ -1,0 +1,93 @@
+package factscache_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/trento-project/agent/internal/factsengine/factscache"
+)
+
+type FactsCacheTestSuite struct {
+	suite.Suite
+}
+
+func TestFactsCacheTestSuite(t *testing.T) {
+	suite.Run(t, new(FactsCacheTestSuite))
+}
+
+// nolint:errcheck
+func (suite *FactsCacheTestSuite) TestEntries() {
+	cache := factscache.NewFactsCache()
+	cache.GetOrUpdate("entry1", func(args ...interface{}) (interface{}, error) {
+		return "", nil
+	})
+	cache.GetOrUpdate("entry2", func(args ...interface{}) (interface{}, error) {
+		return "", nil
+	})
+	entries := cache.Entries()
+
+	suite.ElementsMatch([]string{"entry1", "entry2"}, entries)
+}
+
+func (suite *FactsCacheTestSuite) TestGetOrUpdate() {
+	cache := factscache.NewFactsCache()
+	returnValue := "value"
+
+	updateFunc := func(args ...interface{}) (interface{}, error) {
+		return returnValue, nil
+	}
+
+	value, err := cache.GetOrUpdate("entry1", updateFunc)
+
+	suite.Equal(returnValue, value)
+	suite.NoError(err)
+}
+
+func (suite *FactsCacheTestSuite) TestGetOrUpdateWithError() {
+	cache := factscache.NewFactsCache()
+	someError := "some error"
+
+	updateFunc := func(args ...interface{}) (interface{}, error) {
+		return nil, fmt.Errorf(someError)
+	}
+
+	_, err := cache.GetOrUpdate("entry", updateFunc)
+
+	suite.EqualError(err, someError)
+}
+
+func (suite *FactsCacheTestSuite) TestGetOrUpdateCacheHit() {
+	cache := factscache.NewFactsCache()
+	returnValue := "value"
+	count := 0
+
+	updateFunc := func(args ...interface{}) (interface{}, error) {
+		count++
+		return returnValue, nil
+	}
+
+	// nolint:errcheck
+	cache.GetOrUpdate("entry", updateFunc)
+	value, err := cache.GetOrUpdate("entry", updateFunc)
+
+	suite.Equal(returnValue, value)
+	suite.Equal(1, count)
+	suite.NoError(err)
+}
+
+func (suite *FactsCacheTestSuite) TestGetOrUpdateWithArgs() {
+	cache := factscache.NewFactsCache()
+
+	// nolint:forcetypeassert
+	updateFunc := func(args ...interface{}) (interface{}, error) {
+		arg1 := args[0].(int)
+		arg2 := args[1].(string)
+		return fmt.Sprintf("%d_%s", arg1, arg2), nil
+	}
+
+	value, err := cache.GetOrUpdate("entry", updateFunc, 1, "text")
+
+	suite.Equal("1_text", value)
+	suite.NoError(err)
+}

--- a/internal/factsengine/gatherers/cibadmin.go
+++ b/internal/factsengine/gatherers/cibadmin.go
@@ -47,21 +47,12 @@ func (g *CibAdminGatherer) SetCache(cache *factscache.FactsCache) {
 
 func (g *CibAdminGatherer) Gather(factsRequests []entities.FactRequest) ([]entities.Fact, error) {
 	log.Infof("Starting %s facts gathering process", CibAdminGathererName)
-	var content interface{}
-	var err error
 
 	updateCacheFunc := func(args ...interface{}) (interface{}, error) {
 		return g.executor.Exec("cibadmin", "--query", "--local")
 	}
 
-	if g.cache == nil {
-		content, err = updateCacheFunc()
-	} else {
-		content, err = g.cache.GetOrUpdate(
-			CibAdminGathererCache,
-			updateCacheFunc,
-		)
-	}
+	content, err := factscache.GetOrUpdate(g.cache, CibAdminGathererCache, updateCacheFunc)
 
 	if err != nil {
 		return nil, CibAdminCommandError.Wrap(err.Error())

--- a/internal/factsengine/gatherers/cibadmin_test.go
+++ b/internal/factsengine/gatherers/cibadmin_test.go
@@ -209,8 +209,9 @@ func (suite *CibAdminTestSuite) TestCibAdminGather() {
 }
 
 func (suite *CibAdminTestSuite) TestCibAdminGatherWithCache() {
-	suite.mockExecutor.On("Exec", "cibadmin", "--query", "--local").Return(
-		suite.cibAdminOutput, nil)
+	suite.mockExecutor.On("Exec", "cibadmin", "--query", "--local").
+		Return(suite.cibAdminOutput, nil).
+		Once()
 
 	cache := factscache.NewFactsCache()
 
@@ -234,10 +235,13 @@ func (suite *CibAdminTestSuite) TestCibAdminGatherWithCache() {
 	}
 
 	factResults, err := p.Gather(factRequests)
-
 	suite.NoError(err)
-	entries := cache.Entries()
 	suite.ElementsMatch(expectedResults, factResults)
+
+	_, err = p.Gather(factRequests)
+	suite.NoError(err)
+
+	entries := cache.Entries()
 	suite.ElementsMatch([]string{"cibadmin"}, entries)
 }
 
@@ -262,5 +266,5 @@ func (suite *CibAdminTestSuite) TestCibAdminGatherCacheCastingError() {
 	_, err = p.Gather(factRequests)
 
 	suite.EqualError(err, "fact gathering error: cibadmin-decoding-error - "+
-		"error decoding cibadmin output: error formating the cache output")
+		"error decoding cibadmin output: error casting the command output")
 }

--- a/internal/factsengine/gatherers/gatherer.go
+++ b/internal/factsengine/gatherers/gatherer.go
@@ -1,11 +1,16 @@
 package gatherers
 
 import (
+	"github.com/trento-project/agent/internal/factsengine/factscache"
 	"github.com/trento-project/agent/pkg/factsengine/entities"
 )
 
 type FactGatherer interface {
 	Gather(factsRequests []entities.FactRequest) ([]entities.Fact, error)
+}
+
+type FactGathererWithCache interface {
+	SetCache(cache *factscache.FactsCache)
 }
 
 func StandardGatherers() FactGatherersTree {

--- a/internal/factsengine/gatherers/gatherer.go
+++ b/internal/factsengine/gatherers/gatherer.go
@@ -5,6 +5,12 @@ import (
 	"github.com/trento-project/agent/pkg/factsengine/entities"
 )
 
+// nolint:gochecknoglobals
+var ImplementationError = entities.FactGatheringError{
+	Type:    "implemetation-error",
+	Message: "implementation error",
+}
+
 type FactGatherer interface {
 	Gather(factsRequests []entities.FactRequest) ([]entities.Fact, error)
 }


### PR DESCRIPTION
Add basic facts cache. It is designed to store facts inside the `Gather` function, is the provided gatherer implements the `WithCache` function (coming from `FactGathererWithCache`).

The cache storage has a locking mechanism to avoid race conditions, as the gathering happens in a parallel.

The usage is pretty simple.
- It needs a cache entry name
- A function to get the value that is stored in the function with a specific function signature
- Optional arguments for that function

The memoization is achieved using [singleflight](https://pkg.go.dev/golang.org/x/sync/singleflight#Group.Do)
Basically based on https://github.com/kofalt/go-memoize/blob/master/memoize.go, but we need some adjustments so I have created a custom version (and we don't import many other packages only for this as well)