### PR TITLE
Identify j2ee instances as application instances

### DIFF
--- a/internal/core/sapsystem/sapinstance.go
+++ b/internal/core/sapsystem/sapinstance.go
@@ -16,7 +16,7 @@ import (
 
 var (
 	databaseFeatures         = regexp.MustCompile("HDB.*")
-	applicationFeatures      = regexp.MustCompile("MESSAGESERVER.*|ENQREP|ABAP.*")
+	applicationFeatures      = regexp.MustCompile("MESSAGESERVER.*|ENQREP|ABAP.*|J2EE.*")
 	diagnosticsAgentFeatures = regexp.MustCompile("SMDAGENT")
 )
 

--- a/internal/core/sapsystem/sapsystem_test.go
+++ b/internal/core/sapsystem/sapsystem_test.go
@@ -927,6 +927,13 @@ func (suite *SAPSystemTestSuite) TestDetectType() {
 		{
 			instance: &sapcontrol.SAPInstance{
 				Hostname: "host",
+				Features: "GATEWAY|MESSAGESERVER|ENQUE|WEBDISP",
+			},
+			expectedType: sapsystem.Application,
+		},
+		{
+			instance: &sapcontrol.SAPInstance{
+				Hostname: "host",
 				Features: "ENQREP",
 			},
 			expectedType: sapsystem.Application,
@@ -935,6 +942,20 @@ func (suite *SAPSystemTestSuite) TestDetectType() {
 			instance: &sapcontrol.SAPInstance{
 				Hostname: "host",
 				Features: "ABAP|GATEWAY|ICMAN|IGS",
+			},
+			expectedType: sapsystem.Application,
+		},
+		{
+			instance: &sapcontrol.SAPInstance{
+				Hostname: "host",
+				Features: "J2EE|ICMAN|IGS",
+			},
+			expectedType: sapsystem.Application,
+		},
+		{
+			instance: &sapcontrol.SAPInstance{
+				Hostname: "host",
+				Features: "J2EE|IGS",
 			},
 			expectedType: sapsystem.Application,
 		},


### PR DESCRIPTION
# Description

Fix J2EE instances identification as application instances. Without this, the JAVA instances were identified as unknown type in some cases. It depends on if other application instances where installed in the same host. This could create differences depending on the order of sapcontrol instances output.
Unfortunately our test JAVA scenario had this case...

## How was this tested?
UT and manual testing
