### PR TITLE
Customize node exporter target

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -77,11 +77,16 @@ func LoadConfig(fileSystem afero.Fs) (*agent.Config, error) {
 		DiscoveriesPeriodsConfig: discoveryPeriodsConfig,
 	}
 
+	prometheusTargets := discovery.PrometheusTargets{
+		discovery.NodeExporterName: viper.GetString("node-exporter-target"),
+	}
+
 	return &agent.Config{
 		AgentID:           agentID,
 		InstanceName:      hostname,
 		DiscoveriesConfig: discoveriesConfig,
 		FactsServiceURL:   viper.GetString("facts-service-url"),
 		PluginsFolder:     viper.GetString("plugins-folder"),
+		PrometheusTargets: prometheusTargets,
 	}, nil
 }

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -69,6 +69,9 @@ func (suite *AgentCmdTestSuite) SetupTest() {
 		},
 		FactsServiceURL: "amqp://guest:guest@serviceurl:5672",
 		PluginsFolder:   "/usr/etc/trento/plugins/",
+		PrometheusTargets: map[string]string{
+			"node_exporter": "10.0.0.5:9100",
+		},
 	}
 }
 
@@ -85,6 +88,7 @@ func (suite *AgentCmdTestSuite) TestConfigFromFlags() {
 		"--api-key=some-api-key",
 		"--force-agent-id=some-agent-id",
 		"--facts-service-url=amqp://guest:guest@serviceurl:5672",
+		"--node-exporter-target=10.0.0.5:9100",
 	})
 
 	_ = suite.cmd.Execute()
@@ -107,6 +111,7 @@ func (suite *AgentCmdTestSuite) TestConfigFromEnv() {
 	os.Setenv("TRENTO_API_KEY", "some-api-key")
 	os.Setenv("TRENTO_FORCE_AGENT_ID", "some-agent-id")
 	os.Setenv("TRENTO_FACTS_SERVICE_URL", "amqp://guest:guest@serviceurl:5672")
+	os.Setenv("TRENTO_NODE_EXPORTER_TARGET", "10.0.0.5:9100")
 
 	_ = suite.cmd.Execute()
 

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -123,6 +123,14 @@ func NewStartCmd() *cobra.Command {
 
 	startCmd.Flags().String("facts-service-url", "amqp://guest:guest@localhost:5672", "Facts service queue url")
 
+	startCmd.Flags().
+		String(
+			"node-exporter-target",
+			"",
+			"Node exporter target address in ip:port notation. If not given the lowest "+
+				"ipv4 address with the default 9100 port is used",
+		)
+
 	return startCmd
 }
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -36,6 +36,7 @@ type Config struct {
 	DiscoveriesConfig *discovery.DiscoveriesConfig
 	FactsServiceURL   string
 	PluginsFolder     string
+	PrometheusTargets discovery.PrometheusTargets
 }
 
 // NewAgent returns a new instance of Agent with the given configuration
@@ -48,7 +49,7 @@ func NewAgent(config *Config) (*Agent, error) {
 		discovery.NewSAPSystemsDiscovery(collectorClient, *config.DiscoveriesConfig),
 		discovery.NewCloudDiscovery(collectorClient, *config.DiscoveriesConfig),
 		discovery.NewSubscriptionDiscovery(collectorClient, config.InstanceName, *config.DiscoveriesConfig),
-		discovery.NewHostDiscovery(collectorClient, config.InstanceName, *config.DiscoveriesConfig),
+		discovery.NewHostDiscovery(collectorClient, config.InstanceName, config.PrometheusTargets, *config.DiscoveriesConfig),
 		discovery.NewSaptuneDiscovery(collectorClient, *config.DiscoveriesConfig),
 	}
 

--- a/internal/core/hosts/discovered_host.go
+++ b/internal/core/hosts/discovered_host.go
@@ -1,14 +1,15 @@
 package hosts
 
 type DiscoveredHost struct {
-	OSVersion                string   `json:"os_version"`
-	HostIPAddresses          []string `json:"ip_addresses"`
-	Netmasks                 []int    `json:"netmasks"`
-	HostName                 string   `json:"hostname"`
-	CPUCount                 int      `json:"cpu_count"`
-	SocketCount              int      `json:"socket_count"`
-	TotalMemoryMB            int      `json:"total_memory_mb"`
-	AgentVersion             string   `json:"agent_version"`
-	InstallationSource       string   `json:"installation_source"`
-	FullyQualifiedDomainName *string  `json:"fully_qualified_domain_name,omitempty"`
+	OSVersion                string            `json:"os_version"`
+	HostIPAddresses          []string          `json:"ip_addresses"`
+	Netmasks                 []int             `json:"netmasks"`
+	HostName                 string            `json:"hostname"`
+	CPUCount                 int               `json:"cpu_count"`
+	SocketCount              int               `json:"socket_count"`
+	TotalMemoryMB            int               `json:"total_memory_mb"`
+	AgentVersion             string            `json:"agent_version"`
+	InstallationSource       string            `json:"installation_source"`
+	FullyQualifiedDomainName *string           `json:"fully_qualified_domain_name,omitempty"`
+	PrometheusTargets        map[string]string `json:"prometheus_targets"`
 }

--- a/internal/discovery/host.go
+++ b/internal/discovery/host.go
@@ -132,9 +132,9 @@ func updatePrometheusTargets(targets PrometheusTargets, ipAddresses []string) Pr
 	// Fallback to lowest IP address value to replace empty exporter targets
 	ips := make([]net.IP, 0, len(ipAddresses))
 	for _, ip := range ipAddresses {
-		parsedIp := net.ParseIP(ip)
-		if parsedIp.To4() != nil && !parsedIp.IsLoopback() {
-			ips = append(ips, parsedIp)
+		parsedIP := net.ParseIP(ip)
+		if parsedIP.To4() != nil && !parsedIP.IsLoopback() {
+			ips = append(ips, parsedIP)
 		}
 
 	}

--- a/internal/discovery/host.go
+++ b/internal/discovery/host.go
@@ -121,7 +121,15 @@ func getNetworksData() ([]string, []int, error) {
 }
 
 func updatePrometheusTargets(targets PrometheusTargets, ipAddresses []string) PrometheusTargets {
-	// Get lowest IP address value to replace empty exporter targets
+	// Return exporter details if they are given by the user
+	nodeExporterTarget, ok := targets[NodeExporterName]
+	if ok && nodeExporterTarget != "" {
+		return PrometheusTargets{
+			NodeExporterName: nodeExporterTarget,
+		}
+	}
+
+	// Fallback to lowest IP address value to replace empty exporter targets
 	ips := make([]net.IP, 0, len(ipAddresses))
 	for _, ip := range ipAddresses {
 		parsedIp := net.ParseIP(ip)
@@ -135,14 +143,8 @@ func updatePrometheusTargets(targets PrometheusTargets, ipAddresses []string) Pr
 		return bytes.Compare(ips[i], ips[j]) < 0
 	})
 
-	// Replace exporter values if they are not given by the user
-	nodeExporterTarget, ok := targets[NodeExporterName]
-	if !ok || nodeExporterTarget == "" {
-		nodeExporterTarget = fmt.Sprintf("%s:%d", ips[0], NodeExporterPort)
-	}
-
 	return PrometheusTargets{
-		NodeExporterName: nodeExporterTarget,
+		NodeExporterName: fmt.Sprintf("%s:%d", ips[0], NodeExporterPort),
 	}
 }
 

--- a/internal/discovery/host.go
+++ b/internal/discovery/host.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"sort"
+	"slices"
 	"strconv"
 	"time"
 
@@ -139,8 +139,8 @@ func updatePrometheusTargets(targets PrometheusTargets, ipAddresses []string) Pr
 
 	}
 
-	sort.Slice(ips, func(i, j int) bool {
-		return bytes.Compare(ips[i], ips[j]) < 0
+	slices.SortFunc(ips, func(a, b net.IP) int {
+		return bytes.Compare(a, b)
 	})
 
 	return PrometheusTargets{

--- a/internal/discovery/host_internal_test.go
+++ b/internal/discovery/host_internal_test.go
@@ -1,0 +1,42 @@
+package discovery
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type HostInternalTestSuite struct {
+	suite.Suite
+	ipAddresses []string
+}
+
+func TestHostInternalTestSuite(t *testing.T) {
+	suite.Run(t, new(HostInternalTestSuite))
+}
+
+func (suite *HostInternalTestSuite) SetupSuite() {
+	suite.ipAddresses = []string{"127.0.0.1", "::1", "10.1.1.5", "10.1.1.4", "10.1.1.6", "6c62:7cc9:3936:e802:2bbe"}
+}
+
+func (suite *HostInternalTestSuite) TestUpdatePrometheusTargets() {
+	initialTargets := PrometheusTargets{
+		"node_exporter": "",
+	}
+
+	expectedTargets := PrometheusTargets{
+		"node_exporter": "10.1.1.4:9100",
+	}
+
+	updatedTargets := updatePrometheusTargets(initialTargets, suite.ipAddresses)
+	suite.Equal(expectedTargets, updatedTargets)
+}
+
+func (suite *HostInternalTestSuite) TestUpdatePrometheusTargetsGivenByUser() {
+	initialTargets := PrometheusTargets{
+		"node_exporter": "192.168.1.60:9123",
+	}
+
+	updatedTargets := updatePrometheusTargets(initialTargets, suite.ipAddresses)
+	suite.Equal(initialTargets, updatedTargets)
+}

--- a/internal/discovery/mocks/discovered_host_mock.go
+++ b/internal/discovery/mocks/discovered_host_mock.go
@@ -16,5 +16,8 @@ func NewDiscoveredHostMock() hosts.DiscoveredHost {
 		AgentVersion:             "trento-agent-version",
 		InstallationSource:       "Community",
 		FullyQualifiedDomainName: &fqdn,
+		PrometheusTargets: map[string]string{
+			"node_exporter": "10.1.1.4:9100",
+		},
 	}
 }

--- a/packaging/config/agent.yaml
+++ b/packaging/config/agent.yaml
@@ -95,3 +95,11 @@
 ## Facts gathering service URL
 
 # facts-service-url: amqp://guest:guest@localhost:5672
+
+###############################################################################
+
+## Prometheus exporters targets
+## Configure the prometheus targets. If not given, the lowest discovered IP address
+## with a default port numbers is used
+
+# node-exporter-target: 192.168.1.10:9100

--- a/packaging/config/agent.yaml
+++ b/packaging/config/agent.yaml
@@ -100,6 +100,6 @@
 
 ## Prometheus exporters targets
 ## Configure the prometheus targets. If not given, the lowest discovered IP address
-## with a default port numbers is used
+## with a default port number is used
 
 # node-exporter-target: 192.168.1.10:9100

--- a/test/fixtures/config/agent.yaml
+++ b/test/fixtures/config/agent.yaml
@@ -8,3 +8,4 @@ server-url: http://serverurl
 api-key: some-api-key
 force-agent-id: some-agent-id
 facts-service-url: amqp://guest:guest@serviceurl:5672
+node-exporter-target: 10.0.0.5:9100

--- a/test/fixtures/discovery/host/expected_published_host_discovery.json
+++ b/test/fixtures/discovery/host/expected_published_host_discovery.json
@@ -19,6 +19,9 @@
     "total_memory_mb": 4096,
     "agent_version": "trento-agent-version",
     "installation_source": "Community",
-    "fully_qualified_domain_name": "com.example.trento.host"
+    "fully_qualified_domain_name": "com.example.trento.host",
+    "prometheus_targets": {
+      "node_exporter": "10.1.1.4:9100"
+    }
   }
 }


### PR DESCRIPTION
# Description

Add a new configuration option to give the user the option to choose the node expoter target.

The new parameter is `node-exporter-target` in the command line and configuration file.
If the option is not used, the code will use the lowest ipv4 address plus the default node exporter port.

And it will send a new field in the host discovery as `prometheus_targets` with a `map[string]string` with all the configured exporters.
I have chosen this option to enable future exporters usage. In this case:
```
{
...
    "prometheus_targets": {
        "node_exporter": "10.1.2.3:9100"
    }
}
```

## How was this tested?

UT

## Did you update the documentation?

I added some "in code" documentation, but we will need to add this new value in additional places I guess
