### PR TITLE
Add pr template for agent repo

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,30 @@
+# Description
+
+Please include a summary of the changes and the related issue, if it exists.
+Also, include relevant motivation and context for this PR. List any dependencies that are required for this change.
+
+Fixes # (issue)
+
+## Did you add the right label?
+
+Remember to add the right labels to this PR.
+
+- [ ] **DONE**
+
+## How was this tested?
+
+Describe the tests that have been added/changed for this new behavior.
+
+- [ ] **DONE**
+
+## Did you update the documentation?
+
+Remember to ask yourself if your PR requires changes to the following documentation:
+
+- [Manual installation guide](https://github.com/trento-project/docs/blob/main/guides/manual-installation.md)
+- [Trento Ansible guide](https://github.com/trento-project/ansible/blob/main/README.md)
+- [Trento Agent guides](https://github.com/trento-project/agent/tree/main/docs)
+
+Add a documentation PR or write that no changes are required for the documentation.
+
+- [ ] **DONE**


### PR DESCRIPTION
# Description

Add PR template to remember everyone to update the documentation.
Same as in https://github.com/trento-project/web/pull/2663.