### PR TITLE
Sapservices gatherer improvement

### DIFF
--- a/internal/factsengine/gatherers/sapservices.go
+++ b/internal/factsengine/gatherers/sapservices.go
@@ -143,7 +143,7 @@ func (s *SapServices) getSapServicesFileEntries() ([]SapServicesEntry, error) {
 			extractedSID, extractedInstance := extractInfoFromSystemdService(scannedLine)
 			if extractedSID == "" || extractedInstance == "" {
 				return nil, SapServicesParsingError.Wrap(
-					fmt.Sprintf("could not extract info from systemd SAP services entry: %s", scannedLine),
+					fmt.Sprintf("could not extract values from systemd SAP services entry: %s", scannedLine),
 				)
 			}
 
@@ -156,7 +156,7 @@ func (s *SapServices) getSapServicesFileEntries() ([]SapServicesEntry, error) {
 			extractedSID, extractedInstance := extractInfoFromSapstartService(scannedLine)
 			if extractedSID == "" || extractedInstance == "" {
 				return nil, SapServicesParsingError.Wrap(
-					fmt.Sprintf("could not extract info from sapstartsrv SAP services entry: %s", scannedLine),
+					fmt.Sprintf("could not extract values from sapstartsrv SAP services entry: %s", scannedLine),
 				)
 			}
 			sid = extractedSID

--- a/internal/factsengine/gatherers/sapservices.go
+++ b/internal/factsengine/gatherers/sapservices.go
@@ -129,6 +129,10 @@ func (s *SapServices) getSapServicesFileEntries() ([]SapServicesEntry, error) {
 			continue
 		}
 
+		// If the line does not start with a comment but has a comment in the middle, cut the comment
+		cleanedLine, _, _ := strings.Cut(scannedLine, "#")
+		scannedLine = cleanedLine
+
 		var kind SapServicesStartupKind
 		var sid string
 

--- a/internal/factsengine/gatherers/sapservices_test.go
+++ b/internal/factsengine/gatherers/sapservices_test.go
@@ -54,7 +54,7 @@ systemctl --no-ask-password start SAPS41_1
 	g := gatherers.NewSapServicesGatherer("/usr/sap/sapservices", tFs)
 	result, err := g.Gather(fr)
 	s.Nil(result)
-	s.EqualError(err, "fact gathering error: sap-services-parsing-error - error parsing the sapservices file: could not extract info from systemd SAP services entry: systemctl --no-ask-password start SAPS41_0 ")
+	s.EqualError(err, "fact gathering error: sap-services-parsing-error - error parsing the sapservices file: could not extract values from systemd SAP services entry: systemctl --no-ask-password start SAPS41_0 ")
 
 }
 func (s *SapServicesGathererSuite) TestSapServicesGathererSIDNotIdentifiedSystemd() {
@@ -77,7 +77,7 @@ systemctl --no-ask-password start SADS41_41
 	g := gatherers.NewSapServicesGatherer("/usr/sap/sapservices", tFs)
 	result, err := g.Gather(fr)
 	s.Nil(result)
-	s.EqualError(err, "fact gathering error: sap-services-parsing-error - error parsing the sapservices file: could not extract info from systemd SAP services entry: systemctl --no-ask-password start SADS41_41")
+	s.EqualError(err, "fact gathering error: sap-services-parsing-error - error parsing the sapservices file: could not extract values from systemd SAP services entry: systemctl --no-ask-password start SADS41_41")
 
 }
 
@@ -102,7 +102,7 @@ LD_LIBRARY_PATH=/usr/sap/S41/D40/exe:$LD_LIBRARY_PATH; export LD_LIBRARY_PATH; /
 	g := gatherers.NewSapServicesGatherer("/usr/sap/sapservices", tFs)
 	result, err := g.Gather(fr)
 	s.Nil(result)
-	s.EqualError(err, "fact gathering error: sap-services-parsing-error - error parsing the sapservices file: could not extract info from sapstartsrv SAP services entry: LD_LIBRARY_PATH=/usr/sap/HS1/HDB11/exe:$LD_LIBRARY_PATH;export LD_LIBRARY_PATH;/usr/sap/HS1/HDB11/exe/sapstartsrv pf=/usr/sap/HS1/SYS/profile/HS1HDB11_s41db -D -u hs1adm")
+	s.EqualError(err, "fact gathering error: sap-services-parsing-error - error parsing the sapservices file: could not extract values from sapstartsrv SAP services entry: LD_LIBRARY_PATH=/usr/sap/HS1/HDB11/exe:$LD_LIBRARY_PATH;export LD_LIBRARY_PATH;/usr/sap/HS1/HDB11/exe/sapstartsrv pf=/usr/sap/HS1/SYS/profile/HS1HDB11_s41db -D -u hs1adm")
 }
 
 func (s *SapServicesGathererSuite) TestSapServicesGathererInstanceNotIdentifiedSapstart() {
@@ -126,7 +126,7 @@ LD_LIBRARY_PATH=/usr/sap/S41/D40/exe:$LD_LIBRARY_PATH; export LD_LIBRARY_PATH; /
 	g := gatherers.NewSapServicesGatherer("/usr/sap/sapservices", tFs)
 	result, err := g.Gather(fr)
 	s.Nil(result)
-	s.EqualError(err, "fact gathering error: sap-services-parsing-error - error parsing the sapservices file: could not extract info from sapstartsrv SAP services entry: LD_LIBRARY_PATH=/usr/sap/HS1/HDB11/exe:$LD_LIBRARY_PATH;export LD_LIBRARY_PATH;/usr/sap/HS1/HDB11/exe/sapstartsrv pf=/usr/sap/HS1/SYS/profile/HS1_HDB1_s41db -D -u hs1adm")
+	s.EqualError(err, "fact gathering error: sap-services-parsing-error - error parsing the sapservices file: could not extract values from sapstartsrv SAP services entry: LD_LIBRARY_PATH=/usr/sap/HS1/HDB11/exe:$LD_LIBRARY_PATH;export LD_LIBRARY_PATH;/usr/sap/HS1/HDB11/exe/sapstartsrv pf=/usr/sap/HS1/SYS/profile/HS1_HDB1_s41db -D -u hs1adm")
 }
 
 func (s *SapServicesGathererSuite) TestSapServicesGathererSuccessSapstart() { //nolint:dupl


### PR DESCRIPTION
This PR enhance the sapservices gatherer

- Fix a bug with mid-line comments in sapservices entry: The comments are now discarded
- The instance number is extracted from sapservices entries in both scenarios

This PR changes the shape of the gatherer response, adds a new field `instance_nr` containing the instance number.