### PR TITLE
Add `sudoers` gatherer

### DIFF
--- a/internal/factsengine/gatherers/gatherer.go
+++ b/internal/factsengine/gatherers/gatherer.go
@@ -92,6 +92,9 @@ func StandardGatherers() FactGatherersTree {
 		SBDDumpGathererName: map[string]FactGatherer{
 			"v1": NewDefaultSBDDumpGatherer(),
 		},
+		SudoersGathererName: map[string]FactGatherer{
+			"v1": NewDefaultSudoersGatherer(),
+		},
 		SysctlGathererName: map[string]FactGatherer{
 			"v1": NewDefaultSysctlGatherer(),
 		},

--- a/internal/factsengine/gatherers/sudoers.go
+++ b/internal/factsengine/gatherers/sudoers.go
@@ -182,58 +182,61 @@ func (g *SudoersGatherer) parseUserPrivileges(output string) ([]privilegeEntry, 
 			continue // Skip the header line itself.
 		}
 
-		if inPrivilegesSection {
-			trimmed := strings.TrimSpace(line)
-			if trimmed == "" {
-				continue
-			}
-
-			// Attempt to extract all expected parts from the line.
-			matches := entryRegex.FindStringSubmatch(line)
-			if len(matches) == 0 {
-				// If the line does not match, it might be a continuation of the previous entry.
-				// Advanced parsing would be required to handle multi-line entries.
-				continue
-			}
-
-			// Matches:
-			// matches[1]: run-as specifier (e.g. "ALL : ALL" or "root")
-			// matches[2]: optional password flag (e.g. "NOPASSWD:")
-			// matches[3]: the commands string
-			runas := matches[1]
-			flag := matches[2]
-			commandsStr := matches[3]
-
-			var runAsUser, runAsGroup string
-			parts := strings.Split(runas, ":")
-			runAsUser = strings.TrimSpace(parts[0])
-			if len(parts) > 1 {
-				runAsGroup = strings.TrimSpace(parts[1])
-			}
-
-			noPassword := false
-			if flag == "NOPASSWD:" {
-				noPassword = true
-			}
-
-			// Commands might be a comma-separated list. Split and trim each command.
-			rawCommands := strings.Split(commandsStr, ",")
-			var commands []string
-			for _, cmd := range rawCommands {
-				trimmedCmd := strings.TrimSpace(cmd)
-				if trimmedCmd != "" {
-					commands = append(commands, trimmedCmd)
-				}
-			}
-
-			entry := privilegeEntry{
-				runAsUser:  runAsUser,
-				runAsGroup: runAsGroup,
-				noPassword: noPassword,
-				commands:   commands,
-			}
-			privileges = append(privileges, entry)
+		if !inPrivilegesSection {
+			continue // Skip lines before the privileges section.
 		}
+
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+
+		// Attempt to extract all expected parts from the line.
+		matches := entryRegex.FindStringSubmatch(line)
+		if len(matches) == 0 {
+			// If the line does not match, it might be a continuation of the previous entry.
+			// Advanced parsing would be required to hayndle multi-line entries.
+			continue
+		}
+
+		// Matches:
+		// matches[1]: run-as specifier (e.g. "ALL : ALL" or "root")
+		// matches[2]: optional password flag (e.g. "NOPASSWD:")
+		// matches[3]: the commands string
+		runas := matches[1]
+		flag := matches[2]
+		commandsStr := matches[3]
+
+		var runAsUser, runAsGroup string
+		parts := strings.Split(runas, ":")
+		runAsUser = strings.TrimSpace(parts[0])
+		if len(parts) > 1 {
+			runAsGroup = strings.TrimSpace(parts[1])
+		}
+
+		noPassword := false
+		if flag == "NOPASSWD:" {
+			noPassword = true
+		}
+
+		// Commands might be a comma-separated list. Split and trim each command.
+		rawCommands := strings.Split(commandsStr, ",")
+		var commands []string
+		for _, cmd := range rawCommands {
+			trimmedCmd := strings.TrimSpace(cmd)
+			if trimmedCmd != "" {
+				commands = append(commands, trimmedCmd)
+			}
+		}
+
+		entry := privilegeEntry{
+			runAsUser:  runAsUser,
+			runAsGroup: runAsGroup,
+			noPassword: noPassword,
+			commands:   commands,
+		}
+		privileges = append(privileges, entry)
+
 	}
 
 	if !inPrivilegesSection {

--- a/internal/factsengine/gatherers/sudoers.go
+++ b/internal/factsengine/gatherers/sudoers.go
@@ -1,0 +1,302 @@
+package gatherers
+
+import (
+	"bufio"
+	"context"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/afero"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/trento-project/agent/internal/core/sapsystem"
+	"github.com/trento-project/agent/pkg/factsengine/entities"
+	"github.com/trento-project/agent/pkg/utils"
+)
+
+const (
+	SudoersGathererName = "sudoers"
+)
+
+// nolint:gochecknoglobals
+var (
+	SudoersReadError = entities.FactGatheringError{
+		Type:    "sudoers-read-error",
+		Message: "error reading sudoers",
+	}
+
+	SudoersParseError = entities.FactGatheringError{
+		Type:    "sudoers parse error",
+		Message: "error parsing sudoers",
+	}
+
+	SudoersUserError = entities.FactGatheringError{
+		Type:    "sudoers-user-error",
+		Message: "error finding sudoers users",
+	}
+)
+
+type SudoersGatherer struct {
+	executor utils.CommandExecutor
+	fs       afero.Fs
+}
+
+type PrivilegeEntry struct {
+	RunAsUser  string   `json:"run_as_user"`
+	RunAsGroup string   `json:"run_as_group,omitempty"`
+	NoPassword bool     `json:"no_password"`
+	Commands   []string `json:"commands"`
+}
+
+type ParsedSudoers struct {
+	CommandsAsRoot []PrivilegeEntry
+	User           string
+}
+
+func (p ParsedSudoers) AsInterface() interface{} {
+	return map[string]interface{}{
+		"user":       p.User,
+		"privileges": p.CommandsAsRoot,
+	}
+}
+
+func NewDefaultSudoersGatherer() *SudoersGatherer {
+	return NewSudoersGatherer(utils.Executor{}, afero.NewOsFs())
+}
+
+func NewSudoersGatherer(executor utils.CommandExecutor, fs afero.Fs) *SudoersGatherer {
+	return &SudoersGatherer{
+		executor: executor,
+		fs:       fs,
+	}
+}
+
+func (g *SudoersGatherer) Gather(ctx context.Context, factsRequests []entities.FactRequest) ([]entities.Fact, error) {
+	facts := []entities.Fact{}
+	log.Infof("Starting %s facts gathering process", SudoersGathererName)
+
+	for _, factReq := range factsRequests {
+		var fact entities.Fact
+		var data []ParsedSudoers
+
+		if factReq.Argument == "" {
+			result, err := g.gatherAll(ctx)
+			if err != nil {
+				return nil, err
+			}
+			data = result
+		} else {
+			result, err := g.gatherSingle(ctx, factReq.Argument)
+			if err != nil {
+				return nil, err
+			}
+			data = []ParsedSudoers{result}
+		}
+
+		value, err := toFactValue(data)
+		if err != nil {
+			return nil, err
+		}
+		fact = entities.NewFactGatheredWithRequest(factReq, value)
+		facts = append(facts, fact)
+	}
+
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+
+	log.Infof("Requested %s facts gathered", OSReleaseGathererName)
+	return facts, nil
+}
+
+func (g *SudoersGatherer) gatherAll(ctx context.Context) ([]ParsedSudoers, *entities.FactGatheringError) {
+	usernames, err := findUsernames(g.fs)
+	if err != nil {
+		return nil, SudoersUserError.Wrap(err.Error())
+	}
+	allUsers := []ParsedSudoers{}
+	for _, username := range usernames {
+		single, err := g.gatherSingle(ctx, username)
+		if err != nil {
+			return nil, err
+		}
+		allUsers = append(allUsers, single)
+	}
+	return allUsers, nil
+}
+
+func (g *SudoersGatherer) gatherSingle(
+	ctx context.Context,
+	username string,
+) (ParsedSudoers, *entities.FactGatheringError) {
+	output, err := g.readUserPrivileges(ctx, username)
+	if err != nil {
+		return ParsedSudoers{}, SudoersReadError.Wrap(err.Error())
+	}
+
+	privileges, err := g.parseUserPrivileges(string(output))
+	if err != nil {
+		return ParsedSudoers{}, SudoersParseError.Wrap(err.Error())
+	}
+
+	return ParsedSudoers{
+		CommandsAsRoot: privileges,
+		User:           username,
+	}, nil
+
+}
+
+func (g *SudoersGatherer) readUserPrivileges(ctx context.Context, username string) ([]byte, error) {
+	err := validateUsername(username)
+	if err != nil {
+		return nil, errors.Wrap(err, "invalid username "+username)
+	}
+	output, err := g.executor.ExecContext(ctx, "/usr/bin/sudo", "-l", "-U", username)
+	if err != nil {
+		return nil, errors.Wrap(err, "error running sudo command")
+	}
+	return output, nil
+}
+
+func (g *SudoersGatherer) parseUserPrivileges(output string) ([]PrivilegeEntry, error) {
+	var privileges []PrivilegeEntry
+	scanner := bufio.NewScanner(strings.NewReader(output))
+	var inPrivilegesSection bool
+
+	// This regex detects the header that indicates the start of the command privileges.
+	privilegesStartRegex := regexp.MustCompile(`^User\s+\S+\s+may run the following commands on`)
+	// This regex parses each privilege entry line.
+	// Group 1 captures the run-as specifier inside parentheses.
+	// Group 2 optionally captures "NOPASSWD:" or "PASSWD:".
+	// Group 3 captures the commands and any arguments.
+	entryRegex := regexp.MustCompile(`^\s*\(([^)]+)\)\s*(?:(NOPASSWD:|PASSWD:)\s*)?(.*)$`)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		// Check for the header line to start processing privilege entries.
+		if privilegesStartRegex.MatchString(line) {
+			inPrivilegesSection = true
+			continue // Skip the header line itself.
+		}
+
+		if inPrivilegesSection {
+			trimmed := strings.TrimSpace(line)
+			if trimmed == "" {
+				continue
+			}
+
+			// Attempt to extract all expected parts from the line.
+			matches := entryRegex.FindStringSubmatch(line)
+			if len(matches) == 0 {
+				// If the line does not match, it might be a continuation of the previous entry.
+				// Advanced parsing would be required to handle multi-line entries.
+				continue
+			}
+
+			// Matches:
+			// matches[1]: run-as specifier (e.g. "ALL : ALL" or "root")
+			// matches[2]: optional password flag (e.g. "NOPASSWD:")
+			// matches[3]: the commands string
+			runas := matches[1]
+			flag := matches[2]
+			commandsStr := matches[3]
+
+			var runAsUser, runAsGroup string
+			parts := strings.Split(runas, ":")
+			runAsUser = strings.TrimSpace(parts[0])
+			if len(parts) > 1 {
+				runAsGroup = strings.TrimSpace(parts[1])
+			}
+
+			noPassword := false
+			if flag == "NOPASSWD:" {
+				noPassword = true
+			}
+
+			// Commands might be a comma-separated list. Split and trim each command.
+			rawCommands := strings.Split(commandsStr, ",")
+			var commands []string
+			for _, cmd := range rawCommands {
+				trimmedCmd := strings.TrimSpace(cmd)
+				if trimmedCmd != "" {
+					commands = append(commands, trimmedCmd)
+				}
+			}
+
+			entry := PrivilegeEntry{
+				RunAsUser:  runAsUser,
+				RunAsGroup: runAsGroup,
+				NoPassword: noPassword,
+				Commands:   commands,
+			}
+			privileges = append(privileges, entry)
+		}
+	}
+
+	if !inPrivilegesSection {
+		return nil, errors.New("failed to parse all privilege entries")
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return privileges, nil
+}
+
+func validateUsername(username string) error {
+	// the validation fails if the username contains special characters
+	if strings.ContainsAny(username, " !\"#$%&'()*+,./:;<=>?@[\\]^`{|}~") {
+		return errors.New("username contains special characters")
+	}
+	return nil
+}
+
+func sidToUsername(sid string) string {
+	return strings.ToLower(sid) + "adm"
+}
+
+func findUsernames(fs afero.Fs) ([]string, error) {
+	usernames := []string{}
+
+	systemPaths, err := sapsystem.FindSystems(fs)
+	if err != nil {
+		return nil, SapProfilesFileSystemError.Wrap(err.Error())
+	}
+
+	for _, systemPath := range systemPaths {
+		username := sidToUsername(filepath.Base(systemPath))
+		usernames = append(usernames, username)
+	}
+
+	return usernames, nil
+}
+
+func toFactValue(allUsers []ParsedSudoers) (entities.FactValue, error) {
+	values := make([]interface{}, 0, len(allUsers))
+	for _, data := range allUsers {
+		value := make(map[string]interface{})
+
+		commandAsRoot := make([]interface{}, 0, len(data.CommandsAsRoot))
+		for _, commandEntry := range data.CommandsAsRoot {
+			elem := make(map[string]interface{})
+			elem["run_as_user"] = commandEntry.RunAsUser
+			elem["run_as_group"] = commandEntry.RunAsGroup
+			elem["no_password"] = commandEntry.NoPassword
+			elem["commands"] = commandEntry.Commands
+			commandAsRoot = append(commandAsRoot, elem)
+		}
+		value["commands_as_root"] = commandAsRoot
+		value["user"] = data.User
+
+		values = append(values, value)
+	}
+
+	fact, err := entities.NewFactValue(values)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to format fact value")
+	}
+	return fact, nil
+}

--- a/internal/factsengine/gatherers/sudoers.go
+++ b/internal/factsengine/gatherers/sudoers.go
@@ -107,7 +107,7 @@ func (g *SudoersGatherer) Gather(ctx context.Context, factsRequests []entities.F
 		return nil, ctx.Err()
 	}
 
-	log.Infof("Requested %s facts gathered", OSReleaseGathererName)
+	log.Infof("Requested %s facts gathered", SudoersGathererName)
 	return facts, nil
 }
 

--- a/internal/factsengine/gatherers/sudoers.go
+++ b/internal/factsengine/gatherers/sudoers.go
@@ -263,7 +263,7 @@ func findUsernames(fs afero.Fs) ([]string, error) {
 
 	systemPaths, err := sapsystem.FindSystems(fs)
 	if err != nil {
-		return nil, SapProfilesFileSystemError.Wrap(err.Error())
+		return nil, err
 	}
 
 	for _, systemPath := range systemPaths {

--- a/internal/factsengine/gatherers/sudoers.go
+++ b/internal/factsengine/gatherers/sudoers.go
@@ -214,10 +214,7 @@ func (g *SudoersGatherer) parseUserPrivileges(output string) ([]privilegeEntry, 
 			runAsGroup = strings.TrimSpace(parts[1])
 		}
 
-		noPassword := false
-		if flag == "NOPASSWD:" {
-			noPassword = true
-		}
+		noPassword := flag == "NOPASSWD:"
 
 		// Commands might be a comma-separated list. Split and trim each command.
 		rawCommands := strings.Split(commandsStr, ",")

--- a/internal/factsengine/gatherers/sudoers.go
+++ b/internal/factsengine/gatherers/sudoers.go
@@ -120,7 +120,11 @@ func (g *SudoersGatherer) gatherAll(ctx context.Context) ([]parsedSudoers, *enti
 	for _, username := range usernames {
 		single, err := g.gatherSingle(ctx, username)
 		if err != nil {
-			return nil, err
+			// It is a pretty common thing that SAP users might not remove the /usr/sap/SID directory once they remove
+			// the SAP installation. This would create "false" errors.
+			// We should consider just continuing instead of failing and have a best-effort solution for the gatherAll.
+			// Later on, the check can implement to see if all real installations have their command
+			continue
 		}
 		allUsers = append(allUsers, single)
 	}

--- a/internal/factsengine/gatherers/sudoers_test.go
+++ b/internal/factsengine/gatherers/sudoers_test.go
@@ -196,7 +196,7 @@ sudo: unknown user foo_user
 
 func (suite *SudoersTestSuite) TestSudoersGathererMultipleUsersNotFound() {
 	mockOutput1 := []byte(`
-sudo: unknown user foo_user
+sudo: unknown user fooadm
 `)
 
 	suite.mockExecutor.
@@ -229,9 +229,27 @@ User baradm may run the following commands on host:
 		},
 	}
 
-	_, err = c.Gather(context.Background(), factRequests)
+	factResults, err := c.Gather(context.Background(), factRequests)
 
-	suite.NotEmpty(err)
+	suite.Nil(err)
+	suite.Len(factResults, 1)
+	suite.Empty(factResults[0].Error)
+	suite.Equal(
+		&entities.FactValueList{
+			Value: []entities.FactValue{
+				// expected for user baradm
+				&entities.FactValueMap{
+					Value: map[string]entities.FactValue{
+						"user":         &entities.FactValueString{Value: "baradm"},
+						"run_as_user":  &entities.FactValueString{Value: "ALL"},
+						"run_as_group": &entities.FactValueString{Value: ""},
+						"no_password":  &entities.FactValueBool{Value: true},
+						"command":      &entities.FactValueString{Value: "/usr/sbin/cmd1 --flagbar"},
+					}},
+			},
+		},
+		factResults[0].Value,
+	)
 }
 
 func (suite *SudoersTestSuite) TestSudoersGathererOnError() {

--- a/internal/factsengine/gatherers/sudoers_test.go
+++ b/internal/factsengine/gatherers/sudoers_test.go
@@ -58,41 +58,36 @@ User foo_user may run the following commands on host:
 			Value: []entities.FactValue{
 				&entities.FactValueMap{
 					Value: map[string]entities.FactValue{
-						"user": &entities.FactValueString{Value: "foo_user"},
-						"commands_as_root": &entities.FactValueList{
-							Value: []entities.FactValue{
-								&entities.FactValueMap{
-									Value: map[string]entities.FactValue{
-										"run_as_user":  &entities.FactValueString{Value: "ALL"},
-										"run_as_group": &entities.FactValueString{Value: ""},
-										"no_password":  &entities.FactValueBool{Value: false},
-										"commands": &entities.FactValueList{Value: []entities.FactValue{
-											&entities.FactValueString{Value: "ALL"},
-										}},
-									}},
-								&entities.FactValueMap{
-									Value: map[string]entities.FactValue{
-										"run_as_user":  &entities.FactValueString{Value: "ALL"},
-										"run_as_group": &entities.FactValueString{Value: ""},
-										"no_password":  &entities.FactValueBool{Value: true},
-										"commands": &entities.FactValueList{Value: []entities.FactValue{
-											&entities.FactValueString{Value: "/usr/sbin/cmd1 --flag"},
-											&entities.FactValueString{Value: "/usr/sbin/cmd2"},
-										}},
-									}},
-								&entities.FactValueMap{
-									Value: map[string]entities.FactValue{
-										"run_as_user":  &entities.FactValueString{Value: "ALL"},
-										"run_as_group": &entities.FactValueString{Value: "ALL"},
-										"no_password":  &entities.FactValueBool{Value: false},
-										"commands": &entities.FactValueList{Value: []entities.FactValue{
-											&entities.FactValueString{Value: "ALL"},
-										}},
-									}},
-							},
-						},
-					},
-				},
+						"user":         &entities.FactValueString{Value: "foo_user"},
+						"run_as_user":  &entities.FactValueString{Value: "ALL"},
+						"run_as_group": &entities.FactValueString{Value: ""},
+						"no_password":  &entities.FactValueBool{Value: false},
+						"command":      &entities.FactValueString{Value: "ALL"},
+					}},
+				&entities.FactValueMap{
+					Value: map[string]entities.FactValue{
+						"user":         &entities.FactValueString{Value: "foo_user"},
+						"run_as_user":  &entities.FactValueString{Value: "ALL"},
+						"run_as_group": &entities.FactValueString{Value: ""},
+						"no_password":  &entities.FactValueBool{Value: true},
+						"command":      &entities.FactValueString{Value: "/usr/sbin/cmd1 --flag"},
+					}},
+				&entities.FactValueMap{
+					Value: map[string]entities.FactValue{
+						"user":         &entities.FactValueString{Value: "foo_user"},
+						"run_as_user":  &entities.FactValueString{Value: "ALL"},
+						"run_as_group": &entities.FactValueString{Value: ""},
+						"no_password":  &entities.FactValueBool{Value: true},
+						"command":      &entities.FactValueString{Value: "/usr/sbin/cmd2"},
+					}},
+				&entities.FactValueMap{
+					Value: map[string]entities.FactValue{
+						"user":         &entities.FactValueString{Value: "foo_user"},
+						"run_as_user":  &entities.FactValueString{Value: "ALL"},
+						"run_as_group": &entities.FactValueString{Value: "ALL"},
+						"no_password":  &entities.FactValueBool{Value: false},
+						"command":      &entities.FactValueString{Value: "ALL"},
+					}},
 			},
 		},
 		factResults[0].Value,
@@ -112,7 +107,7 @@ User fooadm may run the following commands on host:
 
 	mockOutput2 := []byte(`
 User baradm may run the following commands on host:
-	(ALL) NOPASSWD: /usr/sbin/cmd1 --flagbar
+	(ALL) NOPASSWD: /usr/sbin/cmd1 --flagbar, /usr/sbin/cmd2
 `)
 
 	suite.mockExecutor.
@@ -146,41 +141,29 @@ User baradm may run the following commands on host:
 				// expected for user baradm
 				&entities.FactValueMap{
 					Value: map[string]entities.FactValue{
-						"user": &entities.FactValueString{Value: "baradm"},
-						"commands_as_root": &entities.FactValueList{
-							Value: []entities.FactValue{
-								&entities.FactValueMap{
-									Value: map[string]entities.FactValue{
-										"run_as_user":  &entities.FactValueString{Value: "ALL"},
-										"run_as_group": &entities.FactValueString{Value: ""},
-										"no_password":  &entities.FactValueBool{Value: true},
-										"commands": &entities.FactValueList{Value: []entities.FactValue{
-											&entities.FactValueString{Value: "/usr/sbin/cmd1 --flagbar"},
-										}},
-									}},
-							},
-						},
-					},
-				},
+						"user":         &entities.FactValueString{Value: "baradm"},
+						"run_as_user":  &entities.FactValueString{Value: "ALL"},
+						"run_as_group": &entities.FactValueString{Value: ""},
+						"no_password":  &entities.FactValueBool{Value: true},
+						"command":      &entities.FactValueString{Value: "/usr/sbin/cmd1 --flagbar"},
+					}},
+				&entities.FactValueMap{
+					Value: map[string]entities.FactValue{
+						"user":         &entities.FactValueString{Value: "baradm"},
+						"run_as_user":  &entities.FactValueString{Value: "ALL"},
+						"run_as_group": &entities.FactValueString{Value: ""},
+						"no_password":  &entities.FactValueBool{Value: true},
+						"command":      &entities.FactValueString{Value: "/usr/sbin/cmd2"},
+					}},
 				// expected for user fooadm
 				&entities.FactValueMap{
 					Value: map[string]entities.FactValue{
-						"user": &entities.FactValueString{Value: "fooadm"},
-						"commands_as_root": &entities.FactValueList{
-							Value: []entities.FactValue{
-								&entities.FactValueMap{
-									Value: map[string]entities.FactValue{
-										"run_as_user":  &entities.FactValueString{Value: "ALL"},
-										"run_as_group": &entities.FactValueString{Value: ""},
-										"no_password":  &entities.FactValueBool{Value: true},
-										"commands": &entities.FactValueList{Value: []entities.FactValue{
-											&entities.FactValueString{Value: "/usr/sbin/cmd1 --flagfoo"},
-										}},
-									}},
-							},
-						},
-					},
-				},
+						"user":         &entities.FactValueString{Value: "fooadm"},
+						"run_as_user":  &entities.FactValueString{Value: "ALL"},
+						"run_as_group": &entities.FactValueString{Value: ""},
+						"no_password":  &entities.FactValueBool{Value: true},
+						"command":      &entities.FactValueString{Value: "/usr/sbin/cmd1 --flagfoo"},
+					}},
 			},
 		},
 		factResults[0].Value,

--- a/internal/factsengine/gatherers/sudoers_test.go
+++ b/internal/factsengine/gatherers/sudoers_test.go
@@ -1,0 +1,301 @@
+package gatherers_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+	"github.com/trento-project/agent/internal/factsengine/gatherers"
+	"github.com/trento-project/agent/pkg/factsengine/entities"
+	utilsMocks "github.com/trento-project/agent/pkg/utils/mocks"
+)
+
+type SudoersTestSuite struct {
+	suite.Suite
+	mockExecutor *utilsMocks.CommandExecutor
+}
+
+func TestSudoersTestSuite(t *testing.T) {
+	suite.Run(t, new(SudoersTestSuite))
+}
+
+func (suite *SudoersTestSuite) SetupTest() {
+	suite.mockExecutor = new(utilsMocks.CommandExecutor)
+}
+
+func (suite *SudoersTestSuite) TestSudoersGathererSingleUserFound() {
+	mockOutput := []byte(`
+User foo_user may run the following commands on host:
+	(ALL) ALL
+    (ALL) NOPASSWD: /usr/sbin/cmd1 --flag, /usr/sbin/cmd2
+    (ALL:ALL) ALL
+`)
+	suite.mockExecutor.
+		On("ExecContext", mock.Anything, "/usr/bin/sudo", "-l", "-U", "foo_user").
+		Return(mockOutput, nil).
+		Once()
+
+	c := gatherers.NewSudoersGatherer(suite.mockExecutor, afero.NewMemMapFs())
+
+	factRequests := []entities.FactRequest{
+		{
+			Name:     "any",
+			Gatherer: "sudoers",
+			Argument: "foo_user",
+		},
+	}
+
+	factResults, err := c.Gather(context.Background(), factRequests)
+
+	suite.NoError(err)
+	suite.Len(factResults, 1)
+	suite.Empty(factResults[0].Error)
+	suite.Equal(
+		&entities.FactValueList{
+			Value: []entities.FactValue{
+				&entities.FactValueMap{
+					Value: map[string]entities.FactValue{
+						"user": &entities.FactValueString{Value: "foo_user"},
+						"commands_as_root": &entities.FactValueList{
+							Value: []entities.FactValue{
+								&entities.FactValueMap{
+									Value: map[string]entities.FactValue{
+										"run_as_user":  &entities.FactValueString{Value: "ALL"},
+										"run_as_group": &entities.FactValueString{Value: ""},
+										"no_password":  &entities.FactValueBool{Value: false},
+										"commands": &entities.FactValueList{Value: []entities.FactValue{
+											&entities.FactValueString{Value: "ALL"},
+										}},
+									}},
+								&entities.FactValueMap{
+									Value: map[string]entities.FactValue{
+										"run_as_user":  &entities.FactValueString{Value: "ALL"},
+										"run_as_group": &entities.FactValueString{Value: ""},
+										"no_password":  &entities.FactValueBool{Value: true},
+										"commands": &entities.FactValueList{Value: []entities.FactValue{
+											&entities.FactValueString{Value: "/usr/sbin/cmd1 --flag"},
+											&entities.FactValueString{Value: "/usr/sbin/cmd2"},
+										}},
+									}},
+								&entities.FactValueMap{
+									Value: map[string]entities.FactValue{
+										"run_as_user":  &entities.FactValueString{Value: "ALL"},
+										"run_as_group": &entities.FactValueString{Value: "ALL"},
+										"no_password":  &entities.FactValueBool{Value: false},
+										"commands": &entities.FactValueList{Value: []entities.FactValue{
+											&entities.FactValueString{Value: "ALL"},
+										}},
+									}},
+							},
+						},
+					},
+				},
+			},
+		},
+		factResults[0].Value,
+	)
+}
+
+func (suite *SudoersTestSuite) TestSudoersGathererMultipleUsersFound() {
+	mockOutput1 := []byte(`
+User fooadm may run the following commands on host:
+	(ALL) NOPASSWD: /usr/sbin/cmd1 --flagfoo
+`)
+
+	suite.mockExecutor.
+		On("ExecContext", mock.Anything, "/usr/bin/sudo", "-l", "-U", "fooadm").
+		Return(mockOutput1, nil).
+		Once()
+
+	mockOutput2 := []byte(`
+User baradm may run the following commands on host:
+	(ALL) NOPASSWD: /usr/sbin/cmd1 --flagbar
+`)
+
+	suite.mockExecutor.
+		On("ExecContext", mock.Anything, "/usr/bin/sudo", "-l", "-U", "baradm").
+		Return(mockOutput2, nil).
+		Once()
+
+	fs := afero.NewMemMapFs()
+	err := afero.WriteFile(fs, "/usr/sap/FOO/SYS/global/hdb/custom/config/global.ini", []byte("key1=value1"), 0400)
+	suite.NoErrorf(err, "error creating content01")
+	err = afero.WriteFile(fs, "/usr/sap/BAR/SYS/global/hdb/custom/config/global.ini", []byte("key1=value1"), 0400)
+	suite.NoErrorf(err, "error creating content02")
+
+	c := gatherers.NewSudoersGatherer(suite.mockExecutor, fs)
+
+	factRequests := []entities.FactRequest{
+		{
+			Name:     "any",
+			Gatherer: "sudoers",
+		},
+	}
+
+	factResults, err := c.Gather(context.Background(), factRequests)
+
+	suite.NoError(err)
+	suite.Len(factResults, 1)
+	suite.Empty(factResults[0].Error)
+	suite.Equal(
+		&entities.FactValueList{
+			Value: []entities.FactValue{
+				// expected for user baradm
+				&entities.FactValueMap{
+					Value: map[string]entities.FactValue{
+						"user": &entities.FactValueString{Value: "baradm"},
+						"commands_as_root": &entities.FactValueList{
+							Value: []entities.FactValue{
+								&entities.FactValueMap{
+									Value: map[string]entities.FactValue{
+										"run_as_user":  &entities.FactValueString{Value: "ALL"},
+										"run_as_group": &entities.FactValueString{Value: ""},
+										"no_password":  &entities.FactValueBool{Value: true},
+										"commands": &entities.FactValueList{Value: []entities.FactValue{
+											&entities.FactValueString{Value: "/usr/sbin/cmd1 --flagbar"},
+										}},
+									}},
+							},
+						},
+					},
+				},
+				// expected for user fooadm
+				&entities.FactValueMap{
+					Value: map[string]entities.FactValue{
+						"user": &entities.FactValueString{Value: "fooadm"},
+						"commands_as_root": &entities.FactValueList{
+							Value: []entities.FactValue{
+								&entities.FactValueMap{
+									Value: map[string]entities.FactValue{
+										"run_as_user":  &entities.FactValueString{Value: "ALL"},
+										"run_as_group": &entities.FactValueString{Value: ""},
+										"no_password":  &entities.FactValueBool{Value: true},
+										"commands": &entities.FactValueList{Value: []entities.FactValue{
+											&entities.FactValueString{Value: "/usr/sbin/cmd1 --flagfoo"},
+										}},
+									}},
+							},
+						},
+					},
+				},
+			},
+		},
+		factResults[0].Value,
+	)
+}
+
+func (suite *SudoersTestSuite) TestSudoersGathererSingleUserNotFound() {
+	mockOutput := []byte(`
+sudo: unknown user foo_user
+`)
+	suite.mockExecutor.
+		On("ExecContext", mock.Anything, "/usr/bin/sudo", "-l", "-U", "foo_user").
+		Return(mockOutput, nil).
+		Once()
+
+	c := gatherers.NewSudoersGatherer(suite.mockExecutor, afero.NewMemMapFs())
+
+	factRequests := []entities.FactRequest{
+		{
+			Name:     "any",
+			Gatherer: "sudoers",
+			Argument: "foo_user",
+		},
+	}
+
+	_, err := c.Gather(context.Background(), factRequests)
+
+	suite.NotEmpty(err)
+}
+
+func (suite *SudoersTestSuite) TestSudoersGathererMultipleUsersNotFound() {
+	mockOutput1 := []byte(`
+sudo: unknown user foo_user
+`)
+
+	suite.mockExecutor.
+		On("ExecContext", mock.Anything, "/usr/bin/sudo", "-l", "-U", "fooadm").
+		Return(mockOutput1, nil).
+		Once()
+
+	mockOutput2 := []byte(`
+User baradm may run the following commands on host:
+	(ALL) NOPASSWD: /usr/sbin/cmd1 --flagbar
+`)
+
+	suite.mockExecutor.
+		On("ExecContext", mock.Anything, "/usr/bin/sudo", "-l", "-U", "baradm").
+		Return(mockOutput2, nil).
+		Once()
+
+	fs := afero.NewMemMapFs()
+	err := afero.WriteFile(fs, "/usr/sap/FOO/SYS/global/hdb/custom/config/global.ini", []byte("key1=value1"), 0400)
+	suite.NoErrorf(err, "error creating content01")
+	err = afero.WriteFile(fs, "/usr/sap/BAR/SYS/global/hdb/custom/config/global.ini", []byte("key1=value1"), 0400)
+	suite.NoErrorf(err, "error creating content02")
+
+	c := gatherers.NewSudoersGatherer(suite.mockExecutor, fs)
+
+	factRequests := []entities.FactRequest{
+		{
+			Name:     "any",
+			Gatherer: "sudoers",
+		},
+	}
+
+	_, err = c.Gather(context.Background(), factRequests)
+
+	suite.NotEmpty(err)
+}
+
+func (suite *SudoersTestSuite) TestSudoersGathererOnError() {
+
+	suite.mockExecutor.
+		On("ExecContext", mock.Anything, "/usr/bin/sudo", "-l", "-U", "foo_user").
+		Return(nil, errors.New("command failure")).
+		Once()
+
+	c := gatherers.NewSudoersGatherer(suite.mockExecutor, afero.NewMemMapFs())
+
+	factRequests := []entities.FactRequest{
+		{
+			Name:     "any",
+			Gatherer: "sudoers",
+			Argument: "foo_user",
+		},
+	}
+
+	_, err := c.Gather(context.Background(), factRequests)
+
+	suite.NotEmpty(err)
+}
+
+func (suite *SudoersTestSuite) TestSudoersContextCancelled() {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	mockOutput := []byte(`
+User foo_user may run the following commands on host:
+	(ALL) ALL
+`)
+	suite.mockExecutor.
+		On("ExecContext", mock.Anything, "/usr/bin/sudo", "-l", "-U", "foo_user").
+		Return(mockOutput, nil)
+
+	c := gatherers.NewSudoersGatherer(suite.mockExecutor, afero.NewMemMapFs())
+
+	factRequests := []entities.FactRequest{
+		{
+			Name:     "any",
+			Gatherer: "sudoers",
+			Argument: "foo_user",
+		},
+	}
+	factResults, err := c.Gather(ctx, factRequests)
+
+	suite.Error(err)
+	suite.Empty(factResults)
+}

--- a/pkg/factsengine/entities/fact_value.go
+++ b/pkg/factsengine/entities/fact_value.go
@@ -58,6 +58,16 @@ func NewFactValue(factInterface interface{}, opts ...FactValueOption) (FactValue
 	}
 
 	switch value := factInterface.(type) {
+	case []string:
+		newList := []FactValue{}
+		for _, value := range value {
+			newValue, err := NewFactValue(value, opts...)
+			if err != nil {
+				return nil, err
+			}
+			newList = append(newList, newValue)
+		}
+		return &FactValueList{Value: newList}, nil
 	case []interface{}:
 		newList := []FactValue{}
 		for _, value := range value {

--- a/pkg/factsengine/entities/fact_value_test.go
+++ b/pkg/factsengine/entities/fact_value_test.go
@@ -41,6 +41,15 @@ func (suite *FactValueTestSuite) TestNewFactValueWithStringConversion() {
 			err: nil,
 		},
 		{
+			description: "Should construct a list type to FactValue (string)",
+			factValue:   []string{"string", "another string"},
+			expected: &entities.FactValueList{Value: []entities.FactValue{
+				&entities.FactValueString{Value: "string"},
+				&entities.FactValueString{Value: "another string"},
+			}},
+			err: nil,
+		},
+		{
 			description: "Should construct a map type to FactValue",
 			factValue: map[string]interface{}{
 				"basic": "basic",


### PR DESCRIPTION
# Description

Add a `sudoers` gatherer to retrieve information about the permission of users, in order to verify the compliance of the host configuration. The gatherer returns a parsed json with the output of the command
```sh
sudo -l -U <user>
```

The gatherer operates in two modes:
* when a user is specified, it fetches the information about the single user
* otherwise, it discovers the SAP users configured in the host and returns data for each user; SAP users are defined by convention using the lower-cased system id and the suffix `adm`

In both cases, the result is a list.

### Example

```sh
$ sudo -l -U prdadm

User prdadm may run the following commands on usr-vmhana01:
    (ALL) ALL
    (ALL) NOPASSWD: /usr/sbin/crm_attribute -n hana_prd_site_srHook_Site1 -v SOK -t crm_config -s SAPHanaSR, /usr/sbin/crm_attribute -n hana_prd_site_srHook_Site1 -v SFAIL -t crm_config -s
        SAPHanaSR, /usr/sbin/crm_attribute -n hana_prd_site_srHook_Site2 -v SOK -t crm_config -s SAPHanaSR, /usr/sbin/crm_attribute -n hana_prd_site_srHook_Site2 -v SFAIL -t crm_config -s
        SAPHanaSR
    (ALL) NOPASSWD: /usr/sbin/SAPHanaSR-hookHelper --case checkTakeover --sid\=prd

$ trento-agent facts gather --gatherer sudoers --argument prdadm

Value:

[
  #{
    "command": "ALL",
    "no_password": false,
    "run_as_group": "",
    "run_as_user": "ALL",
    "user": "prdadm"
  },
  #{
    "command": "/usr/sbin/crm_attribute -n hana_prd_site_srHook_Site1 -v SOK -t crm_config -s SAPHanaSR",
    "no_password": true,
    "run_as_group": "",
    "run_as_user": "ALL",
    "user": "prdadm"
  },
  #{
    "command": "/usr/sbin/crm_attribute -n hana_prd_site_srHook_Site1 -v SFAIL -t crm_config -s SAPHanaSR",
    "no_password": true,
    "run_as_group": "",
    "run_as_user": "ALL",
    "user": "prdadm"
  },
  #{
    "command": "/usr/sbin/crm_attribute -n hana_prd_site_srHook_Site2 -v SOK -t crm_config -s SAPHanaSR",
    "no_password": true,
    "run_as_group": "",
    "run_as_user": "ALL",
    "user": "prdadm"
  },
  #{
    "command": "/usr/sbin/crm_attribute -n hana_prd_site_srHook_Site2 -v SFAIL -t crm_config -s SAPHanaSR",
    "no_password": true,
    "run_as_group": "",
    "run_as_user": "ALL",
    "user": "prdadm"
  },
  #{
    "command": "/usr/sbin/SAPHanaSR-hookHelper --case checkTakeover --sid\\=prd",
    "no_password": true,
    "run_as_group": "",
    "run_as_user": "ALL",
    "user": "prdadm"
  }
]
```

