### PR TITLE
Upload updated rpm spec file in obs commit ci step

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -217,6 +217,7 @@ jobs:
         run: |
           osc checkout $OBS_PROJECT trento-agent -o $OSC_CHECKOUT_DIR
           cp $FOLDER/_service $OSC_CHECKOUT_DIR
+          cp $FOLDER/trento-agent.spec $OSC_CHECKOUT_DIR
           rm -v $OSC_CHECKOUT_DIR/*.tar.gz
           pushd $OSC_CHECKOUT_DIR
           osc service manualrun


### PR DESCRIPTION
# Description

I have noticed that after updating the golang version dependency to 1.22, the spec file in OBS was not changed.
It turned out that we were not updating the spec file in the CI.

This change simply uploads the spec file from github repository to OBS
