### PR TITLE
Add healthcheck to prevent flacky tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,16 +56,7 @@ jobs:
   test:
     runs-on: ubuntu-20.04
     env:
-      RABBITMQ_URL: amqp://guest:guest@localhost:5672
-
-    services:
-      rabbitmq:
-        image: rabbitmq
-        env:
-          RABBITMQ_DEFAULT_USER: guest
-          RABBITMQ_DEFAULT_PASS: guest
-        ports:
-          - 5672:5672
+      RABBITMQ_URL: amqp://guest:guest@localhost:5675
 
     steps:
       - uses: actions/checkout@v4
@@ -79,6 +70,18 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
+      - name: "Docker compose dependencies"
+        uses: isbang/compose-action@v2.0.2
+        with:
+          compose-file: "./docker-compose.yaml"
+          down-flags: "--volumes"
+      - name: Wait for RabbitMQ
+        run: |
+          until timeout 1 bash -c "cat < /dev/null > /dev/tcp/localhost/5675"; do
+            echo "Waiting for RabbitMQ to be ready..."
+            sleep 10
+          done
+          echo "RabbitMQ is up and running!"
       - name: test
         run: make test-coverage
       - name: install goveralls


### PR DESCRIPTION
When running `make test` in the CI, the rabbitmq service may eventually not be ready to accept connections. 
Adding a healthcheck command before running the actual test script. 