### PR TITLE
Implement context cancellation for command based gatherers

### DIFF
--- a/internal/factsengine/gatherers/ascsers_cluster.go
+++ b/internal/factsengine/gatherers/ascsers_cluster.go
@@ -75,13 +75,11 @@ func (g *AscsErsClusterGatherer) SetCache(cache *factscache.FactsCache) {
 }
 
 func (g *AscsErsClusterGatherer) Gather(
-	_ context.Context,
+	ctx context.Context,
 	factsRequests []entities.FactRequest,
 ) ([]entities.Fact, error) {
 	log.Infof("Starting %s facts gathering process", AscsErsClusterGathererName)
 	var cibdata cib.Root
-
-	ctx := context.Background()
 
 	content, err := factscache.GetOrUpdate(
 		g.cache,

--- a/internal/factsengine/gatherers/ascsers_cluster.go
+++ b/internal/factsengine/gatherers/ascsers_cluster.go
@@ -86,7 +86,7 @@ func (g *AscsErsClusterGatherer) Gather(
 	content, err := factscache.GetOrUpdate(
 		g.cache,
 		CibAdminGathererCache,
-		memoizeCibAdmin,
+		makeMemoizeCibAdmin(ctx),
 		g.executor,
 	)
 

--- a/internal/factsengine/gatherers/ascsers_cluster_test.go
+++ b/internal/factsengine/gatherers/ascsers_cluster_test.go
@@ -293,7 +293,7 @@ func (suite *AscsErsClusterTestSuite) TestAscsErskGathererContextCancelled() {
 	cancel()
 
 	suite.mockExecutor.
-		On("ExecContext", mock.Anything, "cibadmin", "--query", "--local").
+		On("ExecContext", ctx, "cibadmin", "--query", "--local").
 		Return(nil, ctx.Err())
 
 	c := gatherers.NewAscsErsClusterGatherer(suite.mockExecutor, suite.webService, nil)

--- a/internal/factsengine/gatherers/ascsers_cluster_test.go
+++ b/internal/factsengine/gatherers/ascsers_cluster_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/trento-project/agent/internal/factsengine/factscache"
 	"github.com/trento-project/agent/internal/factsengine/gatherers"
 	"github.com/trento-project/agent/pkg/factsengine/entities"
+	"github.com/trento-project/agent/pkg/utils"
 	utilsMocks "github.com/trento-project/agent/pkg/utils/mocks"
 	"github.com/trento-project/agent/test/helpers"
 )
@@ -288,15 +289,11 @@ func (suite *AscsErsClusterTestSuite) TestAscsErsClusterGather() {
 	suite.ElementsMatch(expectedEntries, entries)
 }
 
-func (suite *AscsErsClusterTestSuite) TestAscsErskGathererContextCancelled() {
+func (suite *AscsErsClusterTestSuite) TestAscsErsGathererContextCancelled() {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	suite.mockExecutor.
-		On("ExecContext", ctx, "cibadmin", "--query", "--local").
-		Return(nil, ctx.Err())
-
-	c := gatherers.NewAscsErsClusterGatherer(suite.mockExecutor, suite.webService, nil)
+	c := gatherers.NewAscsErsClusterGatherer(utils.Executor{}, suite.webService, nil)
 	factRequests := []entities.FactRequest{
 		{
 			Name:     "ascsers",

--- a/internal/factsengine/gatherers/cibadmin_test.go
+++ b/internal/factsengine/gatherers/cibadmin_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/trento-project/agent/internal/factsengine/factscache"
 	"github.com/trento-project/agent/internal/factsengine/gatherers"
 	"github.com/trento-project/agent/pkg/factsengine/entities"
+	"github.com/trento-project/agent/pkg/utils"
 	utilsMocks "github.com/trento-project/agent/pkg/utils/mocks"
 	"github.com/trento-project/agent/test/helpers"
 )
@@ -277,10 +278,7 @@ func (suite *CibAdminTestSuite) TestCibAdminGatherWithContextCancelled() {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	suite.mockExecutor.On("ExecContext", ctx, "cibadmin", "--query", "--local").
-		Return(nil, ctx.Err())
-
-	p := gatherers.NewCibAdminGatherer(suite.mockExecutor, nil)
+	p := gatherers.NewCibAdminGatherer(utils.Executor{}, nil)
 	factRequests := []entities.FactRequest{
 		{
 			Name:     "cib",

--- a/internal/factsengine/gatherers/cibadmin_test.go
+++ b/internal/factsengine/gatherers/cibadmin_test.go
@@ -277,7 +277,7 @@ func (suite *CibAdminTestSuite) TestCibAdminGatherWithContextCancelled() {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	suite.mockExecutor.On("ExecContext", mock.Anything, "cibadmin", "--query", "--local").
+	suite.mockExecutor.On("ExecContext", ctx, "cibadmin", "--query", "--local").
 		Return(nil, ctx.Err())
 
 	p := gatherers.NewCibAdminGatherer(suite.mockExecutor, nil)

--- a/internal/factsengine/gatherers/cibadmin_test.go
+++ b/internal/factsengine/gatherers/cibadmin_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 	"github.com/trento-project/agent/internal/factsengine/factscache"
 	"github.com/trento-project/agent/internal/factsengine/gatherers"
@@ -37,7 +38,7 @@ func (suite *CibAdminTestSuite) SetupTest() {
 }
 
 func (suite *CibAdminTestSuite) TestCibAdminGatherCmdNotFound() {
-	suite.mockExecutor.On("Exec", "cibadmin", "--query", "--local").Return(
+	suite.mockExecutor.On("ExecContext", mock.Anything, "cibadmin", "--query", "--local").Return(
 		suite.cibAdminOutput, errors.New("cibadmin not found"))
 
 	p := gatherers.NewCibAdminGatherer(suite.mockExecutor, nil)
@@ -58,7 +59,7 @@ func (suite *CibAdminTestSuite) TestCibAdminGatherCmdNotFound() {
 }
 
 func (suite *CibAdminTestSuite) TestCibAdminInvalidXML() {
-	suite.mockExecutor.On("Exec", "cibadmin", "--query", "--local").Return(
+	suite.mockExecutor.On("ExecContext", mock.Anything, "cibadmin", "--query", "--local").Return(
 		[]byte("invalid"), nil)
 
 	p := gatherers.NewCibAdminGatherer(suite.mockExecutor, nil)
@@ -79,7 +80,7 @@ func (suite *CibAdminTestSuite) TestCibAdminInvalidXML() {
 }
 
 func (suite *CibAdminTestSuite) TestCibAdminGather() {
-	suite.mockExecutor.On("Exec", "cibadmin", "--query", "--local").Return(
+	suite.mockExecutor.On("ExecContext", mock.Anything, "cibadmin", "--query", "--local").Return(
 		suite.cibAdminOutput, nil)
 
 	p := gatherers.NewCibAdminGatherer(suite.mockExecutor, nil)
@@ -210,7 +211,7 @@ func (suite *CibAdminTestSuite) TestCibAdminGather() {
 }
 
 func (suite *CibAdminTestSuite) TestCibAdminGatherWithCache() {
-	suite.mockExecutor.On("Exec", "cibadmin", "--query", "--local").
+	suite.mockExecutor.On("ExecContext", mock.Anything, "cibadmin", "--query", "--local").
 		Return(suite.cibAdminOutput, nil).
 		Once()
 
@@ -268,4 +269,29 @@ func (suite *CibAdminTestSuite) TestCibAdminGatherCacheCastingError() {
 
 	suite.EqualError(err, "fact gathering error: cibadmin-decoding-error - "+
 		"error decoding cibadmin output: error casting the command output")
+}
+
+func (suite *CibAdminTestSuite) TestCibAdminGatherWithContextCancelled() {
+
+	// Create a cancelled context
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	suite.mockExecutor.On("ExecContext", mock.Anything, "cibadmin", "--query", "--local").
+		Return(nil, ctx.Err())
+
+	p := gatherers.NewCibAdminGatherer(suite.mockExecutor, nil)
+	factRequests := []entities.FactRequest{
+		{
+			Name:     "cib",
+			Gatherer: "cibadmin",
+			Argument: "cib",
+			CheckID:  "check1",
+		},
+	}
+
+	factResults, err := p.Gather(ctx, factRequests)
+
+	suite.Error(err)
+	suite.Empty(factResults)
 }

--- a/internal/factsengine/gatherers/corosynccmapctl_test.go
+++ b/internal/factsengine/gatherers/corosynccmapctl_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/suite"
 	"github.com/trento-project/agent/internal/factsengine/gatherers"
 	"github.com/trento-project/agent/pkg/factsengine/entities"
+	"github.com/trento-project/agent/pkg/utils"
 	utilsMocks "github.com/trento-project/agent/pkg/utils/mocks"
 	"github.com/trento-project/agent/test/helpers"
 )
@@ -214,11 +215,7 @@ func (suite *CorosyncCmapctlTestSuite) TestCorosyncCmapctlGathererContextCancell
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	suite.mockExecutor.
-		On("ExecContext", ctx, "corosync-cmapctl", "-b").
-		Return(nil, ctx.Err())
-
-	c := gatherers.NewCorosyncCmapctlGatherer(suite.mockExecutor)
+	c := gatherers.NewCorosyncCmapctlGatherer(utils.Executor{})
 	factRequests := []entities.FactRequest{
 		{
 			Name:     "madeup_fact",

--- a/internal/factsengine/gatherers/corosynccmapctl_test.go
+++ b/internal/factsengine/gatherers/corosynccmapctl_test.go
@@ -215,7 +215,7 @@ func (suite *CorosyncCmapctlTestSuite) TestCorosyncCmapctlGathererContextCancell
 	cancel()
 
 	suite.mockExecutor.
-		On("ExecContext", mock.Anything, "corosync-cmapctl", "-b").
+		On("ExecContext", ctx, "corosync-cmapctl", "-b").
 		Return(nil, ctx.Err())
 
 	c := gatherers.NewCorosyncCmapctlGatherer(suite.mockExecutor)

--- a/internal/factsengine/gatherers/dispwork_test.go
+++ b/internal/factsengine/gatherers/dispwork_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/suite"
 	"github.com/trento-project/agent/internal/factsengine/gatherers"
 	"github.com/trento-project/agent/pkg/factsengine/entities"
+	"github.com/trento-project/agent/pkg/utils"
 	utilsMocks "github.com/trento-project/agent/pkg/utils/mocks"
 	"github.com/trento-project/agent/test/helpers"
 )
@@ -138,11 +139,7 @@ func (suite *DispWorkGathererTestSuite) TestDispWorkGathererContextCancelled() {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	suite.mockExecutor.
-		On("ExecContext", ctx, "su", "-", mock.AnythingOfType("string"), "-c", "\"disp+work\"").
-		Return(nil, ctx.Err())
-
-	c := gatherers.NewDispWorkGatherer(suite.fs, suite.mockExecutor)
+	c := gatherers.NewDispWorkGatherer(suite.fs, utils.Executor{})
 	factRequests := []entities.FactRequest{
 		{
 			Name:     "dispwork",

--- a/internal/factsengine/gatherers/dispwork_test.go
+++ b/internal/factsengine/gatherers/dispwork_test.go
@@ -139,7 +139,7 @@ func (suite *DispWorkGathererTestSuite) TestDispWorkGathererContextCancelled() {
 	cancel()
 
 	suite.mockExecutor.
-		On("ExecContext", mock.Anything, "su", "-", mock.AnythingOfType("string"), "-c", "\"disp+work\"").
+		On("ExecContext", ctx, "su", "-", mock.AnythingOfType("string"), "-c", "\"disp+work\"").
 		Return(nil, ctx.Err())
 
 	c := gatherers.NewDispWorkGatherer(suite.fs, suite.mockExecutor)

--- a/internal/factsengine/gatherers/mountinfo.go
+++ b/internal/factsengine/gatherers/mountinfo.go
@@ -66,7 +66,7 @@ func NewMountInfoGatherer(mInfo MountParserInterface, executor utils.CommandExec
 	return &MountInfoGatherer{mInfo: mInfo, executor: executor}
 }
 
-func (g *MountInfoGatherer) Gather(_ context.Context, factsRequests []entities.FactRequest) ([]entities.Fact, error) {
+func (g *MountInfoGatherer) Gather(ctx context.Context, factsRequests []entities.FactRequest) ([]entities.Fact, error) {
 	facts := []entities.Fact{}
 	log.Infof("Starting %s facts gathering process", MountInfoGathererName)
 	mounts, err := g.mInfo.GetMounts(nil)
@@ -92,7 +92,8 @@ func (g *MountInfoGatherer) Gather(_ context.Context, factsRequests []entities.F
 					Options:    mount.Options,
 				}
 
-				if blkidOuptut, err := g.executor.Exec("blkid", foundMountInfoResult.Source, "-o", "export"); err != nil {
+				blkidOuptut, err := g.executor.ExecContext(ctx, "blkid", foundMountInfoResult.Source, "-o", "export")
+				if err != nil {
 					log.Warnf("blkid command failed for source %s: %s", foundMountInfoResult.Source, err)
 				} else if fields, err := envparse.Parse(strings.NewReader(string(blkidOuptut))); err != nil {
 					log.Warnf("error parsing the blkid output: %s", err)

--- a/internal/factsengine/gatherers/mountinfo_test.go
+++ b/internal/factsengine/gatherers/mountinfo_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/trento-project/agent/internal/factsengine/gatherers"
 	"github.com/trento-project/agent/internal/factsengine/gatherers/mocks"
 	"github.com/trento-project/agent/pkg/factsengine/entities"
+	"github.com/trento-project/agent/pkg/utils"
 	utilsMocks "github.com/trento-project/agent/pkg/utils/mocks"
 )
 
@@ -216,11 +217,7 @@ func (suite *MountInfoTestSuite) TestMountInfoParsingGathererContextCancelled() 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	suite.mockMountParser.
-		On("ExecContext", ctx, "blkid", "10.1.1.10:/sapmnt", "-o", "export").
-		Return(nil, ctx.Err())
-
-	c := gatherers.NewSapHostCtrlGatherer(suite.mockExecutor)
+	c := gatherers.NewSapHostCtrlGatherer(utils.Executor{})
 	factRequests := []entities.FactRequest{
 		{Name: "shared",
 			Gatherer: "mount_info",

--- a/internal/factsengine/gatherers/mountinfo_test.go
+++ b/internal/factsengine/gatherers/mountinfo_test.go
@@ -217,7 +217,7 @@ func (suite *MountInfoTestSuite) TestMountInfoParsingGathererContextCancelled() 
 	cancel()
 
 	suite.mockMountParser.
-		On("ExecContext", mock.Anything, "blkid", "10.1.1.10:/sapmnt", "-o", "export").
+		On("ExecContext", ctx, "blkid", "10.1.1.10:/sapmnt", "-o", "export").
 		Return(nil, ctx.Err())
 
 	c := gatherers.NewSapHostCtrlGatherer(suite.mockExecutor)

--- a/internal/factsengine/gatherers/packageversion_test.go
+++ b/internal/factsengine/gatherers/packageversion_test.go
@@ -355,7 +355,7 @@ func (suite *DispWorkGathererTestSuite) TestPackageVersionGathererContextCancell
 	cancel()
 
 	suite.mockExecutor.
-		On("ExecContext", mock.Anything, "/usr/bin/rpm", "-q", "--qf", packageVersionQueryFormat, "").
+		On("ExecContext", ctx, "/usr/bin/rpm", "-q", "--qf", packageVersionQueryFormat, "").
 		Return(nil, ctx.Err())
 
 	c := gatherers.NewSapHostCtrlGatherer(suite.mockExecutor)

--- a/internal/factsengine/gatherers/packageversion_test.go
+++ b/internal/factsengine/gatherers/packageversion_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 	"github.com/trento-project/agent/internal/factsengine/gatherers"
 	"github.com/trento-project/agent/pkg/factsengine/entities"
@@ -30,7 +31,7 @@ func (suite *PackageVersionTestSuite) SetupTest() {
 }
 
 func (suite *PackageVersionTestSuite) TestPackageVersionGathererNoArgumentProvided() {
-	suite.mockExecutor.On("Exec", "/usr/bin/rpm", "-q", "--qf", packageVersionQueryFormat, "").Return(
+	suite.mockExecutor.On("ExecContext", mock.Anything, "/usr/bin/rpm", "-q", "--qf", packageVersionQueryFormat, "").Return(
 		[]byte("rpm: no arguments given for query"), nil)
 
 	p := gatherers.NewPackageVersionGatherer(suite.mockExecutor)
@@ -79,37 +80,37 @@ func (suite *PackageVersionTestSuite) TestPackageVersionGathererNoArgumentProvid
 func (suite *PackageVersionTestSuite) TestPackageVersionGather() {
 	corosyncMockOutputFile, _ := os.Open(helpers.GetFixturePath("gatherers/rpm-query.corosync.output"))
 	corosyncVersionMockOutput, _ := io.ReadAll(corosyncMockOutputFile)
-	suite.mockExecutor.On("Exec", "/usr/bin/rpm", "-q", "--qf", packageVersionQueryFormat, "corosync").
+	suite.mockExecutor.On("ExecContext", mock.Anything, "/usr/bin/rpm", "-q", "--qf", packageVersionQueryFormat, "corosync").
 		Return(corosyncVersionMockOutput, nil)
 
 	pacemakerMockOutputFile, _ := os.Open(helpers.GetFixturePath("gatherers/rpm-query.pacemaker.output"))
 	pacemakerVersionMockOutput, _ := io.ReadAll(pacemakerMockOutputFile)
-	suite.mockExecutor.On("Exec", "/usr/bin/rpm", "-q", "--qf", packageVersionQueryFormat, "pacemaker").
+	suite.mockExecutor.On("ExecContext", mock.Anything, "/usr/bin/rpm", "-q", "--qf", packageVersionQueryFormat, "pacemaker").
 		Return(pacemakerVersionMockOutput, nil)
 
 	multiversionsMockOutputFile, _ :=
 		os.Open(helpers.GetFixturePath("gatherers/rpm-query-multi-versions.variant-1.output"))
 	multiversionsVersionMockOutput, _ := io.ReadAll(multiversionsMockOutputFile)
-	suite.mockExecutor.On("Exec", "/usr/bin/rpm", "-q", "--qf", packageVersionQueryFormat, "sbd").
+	suite.mockExecutor.On("ExecContext", mock.Anything, "/usr/bin/rpm", "-q", "--qf", packageVersionQueryFormat, "sbd").
 		Return(multiversionsVersionMockOutput, nil)
 
 	multiversionsVariantMockOutputFile, _ :=
 		os.Open(helpers.GetFixturePath("gatherers/rpm-query-multi-versions.variant-2.output"))
 	multiversionsVariantVersionMockOutput, _ := io.ReadAll(multiversionsVariantMockOutputFile)
-	suite.mockExecutor.On("Exec", "/usr/bin/rpm", "-q", "--qf", packageVersionQueryFormat, "awk").
+	suite.mockExecutor.On("ExecContext", mock.Anything, "/usr/bin/rpm", "-q", "--qf", packageVersionQueryFormat, "awk").
 		Return(multiversionsVariantVersionMockOutput, nil)
 
-	suite.mockExecutor.On("Exec", "/usr/bin/zypper", "--terse", "versioncmp", "2.4.4", "2.4.5").Return(
+	suite.mockExecutor.On("ExecContext", mock.Anything, "/usr/bin/zypper", "--terse", "versioncmp", "2.4.4", "2.4.5").Return(
 		[]byte("-1\n"), nil)
-	suite.mockExecutor.On("Exec", "/usr/bin/zypper", "--terse", "versioncmp", "2.4.5", "2.4.5").Return(
+	suite.mockExecutor.On("ExecContext", mock.Anything, "/usr/bin/zypper", "--terse", "versioncmp", "2.4.5", "2.4.5").Return(
 		[]byte("0\n"), nil)
-	suite.mockExecutor.On("Exec", "/usr/bin/zypper", "--terse", "versioncmp", "2.4.6", "2.4.5").Return(
+	suite.mockExecutor.On("ExecContext", mock.Anything, "/usr/bin/zypper", "--terse", "versioncmp", "2.4.6", "2.4.5").Return(
 		[]byte("1\n"), nil)
 
 	versionComparisonOutputWithWarningFile, _ :=
 		os.Open(helpers.GetFixturePath("gatherers/versioncmp-with-warning.output"))
 	versionComparisonOutputWithWarning, _ := io.ReadAll(versionComparisonOutputWithWarningFile)
-	suite.mockExecutor.On("Exec", "/usr/bin/zypper", "--terse", "versioncmp", "1.5.2", "1.5.2").Return(
+	suite.mockExecutor.On("ExecContext", mock.Anything, "/usr/bin/zypper", "--terse", "versioncmp", "1.5.2", "1.5.2").Return(
 		versionComparisonOutputWithWarning, nil)
 
 	p := gatherers.NewPackageVersionGatherer(suite.mockExecutor)
@@ -257,22 +258,22 @@ func (suite *PackageVersionTestSuite) TestPackageVersionGather() {
 }
 
 func (suite *PackageVersionTestSuite) TestPackageVersionGatherErrors() {
-	suite.mockExecutor.On("Exec", "/usr/bin/rpm", "-q", "--qf", packageVersionQueryFormat, "sbd").
+	suite.mockExecutor.On("ExecContext", mock.Anything, "/usr/bin/rpm", "-q", "--qf", packageVersionQueryFormat, "sbd").
 		Return([]byte("package sbd is not installed"), errors.New(""))
-	suite.mockExecutor.On("Exec", "/usr/bin/rpm", "-q", "--qf", packageVersionQueryFormat, "pacemake").
+	suite.mockExecutor.On("ExecContext", mock.Anything, "/usr/bin/rpm", "-q", "--qf", packageVersionQueryFormat, "pacemake").
 		Return([]byte("package pacemake is not installed"), errors.New(""))
 
 	mockOutputFile, _ := os.Open(helpers.GetFixturePath("gatherers/rpm-query.corosync.output"))
 	mockOutput, _ := io.ReadAll(mockOutputFile)
-	suite.mockExecutor.On("Exec", "/usr/bin/rpm", "-q", "--qf", packageVersionQueryFormat, "corosync").
+	suite.mockExecutor.On("ExecContext", mock.Anything, "/usr/bin/rpm", "-q", "--qf", packageVersionQueryFormat, "corosync").
 		Return(mockOutput, nil)
 
 	invalidDateMockOutputFile, _ := os.Open(helpers.GetFixturePath("gatherers/rpm-query-invalid-date.output"))
 	invalidDateMockOutput, _ := io.ReadAll(invalidDateMockOutputFile)
-	suite.mockExecutor.On("Exec", "/usr/bin/rpm", "-q", "--qf", packageVersionQueryFormat, "another_package").
+	suite.mockExecutor.On("ExecContext", mock.Anything, "/usr/bin/rpm", "-q", "--qf", packageVersionQueryFormat, "another_package").
 		Return(invalidDateMockOutput, nil)
 
-	suite.mockExecutor.On("Exec", "/usr/bin/zypper", "--terse", "versioncmp", "1.2.3", "2.4.5").Return(
+	suite.mockExecutor.On("ExecContext", mock.Anything, "/usr/bin/zypper", "--terse", "versioncmp", "1.2.3", "2.4.5").Return(
 		[]byte(""), errors.New("zypper: command not found"))
 	p := gatherers.NewPackageVersionGatherer(suite.mockExecutor)
 
@@ -347,4 +348,27 @@ func (suite *PackageVersionTestSuite) TestPackageVersionGatherErrors() {
 
 	suite.NoError(err)
 	suite.ElementsMatch(expectedResults, factResults)
+}
+
+func (suite *DispWorkGathererTestSuite) TestPackageVersionGathererContextCancelled() {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	suite.mockExecutor.
+		On("ExecContext", mock.Anything, "/usr/bin/rpm", "-q", "--qf", packageVersionQueryFormat, "").
+		Return(nil, ctx.Err())
+
+	c := gatherers.NewSapHostCtrlGatherer(suite.mockExecutor)
+	factRequests := []entities.FactRequest{
+		{
+			Name:     "corosync",
+			Gatherer: "package_version",
+			Argument: "corosync",
+			CheckID:  "check1",
+		},
+	}
+	factResults, err := c.Gather(ctx, factRequests)
+
+	suite.Error(err)
+	suite.Empty(factResults)
 }

--- a/internal/factsengine/gatherers/packageversion_test.go
+++ b/internal/factsengine/gatherers/packageversion_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/suite"
 	"github.com/trento-project/agent/internal/factsengine/gatherers"
 	"github.com/trento-project/agent/pkg/factsengine/entities"
+	"github.com/trento-project/agent/pkg/utils"
 	utilsMocks "github.com/trento-project/agent/pkg/utils/mocks"
 	"github.com/trento-project/agent/test/helpers"
 )
@@ -354,11 +355,7 @@ func (suite *DispWorkGathererTestSuite) TestPackageVersionGathererContextCancell
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	suite.mockExecutor.
-		On("ExecContext", ctx, "/usr/bin/rpm", "-q", "--qf", packageVersionQueryFormat, "").
-		Return(nil, ctx.Err())
-
-	c := gatherers.NewSapHostCtrlGatherer(suite.mockExecutor)
+	c := gatherers.NewSapHostCtrlGatherer(utils.Executor{})
 	factRequests := []entities.FactRequest{
 		{
 			Name:     "corosync",

--- a/internal/factsengine/gatherers/saphostctrl_test.go
+++ b/internal/factsengine/gatherers/saphostctrl_test.go
@@ -262,7 +262,7 @@ func (suite *DispWorkGathererTestSuite) TestSapHostCtrlGathererContextCancelled(
 	cancel()
 
 	suite.mockExecutor.
-		On("ExecContext", mock.Anything, "/usr/sap/hostctrl/exe/saphostctrl", "-function", "Ping").
+		On("ExecContext", ctx, "/usr/sap/hostctrl/exe/saphostctrl", "-function", "Ping").
 		Return(nil, ctx.Err())
 
 	c := gatherers.NewSapHostCtrlGatherer(suite.mockExecutor)

--- a/internal/factsengine/gatherers/saphostctrl_test.go
+++ b/internal/factsengine/gatherers/saphostctrl_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/suite"
 	"github.com/trento-project/agent/internal/factsengine/gatherers"
 	"github.com/trento-project/agent/pkg/factsengine/entities"
+	"github.com/trento-project/agent/pkg/utils"
 	utilsMocks "github.com/trento-project/agent/pkg/utils/mocks"
 )
 
@@ -261,11 +262,7 @@ func (suite *DispWorkGathererTestSuite) TestSapHostCtrlGathererContextCancelled(
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	suite.mockExecutor.
-		On("ExecContext", ctx, "/usr/sap/hostctrl/exe/saphostctrl", "-function", "Ping").
-		Return(nil, ctx.Err())
-
-	c := gatherers.NewSapHostCtrlGatherer(suite.mockExecutor)
+	c := gatherers.NewSapHostCtrlGatherer(utils.Executor{})
 	factRequests := []entities.FactRequest{
 		{
 			Name:     "ping",

--- a/internal/factsengine/gatherers/sbddump_test.go
+++ b/internal/factsengine/gatherers/sbddump_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/suite"
 	"github.com/trento-project/agent/internal/factsengine/gatherers"
 	"github.com/trento-project/agent/pkg/factsengine/entities"
+	"github.com/trento-project/agent/pkg/utils"
 	utilsMocks "github.com/trento-project/agent/pkg/utils/mocks"
 	"github.com/trento-project/agent/test/helpers"
 )
@@ -176,10 +177,8 @@ func (suite *SBDDumpTestSuite) TestSBDDumpCancelledContext() {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	mockExecutor := new(utilsMocks.CommandExecutor)
-	mockExecutor.On("ExecContext", mock.Anything, "sbd", "-d", "/dev/vdc", "dump").Return(nil, ctx.Err())
 	sbdDumpGatherer := gatherers.NewSBDDumpGatherer(
-		mockExecutor,
+		utils.Executor{},
 		helpers.GetFixturePath("discovery/cluster/sbd/sbd_config"),
 	)
 	factRequests := []entities.FactRequest{

--- a/internal/factsengine/gatherers/sysctl.go
+++ b/internal/factsengine/gatherers/sysctl.go
@@ -45,11 +45,11 @@ func NewSysctlGatherer(executor utils.CommandExecutor) *SysctlGatherer {
 	}
 }
 
-func (s *SysctlGatherer) Gather(_ context.Context, factsRequests []entities.FactRequest) ([]entities.Fact, error) {
+func (s *SysctlGatherer) Gather(ctx context.Context, factsRequests []entities.FactRequest) ([]entities.Fact, error) {
 	facts := []entities.Fact{}
 	log.Infof("Starting %s facts gathering process", SysctlGathererName)
 
-	output, err := s.executor.Exec("sysctl", "-a")
+	output, err := s.executor.ExecContext(ctx, "sysctl", "-a")
 	if err != nil {
 		return nil, SysctlCommandError.Wrap(err.Error())
 	}

--- a/internal/factsengine/gatherers/sysctl_test.go
+++ b/internal/factsengine/gatherers/sysctl_test.go
@@ -223,7 +223,7 @@ func (suite *SysctlTestSuite) TestSysctlGathererContextCancelled() {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	suite.mockExecutor.On("ExecContext", mock.Anything, "sysctl", "-a").Return(nil, ctx.Err())
+	suite.mockExecutor.On("ExecContext", ctx, "sysctl", "-a").Return(nil, ctx.Err())
 
 	c := gatherers.NewSysctlGatherer(suite.mockExecutor)
 	factRequests := []entities.FactRequest{

--- a/internal/factsengine/gatherers/sysctl_test.go
+++ b/internal/factsengine/gatherers/sysctl_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/suite"
 	"github.com/trento-project/agent/internal/factsengine/gatherers"
 	"github.com/trento-project/agent/pkg/factsengine/entities"
+	"github.com/trento-project/agent/pkg/utils"
 	utilsMocks "github.com/trento-project/agent/pkg/utils/mocks"
 	"github.com/trento-project/agent/test/helpers"
 )
@@ -223,9 +224,7 @@ func (suite *SysctlTestSuite) TestSysctlGathererContextCancelled() {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	suite.mockExecutor.On("ExecContext", ctx, "sysctl", "-a").Return(nil, ctx.Err())
-
-	c := gatherers.NewSysctlGatherer(suite.mockExecutor)
+	c := gatherers.NewSysctlGatherer(utils.Executor{})
 	factRequests := []entities.FactRequest{
 		{
 			Name:     "context_cancelled_fact",

--- a/internal/factsengine/gatherers/verifypassword_test.go
+++ b/internal/factsengine/gatherers/verifypassword_test.go
@@ -302,7 +302,7 @@ func (suite *PasswordTestSuite) TestPasswordGatherContextCancelled() {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	suite.mockExecutor.On("ExecContext", mock.Anything, "getent", "shadow", "hacluster").
+	suite.mockExecutor.On("ExecContext", ctx, "getent", "shadow", "hacluster").
 		Return(nil, ctx.Err())
 
 	verifyPasswordGatherer := gatherers.NewVerifyPasswordGatherer(suite.mockExecutor)

--- a/internal/factsengine/gatherers/verifypassword_test.go
+++ b/internal/factsengine/gatherers/verifypassword_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/suite"
 	"github.com/trento-project/agent/internal/factsengine/gatherers"
 	"github.com/trento-project/agent/pkg/factsengine/entities"
+	"github.com/trento-project/agent/pkg/utils"
 	utilsMocks "github.com/trento-project/agent/pkg/utils/mocks"
 )
 
@@ -302,10 +303,7 @@ func (suite *PasswordTestSuite) TestPasswordGatherContextCancelled() {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	suite.mockExecutor.On("ExecContext", ctx, "getent", "shadow", "hacluster").
-		Return(nil, ctx.Err())
-
-	verifyPasswordGatherer := gatherers.NewVerifyPasswordGatherer(suite.mockExecutor)
+	verifyPasswordGatherer := gatherers.NewVerifyPasswordGatherer(utils.Executor{})
 	factRequests := []entities.FactRequest{
 		{
 			Name:     "hacluster",


### PR DESCRIPTION
# Description

Implement context cancellation for all gatherers that execute commands on the host machine:
* ascsers
* cibadmin
* corosync
* dispwork 
* mountinfo 
* packageversion 
* saphostctrl 
* sbddump 
* sysctl
* verifypassword