### PR TITLE
Update agent to golang 1.23

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.22
+          go-version: 1.23
       - uses: actions/cache@v4.2.0
         id: go-cache
         with:
@@ -62,7 +62,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.22
+          go-version: 1.23
       - uses: actions/cache@v4.2.0
         id: go-cache
         with:
@@ -97,7 +97,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.22
+          go-version: 1.23
       - uses: actions/cache@v4.2.0
         id: go-cache
         with:
@@ -125,7 +125,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.22
+          go-version: 1.23
       - uses: actions/cache@v4.2.0
         id: go-cache
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.59.1
+          version: v1.63.4
           skip-cache: true
           args: "--timeout=3m"
 

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -16,7 +16,7 @@ linters:
     - errchkjson
     - errorlint
     - exhaustive
-    - exportloopref
+    - copyloopvar
     - forbidigo
     - forcetypeassert
     - gochecknoglobals

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
-golang 1.22.5
+golang 1.23.6
 mockery 2.32.3
-golangci-lint 1.59.1
+golangci-lint 1.63.4
 bats 1.11.1

--- a/cmd/facts.go
+++ b/cmd/facts.go
@@ -190,6 +190,6 @@ func list(*cobra.Command, []string) {
 	log.Printf("Available gatherers:")
 
 	for _, g := range gatherers {
-		log.Printf(g)
+		log.Printf("%s", g)
 	}
 }

--- a/cmd/facts.go
+++ b/cmd/facts.go
@@ -190,6 +190,6 @@ func list(*cobra.Command, []string) {
 	log.Printf("Available gatherers:")
 
 	for _, g := range gatherers {
-		log.Printf("%s", g)
+		log.Print(g)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/trento-project/agent
 
-go 1.22
+go 1.23
 
 require (
 	github.com/clbanning/mxj/v2 v2.5.7

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -167,14 +167,14 @@ func repeat(ctx context.Context, operation string, tick func(), interval time.Du
 
 	ticker := time.NewTicker(interval)
 	msg := fmt.Sprintf("Next execution for operation %s in %s", operation, interval)
-	log.Debugf(msg)
+	log.Debug(msg)
 
 	defer ticker.Stop()
 	for {
 		select {
 		case <-ticker.C:
 			tick()
-			log.Debugf(msg)
+			log.Debug(msg)
 		case <-ctx.Done():
 			return
 		}

--- a/internal/core/cluster/sbd.go
+++ b/internal/core/cluster/sbd.go
@@ -135,7 +135,7 @@ func (s *SBDDevice) LoadDeviceData() error {
 	}
 
 	if len(sbdErrors) > 0 {
-		return fmt.Errorf(strings.Join(sbdErrors, ";"))
+		return errors.New(strings.Join(sbdErrors, ";"))
 	}
 
 	return nil

--- a/internal/core/hosts/discovered_host.go
+++ b/internal/core/hosts/discovered_host.go
@@ -7,7 +7,7 @@ type DiscoveredHost struct {
 	HostName                 string            `json:"hostname"`
 	CPUCount                 int               `json:"cpu_count"`
 	SocketCount              int               `json:"socket_count"`
-	TotalMemoryMB            int               `json:"total_memory_mb"`
+	TotalMemoryMB            uint64            `json:"total_memory_mb"`
 	AgentVersion             string            `json:"agent_version"`
 	InstallationSource       string            `json:"installation_source"`
 	FullyQualifiedDomainName *string           `json:"fully_qualified_domain_name,omitempty"`

--- a/internal/core/saptune/saptune.go
+++ b/internal/core/saptune/saptune.go
@@ -59,7 +59,7 @@ func (s *Saptune) RunCommand(args ...string) ([]byte, error) {
 	log.Infof("Running saptune command: saptune %v", args)
 	output, err := s.executor.Exec("saptune", args...)
 	if err != nil {
-		log.Debugf(err.Error())
+		log.Debug(err.Error())
 	}
 	log.Debugf("saptune output: %s", string(output))
 	log.Infof("Saptune command executed")

--- a/internal/discovery/host.go
+++ b/internal/discovery/host.go
@@ -170,12 +170,12 @@ func getOSVersion() string {
 	return infoStat.PlatformVersion
 }
 
-func getTotalMemoryMB() int {
+func getTotalMemoryMB() uint64 {
 	v, err := mem.VirtualMemory()
 	if err != nil {
 		log.Errorf("Error while getting memory info: %s", err)
 	}
-	return int(v.Total) / 1024 / 1024
+	return v.Total / 1024 / 1024
 }
 
 func getLogicalCPUs() int {

--- a/internal/factsengine/factscache/cache_test.go
+++ b/internal/factsengine/factscache/cache_test.go
@@ -60,7 +60,7 @@ func (suite *FactsCacheTestSuite) TestGetOrUpdateWithError() {
 	someError := "some error"
 
 	updateFunc := func(_ ...interface{}) (interface{}, error) {
-		return nil, fmt.Errorf(someError)
+		return nil, fmt.Errorf("%s", someError)
 	}
 
 	_, err := cache.GetOrUpdate("entry", updateFunc)

--- a/internal/factsengine/gatherers/fstab.go
+++ b/internal/factsengine/gatherers/fstab.go
@@ -3,6 +3,8 @@ package gatherers
 import (
 	"context"
 	"encoding/json"
+	"math"
+	"strconv"
 	"strings"
 
 	"github.com/d-tux/go-fstab"
@@ -60,7 +62,13 @@ func (f *FstabGatherer) Gather(ctx context.Context, factsRequests []entities.Fac
 
 	entries := []FstabEntry{}
 
-	for _, m := range mounts {
+	for i, m := range mounts {
+		if m.PassNo < 0 {
+			return nil, FstabFileDecodingError.Wrap("invalid check order for mount" + strconv.Itoa(i))
+		}
+		if m.Freq < 0 || m.Freq > math.MaxUint8 {
+			return nil, FstabFileDecodingError.Wrap("invalid backup frequency for mount" + strconv.Itoa(i))
+		}
 		entries = append(entries, FstabEntry{
 			MountPoint:     m.File,
 			Device:         m.SpecValue(),

--- a/internal/factsengine/gatherers/groups.go
+++ b/internal/factsengine/gatherers/groups.go
@@ -108,6 +108,9 @@ func parseGroupsFile(fileContent io.Reader) ([]GroupsEntry, error) {
 		if err != nil {
 			return nil, fmt.Errorf("could not convert group id %s to integer", values[2])
 		}
+		if groupID < 0 {
+			return nil, fmt.Errorf("group id %d is less than 0", groupID)
+		}
 
 		groupUsers := strings.Split(values[3], ",")
 		if len(groupUsers) == 1 && groupUsers[0] == "" {

--- a/packaging/suse/trento-agent.spec
+++ b/packaging/suse/trento-agent.spec
@@ -28,7 +28,7 @@ Source:         %{name}-%{version}.tar.gz
 Source1:        vendor.tar.gz
 ExclusiveArch:  aarch64 x86_64 ppc64le s390x
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
-BuildRequires:  golang(API) = 1.22
+BuildRequires:  golang(API) = 1.23
 Requires:       golang-github-prometheus-node_exporter
 Provides:       %{name} = %{version}-%{release}
 Provides:       trento = %{version}-%{release}


### PR DESCRIPTION
This PR updates the agent code/building infrastructure to be built with golang 1.23.

Version 1.23 is available in our build system at https://build.opensuse.org/package/show/devel:languages:go/go1.23

Some adjustments were needed in the code, please follow the comments below for the discussion.