### PR TITLE
Add ip_addresses_netmasks field to host discovery

### DIFF
--- a/internal/core/hosts/discovered_host.go
+++ b/internal/core/hosts/discovered_host.go
@@ -3,6 +3,7 @@ package hosts
 type DiscoveredHost struct {
 	OSVersion                string   `json:"os_version"`
 	HostIPAddresses          []string `json:"ip_addresses"`
+	HostIPAddressesNetmasks  []string `json:"ip_addresses_netmasks"`
 	HostName                 string   `json:"hostname"`
 	CPUCount                 int      `json:"cpu_count"`
 	SocketCount              int      `json:"socket_count"`

--- a/internal/discovery/host.go
+++ b/internal/discovery/host.go
@@ -50,7 +50,7 @@ func (d HostDiscovery) GetInterval() time.Duration {
 
 // Execute one iteration of a discovery and publish to the collector
 func (d HostDiscovery) Discover(ctx context.Context) (string, error) {
-	ipAddresses, err := getHostIPAddresses()
+	ipAddresses, ipAddressesNetmasks, err := getHostIPAddresses()
 	if err != nil {
 		return "", err
 	}
@@ -58,6 +58,7 @@ func (d HostDiscovery) Discover(ctx context.Context) (string, error) {
 	host := hosts.DiscoveredHost{
 		OSVersion:                getOSVersion(),
 		HostIPAddresses:          ipAddresses,
+		HostIPAddressesNetmasks:  ipAddressesNetmasks,
 		HostName:                 d.host,
 		CPUCount:                 getLogicalCPUs(),
 		SocketCount:              getCPUSocketCount(),
@@ -76,13 +77,14 @@ func (d HostDiscovery) Discover(ctx context.Context) (string, error) {
 	return fmt.Sprintf("Host with name: %s successfully discovered", d.host), nil
 }
 
-func getHostIPAddresses() ([]string, error) {
+func getHostIPAddresses() ([]string, []string, error) {
 	interfaces, err := net.Interfaces()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	ipAddrList := make([]string, 0)
+	ipAddrNetmaskList := make([]string, 0)
 
 	for _, inter := range interfaces {
 		addrs, err := inter.Addrs()
@@ -93,10 +95,11 @@ func getHostIPAddresses() ([]string, error) {
 		for _, ipaddr := range addrs {
 			ipv4Addr, _, _ := net.ParseCIDR(ipaddr.String())
 			ipAddrList = append(ipAddrList, ipv4Addr.String())
+			ipAddrNetmaskList = append(ipAddrNetmaskList, ipaddr.String())
 		}
 	}
 
-	return ipAddrList, nil
+	return ipAddrList, ipAddrNetmaskList, nil
 }
 
 func getHostFQDN() *string {

--- a/internal/discovery/mocks/discovered_host_mock.go
+++ b/internal/discovery/mocks/discovered_host_mock.go
@@ -8,6 +8,7 @@ func NewDiscoveredHostMock() hosts.DiscoveredHost {
 	return hosts.DiscoveredHost{
 		OSVersion:                "15-SP2",
 		HostIPAddresses:          []string{"10.1.1.4", "10.1.1.5", "10.1.1.6"},
+		HostIPAddressesNetmasks:  []string{"10.1.1.4/16", "10.1.1.5/24", "10.1.1.6/32"},
 		HostName:                 "thehostnamewherethediscoveryhappened",
 		CPUCount:                 2,
 		SocketCount:              1,

--- a/test/fixtures/discovery/host/expected_published_host_discovery.json
+++ b/test/fixtures/discovery/host/expected_published_host_discovery.json
@@ -8,6 +8,11 @@
             "10.1.1.5",
             "10.1.1.6"
         ],
+        "ip_addresses_netmasks" :[
+            "10.1.1.4/16",
+            "10.1.1.5/24",
+            "10.1.1.6/32"
+        ],
         "hostname": "thehostnamewherethediscoveryhappened",
         "cpu_count": 2,
         "socket_count": 1,


### PR DESCRIPTION
This PR adds the `ip_addresses_netmasks` field to the hosts discovery. We previously discarded the netmask to prepare the content for the `ip_addresses` field. Now, instead of discarding it, we send it together with the IP address in CIDR notation:
```
...
ip_addresses: ["192.168.2.3"],  //This field hasn't been changed
ip_addresses_netmasks: ["192.168.2.3/24"],
...
```