### PR TITLE
Add tests on built binaries

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -133,9 +133,7 @@ jobs:
       - name: build
         run: make -j4 cross-compiled
       - name: compress
-        run: |
-          set -x
-          find ./build -maxdepth 1 -mindepth 1 -type d -exec sh -c 'tar -zcf build/trento-agent-$(basename {}).tgz -C {} trento-agent -C $(pwd)/packaging/systemd trento-agent.service' \;
+        run: make bundle
       - uses: actions/upload-artifact@v4
         with:
           name: trento-binaries

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -88,7 +88,7 @@ jobs:
           COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: goveralls -coverprofile=covprofile -service=github
 
-  test-plugins:
+  test-build:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
@@ -102,22 +102,20 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
-      - name: build dummy plugin
-        run: |
-          mkdir /tmp/plugins
-          go build -o /tmp/plugins/dummy ./plugin_examples/dummy.go
+      - name: build plugins
+        run: make build-plugin-examples
       - name: build trento binary
         run: make build
-      - name: run facts list command
-        run: |
-          ./trento-agent facts list --plugins-folder /tmp/plugins 2>&1 | grep -q "dummy"
-      - name: run facts gather command
-        run: |
-          ./trento-agent facts gather --gatherer dummy --argument 1 --plugins-folder /tmp/plugins 2>&1 | grep -q 'Name: 1'
+      - name: Setup BATS
+        uses: mig4/setup-bats@v1
+        with:
+          bats-version: 1.11.1
+      - name: run tests
+        run: make test-build
 
   build-static-binary:
     runs-on: ubuntu-20.04
-    needs: [static-analysis, test, test-plugins]
+    needs: [static-analysis, test, test-build]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -183,7 +181,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
   obs-commit:
-    needs: [static-analysis, test, test-plugins]
+    needs: [static-analysis, test, test-build]
     runs-on: ubuntu-20.04
     if: github.ref == 'refs/heads/main' || github.event_name == 'release'
     container:

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,4 @@
 golang 1.22.5
 mockery 2.32.3
 golangci-lint 1.59.1
+bats 1.11.1

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ LDFLAGS = -X github.com/trento-project/agent/version.Version="$(VERSION)"
 LDFLAGS := $(LDFLAGS) -X github.com/trento-project/agent/version.InstallationSource="$(INSTALLATIONSOURCE)"
 ARCHS ?= amd64 arm64 ppc64le s390x
 DEBUG ?= 0
+BUILD_DIR ?= ./build
 
 ifeq ($(DEBUG), 0)
 	LDFLAGS += -s -w
@@ -18,7 +19,11 @@ default: clean mod-tidy fmt vet-check test build
 .PHONY: build
 build: agent
 agent:
-	$(GO_BUILD) -o trento-agent
+	$(GO_BUILD) -o $(BUILD_DIR)/trento-agent
+
+.PHONY: build-plugin-examples
+build-plugin-examples:
+	$(GO_BUILD) -o $(BUILD_DIR)/plugin_examples/dummy ./plugin_examples/dummy.go
 
 .PHONY: cross-compiled $(ARCHS)
 cross-compiled: $(ARCHS)
@@ -76,3 +81,7 @@ test-short:
 .PHONY: test-coverage
 test-coverage: 
 	go test -v -p 1 -race -covermode atomic -coverprofile=covprofile ./...
+
+.PHONY: test-build
+test-build:
+	bats -r ./test

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ CURRENT_ARCH := $(shell go env GOARCH)
 ARCHS ?= amd64 arm64 ppc64le s390x
 DEBUG ?= 0
 BUILD_DIR := ./build
+BUILD_OUTPUT ?= $(BUILD_DIR)/$(CURRENT_ARCH)/trento-agent
 
 ifeq ($(DEBUG), 0)
 	LDFLAGS += -s -w
@@ -20,7 +21,7 @@ default: clean mod-tidy fmt vet-check test build
 .PHONY: build
 build: agent
 agent:
-	$(GO_BUILD) -o $(BUILD_DIR)/$(CURRENT_ARCH)/trento-agent
+	$(GO_BUILD) -o $(BUILD_OUTPUT)
 
 .PHONY: build-plugin-examples
 build-plugin-examples:

--- a/README.md
+++ b/README.md
@@ -214,8 +214,13 @@ We use GNU Make as a task manager; here are some common targets:
 ```shell
 make # clean, test and build everything
 
+make build # build for the current architecture
+make cross-compile # build for a list of supported architectures
+make bundle # prepare all the bundles for each built artifact
 make clean # removes any build artifact
 make test # executes all the tests
+make test-short # executes all tests that don't require dependencies
+make test-build # executes tests on built artifacts
 make fmt # fixes code formatting
 make web-assets # invokes the frontend build scripts
 make generate # refresh automatically generated code (e.g. static Go mocks)

--- a/packaging/suse/trento-agent.spec
+++ b/packaging/suse/trento-agent.spec
@@ -49,7 +49,7 @@ Trento agents are client-side processes responsible for the automatic discovery 
 %define shortname agent
 
 %build
-VERSION=%{version} INSTALLATIONSOURCE=Suse make build
+VERSION=%{version} INSTALLATIONSOURCE=Suse BUILD_OUTPUT="./trento-agent" make build
 
 %install
 

--- a/test/cli/agent.bats
+++ b/test/cli/agent.bats
@@ -1,0 +1,21 @@
+setup() {
+    # Set the test root as the project root
+    DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )/../.." >/dev/null 2>&1 && pwd )"
+
+    # Add the build folder to the PATH
+    PATH="$DIR/build:$PATH"
+}
+
+@test "it should show help" {
+    run trento-agent --help
+
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q "Usage:"
+}
+
+@test "it should show agent id" {
+    run trento-agent id
+
+    [ "$status" -eq 0 ]
+    [ -n "$output" ]
+}

--- a/test/cli/agent.bats
+++ b/test/cli/agent.bats
@@ -3,7 +3,8 @@ setup() {
     DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )/../.." >/dev/null 2>&1 && pwd )"
 
     # Add the build folder to the PATH
-    PATH="$DIR/build:$PATH"
+    BUILD_DIR="$DIR/build/$(go env GOARCH)"
+    PATH="$BUILD_DIR:$PATH"
 }
 
 @test "it should show help" {

--- a/test/cli/packaging.bats
+++ b/test/cli/packaging.bats
@@ -1,0 +1,23 @@
+setup() {
+    # Set the test root as the project root
+    DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )/../.." >/dev/null 2>&1 && pwd )"
+
+    # Add the build folder to the PATH
+    BUILD_DIR="$DIR/build/$(go env GOARCH)"
+    PATH="$BUILD_DIR:$PATH"
+}
+
+@test "it should package the artifact for the release including only the necessary files" {
+    run make bundle
+    
+    [ "$status" -eq 0 ]
+    [ -f "$DIR/build/trento-agent-$(go env GOARCH).tgz" ]
+
+    TMP_DIR=$(mktemp -d)
+    run tar -xzf "$DIR/build/trento-agent-$(go env GOARCH).tgz" -C $TMP_DIR
+
+    [ "$status" -eq 0 ]
+    [ $(ls -1 $TMP_DIR | wc -l) -eq 2 ]
+    [ -f "$TMP_DIR/trento-agent" ]
+    [ -f "$TMP_DIR/trento-agent.service" ]   
+}

--- a/test/cli/plugins.bats
+++ b/test/cli/plugins.bats
@@ -1,0 +1,33 @@
+setup() {
+    # Set the test root as the project root
+    DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )/../.." >/dev/null 2>&1 && pwd )"
+
+    # Add the build folder to the PATH
+    PATH="$DIR/build:$PATH"
+}
+
+
+@test "it should include the dummy plugin into list" {
+    run trento-agent facts list --plugins-folder ./build/plugin_examples
+
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q "dummy"
+}
+
+@test "it should should execute the dummy plugin" {
+    run trento-agent facts gather \
+        --plugins-folder ./build/plugin_examples \
+        --gatherer dummy --argument 1
+
+    [ "$status" -eq 0 ]
+    echo $output | grep -q "Name: 1"
+}
+
+@test "it should execute the dummy plugin with a different argument" {
+    run trento-agent facts gather \
+        --plugins-folder ./build/plugin_examples \
+        --gatherer dummy --argument 2
+
+    [ "$status" -eq 0 ]
+    echo $output | grep -q "Name: 2"
+}

--- a/test/cli/plugins.bats
+++ b/test/cli/plugins.bats
@@ -3,12 +3,13 @@ setup() {
     DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )/../.." >/dev/null 2>&1 && pwd )"
 
     # Add the build folder to the PATH
-    PATH="$DIR/build:$PATH"
+    BUILD_DIR="$DIR/build/$(go env GOARCH)"
+    PATH="$BUILD_DIR:$PATH"
 }
 
 
 @test "it should include the dummy plugin into list" {
-    run trento-agent facts list --plugins-folder ./build/plugin_examples
+    run trento-agent facts list --plugins-folder $BUILD_DIR/plugin_examples
 
     [ "$status" -eq 0 ]
     echo "$output" | grep -q "dummy"
@@ -16,7 +17,7 @@ setup() {
 
 @test "it should should execute the dummy plugin" {
     run trento-agent facts gather \
-        --plugins-folder ./build/plugin_examples \
+        --plugins-folder $BUILD_DIR/plugin_examples \
         --gatherer dummy --argument 1
 
     [ "$status" -eq 0 ]
@@ -25,7 +26,7 @@ setup() {
 
 @test "it should execute the dummy plugin with a different argument" {
     run trento-agent facts gather \
-        --plugins-folder ./build/plugin_examples \
+        --plugins-folder $BUILD_DIR/plugin_examples \
         --gatherer dummy --argument 2
 
     [ "$status" -eq 0 ]


### PR DESCRIPTION
# Description

Introduce [BATS](https://github.com/bats-core/bats-core) to enable testing on built binaries, simulating the normal usage.

* add `bats` to the development tools
* add `*.bats` tests suites
* add `make test-build` command that run all the bats tests
* add `make build-plugin-examples` command that build the plugin examples into `./build/plutin-examples`
* add the commands to the CI

Furthermore, the build destination directory has been changed to `build/$(go mod GOARCH)`.