### PR TITLE
Handle context cancellation in fact gatherers

### DIFF
--- a/internal/factsengine/gatherers/corosyncconf.go
+++ b/internal/factsengine/gatherers/corosyncconf.go
@@ -51,7 +51,7 @@ func NewCorosyncConfGatherer(configFile string) *CorosyncConfGatherer {
 }
 
 func (s *CorosyncConfGatherer) Gather(
-	_ context.Context,
+	ctx context.Context,
 	factsRequests []entities.FactRequest,
 ) ([]entities.Fact, error) {
 	facts := []entities.Fact{}
@@ -80,6 +80,10 @@ func (s *CorosyncConfGatherer) Gather(
 			fact = entities.NewFactGatheredWithError(factReq, err)
 		}
 		facts = append(facts, fact)
+	}
+
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
 	}
 
 	log.Infof("Requested corosync.conf file facts gathered")

--- a/internal/factsengine/gatherers/corosyncconf_test.go
+++ b/internal/factsengine/gatherers/corosyncconf_test.go
@@ -243,3 +243,23 @@ func (suite *CorosyncConfTestSuite) TestCorosyncConfInvalid() {
 	suite.EqualError(err, expectedError.Error())
 	suite.Empty(factsGathered)
 }
+
+func (suite *CorosyncCmapctlTestSuite) TestCorosyncConfContextCancelled() {
+	c := gatherers.NewCorosyncConfGatherer(helpers.GetFixturePath("gatherers/corosync.conf.one_node"))
+
+	factsRequest := []entities.FactRequest{
+		{
+			Name:     "corosync_nodes",
+			Gatherer: "corosync.conf",
+			Argument: "nodelist.node",
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	factResults, err := c.Gather(ctx, factsRequest)
+
+	suite.Error(err)
+	suite.Empty(factResults)
+}

--- a/internal/factsengine/gatherers/fstab.go
+++ b/internal/factsengine/gatherers/fstab.go
@@ -49,7 +49,7 @@ func NewDefaultFstabGatherer() *FstabGatherer {
 	return &FstabGatherer{fstabFilePath: FstabFilePath}
 }
 
-func (f *FstabGatherer) Gather(_ context.Context, factsRequests []entities.FactRequest) ([]entities.Fact, error) {
+func (f *FstabGatherer) Gather(ctx context.Context, factsRequests []entities.FactRequest) ([]entities.Fact, error) {
 	log.Infof("Starting %s facts gathering process", FstabGathererName)
 	facts := []entities.Fact{}
 
@@ -78,6 +78,10 @@ func (f *FstabGatherer) Gather(_ context.Context, factsRequests []entities.FactR
 
 	for _, requestedFact := range factsRequests {
 		facts = append(facts, entities.NewFactGatheredWithRequest(requestedFact, factValues))
+	}
+
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
 	}
 
 	log.Infof("Requested %s facts gathered", FstabGathererName)

--- a/internal/factsengine/gatherers/fstab_test.go
+++ b/internal/factsengine/gatherers/fstab_test.go
@@ -158,3 +158,24 @@ func (s *FstabGathererTestSuite) TestFstabGatheringSuccess() {
 	s.NoError(err)
 	s.EqualValues(expectedResults, result)
 }
+
+func (suite *SapInstanceHostnameResolverTestSuite) TestFstabContextCancelled() {
+
+	gatherer := gatherers.NewFstabGatherer(helpers.GetFixturePath("gatherers/fstab.valid"))
+
+	factsRequest := []entities.FactRequest{
+		{
+			Name:     "fstab",
+			CheckID:  "check1",
+			Gatherer: "fstab",
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	factResults, err := gatherer.Gather(ctx, factsRequest)
+
+	suite.Error(err)
+	suite.Empty(factResults)
+}

--- a/internal/factsengine/gatherers/groups.go
+++ b/internal/factsengine/gatherers/groups.go
@@ -50,7 +50,7 @@ func NewGroupsGatherer(groupsFilePath string) *GroupsGatherer {
 	return &GroupsGatherer{groupsFilePath: groupsFilePath}
 }
 
-func (g *GroupsGatherer) Gather(_ context.Context, factsRequests []entities.FactRequest) ([]entities.Fact, error) {
+func (g *GroupsGatherer) Gather(ctx context.Context, factsRequests []entities.FactRequest) ([]entities.Fact, error) {
 	log.Infof("Starting %s facts gathering process", GroupsGathererName)
 	facts := []entities.Fact{}
 
@@ -78,6 +78,10 @@ func (g *GroupsGatherer) Gather(_ context.Context, factsRequests []entities.Fact
 
 	for _, requestedFact := range factsRequests {
 		facts = append(facts, entities.NewFactGatheredWithRequest(requestedFact, factValues))
+	}
+
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
 	}
 
 	log.Infof("Requested %s facts gathered", GroupsGathererName)

--- a/internal/factsengine/gatherers/groups_test.go
+++ b/internal/factsengine/gatherers/groups_test.go
@@ -111,3 +111,21 @@ func (s *GroupsGathererSuite) TestGroupsParsingDecodeErrorInvalidFormat() {
 	s.Nil(result)
 	s.EqualError(err, "fact gathering error: groups-decoding-error - error deconding groups file: could not decode groups file line daemon:x:1, entry are less then 4")
 }
+
+func (s *GroupsGathererSuite) TestGroupsContextCancelled() {
+	gatherer := gatherers.NewGroupsGatherer(helpers.GetFixturePath("gatherers/groups.valid"))
+
+	factsRequest := []entities.FactRequest{{
+		Name:     "groups",
+		Gatherer: "groups",
+		CheckID:  "checkone",
+	}}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	factResults, err := gatherer.Gather(ctx, factsRequest)
+
+	s.Error(err)
+	s.Empty(factResults)
+}

--- a/internal/factsengine/gatherers/hostsfile.go
+++ b/internal/factsengine/gatherers/hostsfile.go
@@ -54,7 +54,7 @@ func NewHostsFileGatherer(hostsFile string) *HostsFileGatherer {
 	return &HostsFileGatherer{hostsFilePath: hostsFile}
 }
 
-func (s *HostsFileGatherer) Gather(_ context.Context, factsRequests []entities.FactRequest) ([]entities.Fact, error) {
+func (s *HostsFileGatherer) Gather(ctx context.Context, factsRequests []entities.FactRequest) ([]entities.Fact, error) {
 	facts := []entities.Fact{}
 	log.Infof("Starting /etc/hosts file facts gathering process")
 
@@ -83,6 +83,10 @@ func (s *HostsFileGatherer) Gather(_ context.Context, factsRequests []entities.F
 			fact = entities.NewFactGatheredWithError(factReq, gatheringError)
 		}
 		facts = append(facts, fact)
+	}
+
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
 	}
 
 	log.Infof("Requested /etc/hosts file facts gathered")

--- a/internal/factsengine/gatherers/hostsfile_test.go
+++ b/internal/factsengine/gatherers/hostsfile_test.go
@@ -153,3 +153,22 @@ func (suite *HostsFileTestSuite) TestHostsFileIgnoresCommentedHosts() {
 	suite.NoError(err)
 	suite.ElementsMatch(expectedResults, factResults)
 }
+
+func (suite *HostsFileTestSuite) TestHostsFileContextCancelled() {
+	gatherer := gatherers.NewHostsFileGatherer(helpers.GetFixturePath("gatherers/hosts.basic"))
+
+	factsRequest := []entities.FactRequest{{
+		Name:     "hosts_localhost",
+		Gatherer: "hosts",
+		Argument: "localhost",
+		CheckID:  "check1",
+	}}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	factResults, err := gatherer.Gather(ctx, factsRequest)
+
+	suite.Error(err)
+	suite.Empty(factResults)
+}

--- a/internal/factsengine/gatherers/osrelease.go
+++ b/internal/factsengine/gatherers/osrelease.go
@@ -41,7 +41,7 @@ func NewOSReleaseGatherer(path string) *OSReleaseGatherer {
 	}
 }
 
-func (g *OSReleaseGatherer) Gather(_ context.Context, factsRequests []entities.FactRequest) ([]entities.Fact, error) {
+func (g *OSReleaseGatherer) Gather(ctx context.Context, factsRequests []entities.FactRequest) ([]entities.Fact, error) {
 	facts := []entities.Fact{}
 	log.Infof("Starting %s facts gathering process", OSReleaseGathererName)
 
@@ -72,6 +72,10 @@ func (g *OSReleaseGatherer) Gather(_ context.Context, factsRequests []entities.F
 	for _, requestedFact := range factsRequests {
 		fact := entities.NewFactGatheredWithRequest(requestedFact, osReleaseFactValue)
 		facts = append(facts, fact)
+	}
+
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
 	}
 
 	log.Infof("Requested %s facts gathered", OSReleaseGathererName)

--- a/internal/factsengine/gatherers/osrelease_test.go
+++ b/internal/factsengine/gatherers/osrelease_test.go
@@ -87,3 +87,21 @@ func (suite *OSReleaseGathererTestSuite) TestOSReleaseGathererErrorDecoding() {
 
 	suite.EqualError(err, "fact gathering error: os-release-decoding-error - error decoding file content: error on line 3: missing =")
 }
+
+func (suite *OSReleaseGathererTestSuite) TestOSReleaseContextCancelled() {
+	gatherer := gatherers.NewOSReleaseGatherer(helpers.GetFixturePath("gatherers/os-release.basic"))
+
+	factsRequest := []entities.FactRequest{{
+		Name:     "os-release",
+		Gatherer: "os-release@v1",
+		CheckID:  "check1",
+	}}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	factResults, err := gatherer.Gather(ctx, factsRequest)
+
+	suite.Error(err)
+	suite.Empty(factResults)
+}

--- a/internal/factsengine/gatherers/passwd.go
+++ b/internal/factsengine/gatherers/passwd.go
@@ -54,7 +54,7 @@ func NewPasswdGatherer(path string) *PasswdGatherer {
 	}
 }
 
-func (g *PasswdGatherer) Gather(_ context.Context, factsRequests []entities.FactRequest) ([]entities.Fact, error) {
+func (g *PasswdGatherer) Gather(ctx context.Context, factsRequests []entities.FactRequest) ([]entities.Fact, error) {
 	facts := []entities.Fact{}
 	log.Infof("Starting %s facts gathering process", PasswdGathererName)
 
@@ -72,6 +72,10 @@ func (g *PasswdGatherer) Gather(_ context.Context, factsRequests []entities.Fact
 		fact := entities.NewFactGatheredWithRequest(requestedFact, factValues)
 
 		facts = append(facts, fact)
+	}
+
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
 	}
 
 	log.Infof("Requested %s facts gathered", PasswdGathererName)

--- a/internal/factsengine/gatherers/passwd_test.go
+++ b/internal/factsengine/gatherers/passwd_test.go
@@ -108,3 +108,21 @@ func (suite *PasswdTestSuite) TestPasswdErrorDecoding() {
 	suite.EqualError(err, "fact gathering error: passwd-file-error - error reading /etc/passwd file: "+
 		"invalid passwd file: line 1 entry does not have 7 values")
 }
+
+func (suite *PasswdTestSuite) TestPasswdContextCancelled() {
+	gatherer := gatherers.NewPasswdGatherer(helpers.GetFixturePath("gatherers/passwd.basic"))
+
+	factsRequest := []entities.FactRequest{{
+		Name:     "passwd",
+		Gatherer: "passwd",
+		CheckID:  "check1",
+	}}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	factResults, err := gatherer.Gather(ctx, factsRequest)
+
+	suite.Error(err)
+	suite.Empty(factResults)
+}

--- a/internal/factsengine/gatherers/sapcontrol.go
+++ b/internal/factsengine/gatherers/sapcontrol.go
@@ -210,6 +210,12 @@ func (s *SapControlGatherer) gatherSingle(
 				webmethod,
 			)
 
+			// If the context is done, avoid processing all the instances
+			// The error will be handled by the caller anyway
+			if ctx.Err() != nil {
+				return entities.Fact{}
+			}
+
 			if err != nil {
 				log.Error(SapcontrolWebmethodError.
 					Wrap(fmt.Sprintf("argument %s for %s/%s", factReq.Argument, sid, instanceName)).

--- a/internal/factsengine/gatherers/sapcontrol.go
+++ b/internal/factsengine/gatherers/sapcontrol.go
@@ -151,28 +151,20 @@ func (s *SapControlGatherer) Gather(
 		return nil, SapcontrolFileSystemError.Wrap(err.Error())
 	}
 
-	results := make(chan []entities.Fact)
-	go func() {
+	log.Infof("Starting %s facts gathering process", SapControlGathererName)
+	facts := []entities.Fact{}
 
-		log.Infof("Starting %s facts gathering process", SapControlGathererName)
-		facts := []entities.Fact{}
-
-		for _, factReq := range factsRequests {
-			fact := s.gatherSingle(ctx, factReq, foundSystems)
-			facts = append(facts, fact)
-		}
-
-		log.Infof("Requested %s facts gathered", SapControlGathererName)
-
-		results <- facts
-	}()
-
-	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	case facts := <-results:
-		return facts, nil
+	for _, factReq := range factsRequests {
+		fact := s.gatherSingle(ctx, factReq, foundSystems)
+		facts = append(facts, fact)
 	}
+
+	log.Infof("Requested %s facts gathered", SapControlGathererName)
+
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+	return facts, nil
 }
 
 func (s *SapControlGatherer) gatherSingle(

--- a/internal/factsengine/gatherers/sapcontrol_test.go
+++ b/internal/factsengine/gatherers/sapcontrol_test.go
@@ -642,3 +642,25 @@ func (suite *SapControlGathererSuite) TestSapControlGathererHAGetFailoverConfig(
 	suite.NoError(err)
 	suite.EqualValues(expectedFacts, results)
 }
+
+func (suite *SapControlGathererSuite) TestSapControlGathererContextCancelled() {
+
+	gatherer := gatherers.NewSapControlGatherer(suite.webService, suite.testFS, nil)
+
+	factsRequest := []entities.FactRequest{
+		{
+			Name:     "missing_argument",
+			Gatherer: "sapcontrol",
+			CheckID:  "check1",
+			Argument: "",
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	factResults, err := gatherer.Gather(ctx, factsRequest)
+
+	suite.Error(err)
+	suite.Empty(factResults)
+}

--- a/internal/factsengine/gatherers/sapinstancehostnameresolver.go
+++ b/internal/factsengine/gatherers/sapinstancehostnameresolver.go
@@ -99,7 +99,7 @@ func NewSapInstanceHostnameResolverGatherer(
 }
 
 func (r *SapInstanceHostnameResolverGatherer) Gather(
-	_ context.Context,
+	ctx context.Context,
 	factsRequests []entities.FactRequest,
 ) ([]entities.Fact, error) {
 	facts := []entities.Fact{}
@@ -120,6 +120,10 @@ func (r *SapInstanceHostnameResolverGatherer) Gather(
 	for _, factReq := range factsRequests {
 		fact = entities.NewFactGatheredWithRequest(factReq, factValue)
 		facts = append(facts, fact)
+	}
+
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
 	}
 
 	return facts, nil

--- a/internal/factsengine/gatherers/sapinstancehostnameresolver_test.go
+++ b/internal/factsengine/gatherers/sapinstancehostnameresolver_test.go
@@ -187,3 +187,22 @@ func (suite *SapInstanceHostnameResolverTestSuite) TestSapInstanceHostnameResolv
 	suite.NoError(err)
 	suite.Equal(expectedResults, factResults)
 }
+
+func (suite *SapInstanceHostnameResolverTestSuite) TestSapInstanceHostnameResolverContextCancelled() {
+	appFS := afero.NewMemMapFs()
+	gatherer := gatherers.NewSapInstanceHostnameResolverGatherer(appFS, suite.mockResolver, suite.mockPinger)
+
+	factsRequest := []entities.FactRequest{{
+		Name:     "sapinstance_hostname_resolver",
+		Gatherer: "sapinstance_hostname_resolver",
+		CheckID:  "check1",
+	}}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	factResults, err := gatherer.Gather(ctx, factsRequest)
+
+	suite.Error(err)
+	suite.Empty(factResults)
+}

--- a/internal/factsengine/gatherers/sapprofiles.go
+++ b/internal/factsengine/gatherers/sapprofiles.go
@@ -54,7 +54,10 @@ func NewSapProfilesGatherer(fs afero.Fs) *SapProfilesGatherer {
 	return &SapProfilesGatherer{fs: fs}
 }
 
-func (s *SapProfilesGatherer) Gather(_ context.Context, factsRequests []entities.FactRequest) ([]entities.Fact, error) {
+func (s *SapProfilesGatherer) Gather(
+	ctx context.Context,
+	factsRequests []entities.FactRequest,
+) ([]entities.Fact, error) {
 	log.Infof("Starting %s facts gathering process", SapProfilesGathererName)
 	facts := []entities.Fact{}
 	systems := make(SapSystemMap)
@@ -86,8 +89,11 @@ func (s *SapProfilesGatherer) Gather(_ context.Context, factsRequests []entities
 		facts = append(facts, entities.NewFactGatheredWithRequest(requestedFact, factValues))
 	}
 
-	log.Infof("Requested %s facts gathered", SapProfilesGathererName)
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
 
+	log.Infof("Requested %s facts gathered", SapProfilesGathererName)
 	return facts, nil
 }
 

--- a/internal/factsengine/gatherers/sapprofiles_test.go
+++ b/internal/factsengine/gatherers/sapprofiles_test.go
@@ -399,3 +399,22 @@ func (suite *SapProfilesTestSuite) TestSapProfilesInvalidProfile() {
 		"error reading the sap profiles file system: could not parse profile file: error "+
 		"on line 1: missing =")
 }
+
+func (suite *SapProfilesTestSuite) TestSapProfilesContextCancelled() {
+	appFS := afero.NewMemMapFs()
+	gatherer := gatherers.NewSapProfilesGatherer(appFS)
+
+	factsRequest := []entities.FactRequest{{
+		Name:     "sap_profiles",
+		Gatherer: "sap_profiles",
+		CheckID:  "check1",
+	}}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	factResults, err := gatherer.Gather(ctx, factsRequest)
+
+	suite.Error(err)
+	suite.Empty(factResults)
+}


### PR DESCRIPTION
# Description

Following https://github.com/trento-project/agent/pull/376, handle context cancellation in the following gatherers
* corosyncconf
* fstab
* groups
* hostsfile
* osrelease
* passwd
* sapcontrol
* sapinstancehostnameresolver
* sapprofiles


