### PR TITLE
Discover host ip address netmasks

### DIFF
--- a/internal/core/hosts/discovered_host.go
+++ b/internal/core/hosts/discovered_host.go
@@ -1,13 +1,25 @@
 package hosts
 
+type NetworkInterface struct {
+	Index     int       `json:"index"`
+	Name      string    `json:"name"`
+	Addresses []Address `json:"addresses"`
+}
+
+type Address struct {
+	Address string `json:"address"`
+	Netmask int    `json:"netmask"`
+}
+
 type DiscoveredHost struct {
-	OSVersion                string   `json:"os_version"`
-	HostIPAddresses          []string `json:"ip_addresses"`
-	HostName                 string   `json:"hostname"`
-	CPUCount                 int      `json:"cpu_count"`
-	SocketCount              int      `json:"socket_count"`
-	TotalMemoryMB            int      `json:"total_memory_mb"`
-	AgentVersion             string   `json:"agent_version"`
-	InstallationSource       string   `json:"installation_source"`
-	FullyQualifiedDomainName *string  `json:"fully_qualified_domain_name,omitempty"`
+	OSVersion                string             `json:"os_version"`
+	HostIPAddresses          []string           `json:"ip_addresses"` // deprecated
+	NetworkInterfaces        []NetworkInterface `json:"network_interfaces"`
+	HostName                 string             `json:"hostname"`
+	CPUCount                 int                `json:"cpu_count"`
+	SocketCount              int                `json:"socket_count"`
+	TotalMemoryMB            int                `json:"total_memory_mb"`
+	AgentVersion             string             `json:"agent_version"`
+	InstallationSource       string             `json:"installation_source"`
+	FullyQualifiedDomainName *string            `json:"fully_qualified_domain_name,omitempty"`
 }

--- a/internal/core/hosts/discovered_host.go
+++ b/internal/core/hosts/discovered_host.go
@@ -1,25 +1,14 @@
 package hosts
 
-type NetworkInterface struct {
-	Index     int       `json:"index"`
-	Name      string    `json:"name"`
-	Addresses []Address `json:"addresses"`
-}
-
-type Address struct {
-	Address string `json:"address"`
-	Netmask int    `json:"netmask"`
-}
-
 type DiscoveredHost struct {
-	OSVersion                string             `json:"os_version"`
-	HostIPAddresses          []string           `json:"ip_addresses"` // deprecated
-	NetworkInterfaces        []NetworkInterface `json:"network_interfaces"`
-	HostName                 string             `json:"hostname"`
-	CPUCount                 int                `json:"cpu_count"`
-	SocketCount              int                `json:"socket_count"`
-	TotalMemoryMB            int                `json:"total_memory_mb"`
-	AgentVersion             string             `json:"agent_version"`
-	InstallationSource       string             `json:"installation_source"`
-	FullyQualifiedDomainName *string            `json:"fully_qualified_domain_name,omitempty"`
+	OSVersion                string   `json:"os_version"`
+	HostIPAddresses          []string `json:"ip_addresses"`
+	Netmasks                 []int    `json:"netmasks"`
+	HostName                 string   `json:"hostname"`
+	CPUCount                 int      `json:"cpu_count"`
+	SocketCount              int      `json:"socket_count"`
+	TotalMemoryMB            int      `json:"total_memory_mb"`
+	AgentVersion             string   `json:"agent_version"`
+	InstallationSource       string   `json:"installation_source"`
+	FullyQualifiedDomainName *string  `json:"fully_qualified_domain_name,omitempty"`
 }

--- a/internal/discovery/mocks/discovered_host_mock.go
+++ b/internal/discovery/mocks/discovered_host_mock.go
@@ -6,38 +6,9 @@ func NewDiscoveredHostMock() hosts.DiscoveredHost {
 	fqdn := "com.example.trento.host"
 
 	return hosts.DiscoveredHost{
-		OSVersion:       "15-SP2",
-		HostIPAddresses: []string{"10.1.1.4", "10.1.1.5", "10.1.1.6"},
-		NetworkInterfaces: []hosts.NetworkInterface{
-			{
-				Index: 0,
-				Name:  "eth0",
-				Addresses: []hosts.Address{
-					{
-						Address: "10.1.1.4",
-						Netmask: 24,
-					},
-					{
-						Address: "10.1.1.5",
-						Netmask: 16,
-					},
-					{
-						Address: "10.1.1.6",
-						Netmask: 32,
-					},
-				},
-			},
-			{
-				Index: 1,
-				Name:  "eth1",
-				Addresses: []hosts.Address{
-					{
-						Address: "10.1.2.4",
-						Netmask: 24,
-					},
-				},
-			},
-		},
+		OSVersion:                "15-SP2",
+		HostIPAddresses:          []string{"10.1.1.4", "10.1.1.5", "10.1.1.6"},
+		Netmasks:                 []int{24, 16, 32},
 		HostName:                 "thehostnamewherethediscoveryhappened",
 		CPUCount:                 2,
 		SocketCount:              1,

--- a/internal/discovery/mocks/discovered_host_mock.go
+++ b/internal/discovery/mocks/discovered_host_mock.go
@@ -6,8 +6,38 @@ func NewDiscoveredHostMock() hosts.DiscoveredHost {
 	fqdn := "com.example.trento.host"
 
 	return hosts.DiscoveredHost{
-		OSVersion:                "15-SP2",
-		HostIPAddresses:          []string{"10.1.1.4", "10.1.1.5", "10.1.1.6"},
+		OSVersion:       "15-SP2",
+		HostIPAddresses: []string{"10.1.1.4", "10.1.1.5", "10.1.1.6"},
+		NetworkInterfaces: []hosts.NetworkInterface{
+			{
+				Index: 0,
+				Name:  "eth0",
+				Addresses: []hosts.Address{
+					{
+						Address: "10.1.1.4",
+						Netmask: 24,
+					},
+					{
+						Address: "10.1.1.5",
+						Netmask: 16,
+					},
+					{
+						Address: "10.1.1.6",
+						Netmask: 32,
+					},
+				},
+			},
+			{
+				Index: 1,
+				Name:  "eth1",
+				Addresses: []hosts.Address{
+					{
+						Address: "10.1.2.4",
+						Netmask: 24,
+					},
+				},
+			},
+		},
 		HostName:                 "thehostnamewherethediscoveryhappened",
 		CPUCount:                 2,
 		SocketCount:              1,

--- a/test/fixtures/discovery/host/expected_published_host_discovery.json
+++ b/test/fixtures/discovery/host/expected_published_host_discovery.json
@@ -1,19 +1,49 @@
 {
-    "agent_id": "779cdd70-e9e2-58ca-b18a-bf3eb3f71244",
-    "discovery_type": "host_discovery",
-    "payload": {
-        "os_version": "15-SP2",
-        "ip_addresses": [
-            "10.1.1.4",
-            "10.1.1.5",
-            "10.1.1.6"
-        ],
-        "hostname": "thehostnamewherethediscoveryhappened",
-        "cpu_count": 2,
-        "socket_count": 1,
-        "total_memory_mb": 4096,
-        "agent_version": "trento-agent-version",
-        "installation_source": "Community",
-        "fully_qualified_domain_name": "com.example.trento.host"
-    }
+  "agent_id": "779cdd70-e9e2-58ca-b18a-bf3eb3f71244",
+  "discovery_type": "host_discovery",
+  "payload": {
+    "os_version": "15-SP2",
+    "ip_addresses": [
+      "10.1.1.4",
+      "10.1.1.5",
+      "10.1.1.6"
+    ],
+    "network_interfaces": [
+      {
+        "index": 0,
+        "name": "eth0",
+        "addresses": [
+          {
+            "address": "10.1.1.4",
+            "netmask": 24
+          },
+          {
+            "address": "10.1.1.5",
+            "netmask": 16
+          },
+          {
+            "address": "10.1.1.6",
+            "netmask": 32
+          }
+        ]
+      },
+      {
+        "index": 1,
+        "name": "eth1",
+        "addresses": [
+          {
+            "address": "10.1.2.4",
+            "netmask": 24
+          }
+        ]
+      }
+    ],
+    "hostname": "thehostnamewherethediscoveryhappened",
+    "cpu_count": 2,
+    "socket_count": 1,
+    "total_memory_mb": 4096,
+    "agent_version": "trento-agent-version",
+    "installation_source": "Community",
+    "fully_qualified_domain_name": "com.example.trento.host"
+  }
 }

--- a/test/fixtures/discovery/host/expected_published_host_discovery.json
+++ b/test/fixtures/discovery/host/expected_published_host_discovery.json
@@ -8,35 +8,10 @@
       "10.1.1.5",
       "10.1.1.6"
     ],
-    "network_interfaces": [
-      {
-        "index": 0,
-        "name": "eth0",
-        "addresses": [
-          {
-            "address": "10.1.1.4",
-            "netmask": 24
-          },
-          {
-            "address": "10.1.1.5",
-            "netmask": 16
-          },
-          {
-            "address": "10.1.1.6",
-            "netmask": 32
-          }
-        ]
-      },
-      {
-        "index": 1,
-        "name": "eth1",
-        "addresses": [
-          {
-            "address": "10.1.2.4",
-            "netmask": 24
-          }
-        ]
-      }
+    "netmasks": [
+      24,
+      16,
+      32
     ],
     "hostname": "thehostnamewherethediscoveryhappened",
     "cpu_count": 2,


### PR DESCRIPTION
# Description

Discover host netmasks and send them in the` netmasks` field. Each value corresponds the value in the same position for `ip_addresses`.

I'm aware that this "position related" usage is not optimal, and actually, in the 1st commit I implemented a more complex struct to send complete network interfaces. But this makes compatibility between old web/new agent, new web/old agent more difficult, so I sticked to simplest solution.

If for some reason, in the future we need more information about network interfaces, I finally think that we will need something more complex implementation that eventually will require some upgrade in api versioning or even major version of agent/web.

## How was this tested?

Partially tested...
We don't have any code testing host discoveries, and in fact, testing `network` related things is pretty  difficult.
Basically the serialization as json is the unique thing that it is tested.
In any case, the used functions are not changed, just the composed final code, so as everything was working now, i expect that it will continue working

