### PR TITLE
Identify current instance SAP instances

### DIFF
--- a/internal/core/sapsystem/sapcontrol.go
+++ b/internal/core/sapsystem/sapcontrol.go
@@ -40,8 +40,8 @@ func NewSAPControl(ctx context.Context, w sapcontrol.WebService, fs afero.Fs, ho
 		Instances:  instances.Instances,
 	}
 
-	if err := sapControl.enrichRunningLocally(fs, hostname); err != nil {
-		return nil, errors.Wrap(err, "Error finding locally running instances")
+	if err := sapControl.enrichCurrentInstance(fs, hostname); err != nil {
+		return nil, errors.Wrap(err, "Error finding current instance")
 	}
 
 	return sapControl, nil
@@ -57,13 +57,13 @@ func (s *SAPControl) findProperty(key string) (string, error) {
 	return "", fmt.Errorf("Property %s not found", key)
 }
 
-// enrichRunningLocally identifies and sets the locally running instance in the
+// enrichCurrentInstance identifies and sets the currently discovered instance in the
 // SapControl.Instances list. This is required to later on extract information from
 // that dataset
 // The logic is based on this: https://m1bc.home.blog/2019/09/09/getsysteminstancelist-duplicate-entries/
 // The file syntax is: startPriority_httpPort_httpsPort_features_dispstatus_instanceNr_hostname
 // The content of the file includes the real hostname of the machine where the instance is running
-func (s *SAPControl) enrichRunningLocally(fs afero.Fs, hostname string) error {
+func (s *SAPControl) enrichCurrentInstance(fs afero.Fs, hostname string) error {
 	sid, err := s.findProperty("SAPSYSTEMNAME")
 	if err != nil {
 		return err
@@ -101,7 +101,7 @@ func (s *SAPControl) enrichRunningLocally(fs afero.Fs, hostname string) error {
 			}
 
 			if strings.Contains(string(instanceFileContent), hostname) {
-				instance.RunningLocally = true
+				instance.CurrentInstance = true
 				break
 			}
 		}

--- a/internal/core/sapsystem/sapcontrol.go
+++ b/internal/core/sapsystem/sapcontrol.go
@@ -3,8 +3,12 @@ package sapsystem
 import (
 	"context"
 	"fmt"
+	"path"
+	"regexp"
+	"strings"
 
 	"github.com/pkg/errors"
+	"github.com/spf13/afero"
 	sapcontrol "github.com/trento-project/agent/internal/core/sapsystem/sapcontrolapi"
 )
 
@@ -14,7 +18,7 @@ type SAPControl struct {
 	Properties []*sapcontrol.InstanceProperty
 }
 
-func NewSAPControl(ctx context.Context, w sapcontrol.WebService) (*SAPControl, error) {
+func NewSAPControl(ctx context.Context, w sapcontrol.WebService, fs afero.Fs, hostname string) (*SAPControl, error) {
 	properties, err := w.GetInstanceProperties(ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "SAPControl web service error")
@@ -30,11 +34,17 @@ func NewSAPControl(ctx context.Context, w sapcontrol.WebService) (*SAPControl, e
 		return nil, errors.Wrap(err, "SAPControl web service error")
 	}
 
-	return &SAPControl{
+	sapControl := &SAPControl{
 		Properties: properties.Properties,
 		Processes:  processes.Processes,
 		Instances:  instances.Instances,
-	}, nil
+	}
+
+	if err := sapControl.enrichRunningLocally(fs, hostname); err != nil {
+		return nil, errors.Wrap(err, "Error finding locally running instances")
+	}
+
+	return sapControl, nil
 }
 
 func (s *SAPControl) findProperty(key string) (string, error) {
@@ -45,4 +55,75 @@ func (s *SAPControl) findProperty(key string) (string, error) {
 	}
 
 	return "", fmt.Errorf("Property %s not found", key)
+}
+
+// enrichRunningLocally identifies and sets the locally running instance in the
+// SapControl.Instances list. This is required to later on extract information from
+// that dataset
+// The logic is based on this: https://m1bc.home.blog/2019/09/09/getsysteminstancelist-duplicate-entries/
+// The file syntax is: startPriority_httpPort_httpsPort_features_dispstatus_instanceNr_hostname
+// The content of the file includes the real hostname of the machine where the instance is running
+func (s *SAPControl) enrichRunningLocally(fs afero.Fs, hostname string) error {
+	sid, err := s.findProperty("SAPSYSTEMNAME")
+	if err != nil {
+		return err
+	}
+
+	instanceNumber, err := s.findProperty("SAPSYSTEM")
+	if err != nil {
+		return err
+	}
+
+	sapLocalhost, err := s.findProperty("SAPLOCALHOST")
+	if err != nil {
+		return err
+	}
+
+	sapControlInstancesPath := path.Join("/usr/sap", sid, "/SYS/global/sapcontrol")
+	instanceFiles, err := afero.ReadDir(fs, sapControlInstancesPath)
+	if err != nil {
+		return errors.Wrap(err, "sapcontrol folder not found")
+	}
+
+	for _, instance := range s.Instances {
+		if !(fmt.Sprintf("%02d", instance.InstanceNr) == instanceNumber && instance.Hostname == sapLocalhost) {
+			continue
+		}
+
+		for _, instanceFile := range instanceFiles {
+			if !instanceMatches(instance, instanceFile.Name()) {
+				continue
+			}
+			absInstancePath := path.Join(sapControlInstancesPath, instanceFile.Name())
+			instanceFileContent, err := afero.ReadFile(fs, absInstancePath)
+			if err != nil {
+				continue
+			}
+
+			if strings.Contains(string(instanceFileContent), hostname) {
+				instance.RunningLocally = true
+				break
+			}
+		}
+	}
+
+	return nil
+}
+
+func instanceMatches(instance *sapcontrol.SAPInstance, instanceFile string) bool {
+	matched, err := regexp.MatchString(fmt.Sprintf(
+		"%s_%d_%d_.*_%d_%02d_%s",
+		instance.StartPriority,
+		instance.HttpPort,
+		instance.HttpsPort,
+		sapcontrol.DispstatusCodeFromStr(instance.Dispstatus),
+		instance.InstanceNr,
+		instance.Hostname,
+	), instanceFile)
+
+	if err != nil {
+		return false
+	}
+
+	return matched
 }

--- a/internal/core/sapsystem/sapcontrolapi/webservice.go
+++ b/internal/core/sapsystem/sapcontrolapi/webservice.go
@@ -136,8 +136,9 @@ type SAPInstance struct {
 	StartPriority string     `xml:"startPriority,omitempty" json:"startPriority,omitempty"`
 	Features      string     `xml:"features,omitempty" json:"features,omitempty"`
 	Dispstatus    STATECOLOR `xml:"dispstatus,omitempty" json:"dispstatus,omitempty"`
-	// Added manually as a virtual field
-	RunningLocally bool `json:"runningLocally"`
+	// Added manually as a virtual field to identify if the instance belongs to
+	// the currently discovered instance
+	CurrentInstance bool `json:"currentInstance"`
 }
 
 type VersionInfo struct {

--- a/internal/core/sapsystem/sapcontrolapi/webservice.go
+++ b/internal/core/sapsystem/sapcontrolapi/webservice.go
@@ -137,7 +137,7 @@ type SAPInstance struct {
 	Features      string     `xml:"features,omitempty" json:"features,omitempty"`
 	Dispstatus    STATECOLOR `xml:"dispstatus,omitempty" json:"dispstatus,omitempty"`
 	// Added manually as a virtual field
-	RunningLocally bool `json:"runningLocally,omitempty"`
+	RunningLocally bool `json:"runningLocally"`
 }
 
 type VersionInfo struct {

--- a/internal/core/sapsystem/sapcontrolapi/webservice.go
+++ b/internal/core/sapsystem/sapcontrolapi/webservice.go
@@ -136,6 +136,8 @@ type SAPInstance struct {
 	StartPriority string     `xml:"startPriority,omitempty" json:"startPriority,omitempty"`
 	Features      string     `xml:"features,omitempty" json:"features,omitempty"`
 	Dispstatus    STATECOLOR `xml:"dispstatus,omitempty" json:"dispstatus,omitempty"`
+	// Added manually as a virtual field
+	RunningLocally bool `json:"runningLocally,omitempty"`
 }
 
 type VersionInfo struct {
@@ -259,4 +261,13 @@ func (s *webService) HAGetFailoverConfig(ctx context.Context) (*HAGetFailoverCon
 	}
 
 	return response, nil
+}
+
+func DispstatusCodeFromStr(state STATECOLOR) STATECOLOR_CODE {
+	return map[STATECOLOR]STATECOLOR_CODE{
+		STATECOLOR_GRAY:   STATECOLOR_CODE_GRAY,
+		STATECOLOR_GREEN:  STATECOLOR_CODE_GREEN,
+		STATECOLOR_YELLOW: STATECOLOR_CODE_YELLOW,
+		STATECOLOR_RED:    STATECOLOR_CODE_RED,
+	}[state]
 }

--- a/internal/core/sapsystem/sapinstance.go
+++ b/internal/core/sapsystem/sapinstance.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
+	"github.com/spf13/afero"
 	"github.com/trento-project/agent/internal/core/sapsystem/sapcontrolapi"
 	"github.com/trento-project/agent/pkg/utils"
 )
@@ -39,13 +40,14 @@ func NewSAPInstance(
 	ctx context.Context,
 	w sapcontrolapi.WebService,
 	executor utils.CommandExecutor,
+	fs afero.Fs,
 ) (*SAPInstance, error) {
 	host, err := os.Hostname()
 	if err != nil {
 		return nil, err
 	}
 
-	scontrol, err := NewSAPControl(ctx, w)
+	scontrol, err := NewSAPControl(ctx, w, fs, host)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/core/sapsystem/sapsystem.go
+++ b/internal/core/sapsystem/sapsystem.go
@@ -155,7 +155,7 @@ func NewSAPSystem(
 	// Find instances
 	for _, instPath := range instPaths {
 		webService := webService.New(instPath[1])
-		instance, err := NewSAPInstance(ctx, webService, executor)
+		instance, err := NewSAPInstance(ctx, webService, executor, fs)
 		if err != nil {
 			log.Errorf("Error discovering a SAP instance: %s", err)
 			continue

--- a/internal/core/sapsystem/sapsystem_test.go
+++ b/internal/core/sapsystem/sapsystem_test.go
@@ -562,24 +562,24 @@ func (suite *SAPSystemTestSuite) TestNewSAPInstanceDatabase() {
 			},
 			Instances: []*sapcontrol.SAPInstance{
 				{
-					Hostname:       "host1",
-					InstanceNr:     0,
-					HttpPort:       50013,
-					HttpsPort:      50014,
-					StartPriority:  "0.3",
-					Features:       "HDB|HDB_WORKER",
-					Dispstatus:     sapcontrol.STATECOLOR_GREEN,
-					RunningLocally: false,
+					Hostname:        "host1",
+					InstanceNr:      0,
+					HttpPort:        50013,
+					HttpsPort:       50014,
+					StartPriority:   "0.3",
+					Features:        "HDB|HDB_WORKER",
+					Dispstatus:      sapcontrol.STATECOLOR_GREEN,
+					CurrentInstance: false,
 				},
 				{
-					Hostname:       "host2",
-					InstanceNr:     1,
-					HttpPort:       50113,
-					HttpsPort:      50114,
-					StartPriority:  "0.3",
-					Features:       "HDB|HDB_WORKER",
-					Dispstatus:     sapcontrol.STATECOLOR_YELLOW,
-					RunningLocally: true,
+					Hostname:        "host2",
+					InstanceNr:      1,
+					HttpPort:        50113,
+					HttpsPort:       50114,
+					StartPriority:   "0.3",
+					Features:        "HDB|HDB_WORKER",
+					Dispstatus:      sapcontrol.STATECOLOR_YELLOW,
+					CurrentInstance: true,
 				},
 			},
 		},
@@ -830,24 +830,24 @@ func (suite *SAPSystemTestSuite) TestNewSAPInstanceApp() {
 			},
 			Instances: []*sapcontrol.SAPInstance{
 				{
-					Hostname:       "host1",
-					InstanceNr:     0,
-					HttpPort:       50013,
-					HttpsPort:      50014,
-					StartPriority:  "0.3",
-					Features:       "MESSAGESERVER|ENQUE",
-					Dispstatus:     sapcontrol.STATECOLOR_GREEN,
-					RunningLocally: true,
+					Hostname:        "host1",
+					InstanceNr:      0,
+					HttpPort:        50013,
+					HttpsPort:       50014,
+					StartPriority:   "0.3",
+					Features:        "MESSAGESERVER|ENQUE",
+					Dispstatus:      sapcontrol.STATECOLOR_GREEN,
+					CurrentInstance: true,
 				},
 				{
-					Hostname:       "host2",
-					InstanceNr:     1,
-					HttpPort:       50113,
-					HttpsPort:      50114,
-					StartPriority:  "0.3",
-					Features:       "some other features",
-					Dispstatus:     sapcontrol.STATECOLOR_YELLOW,
-					RunningLocally: false,
+					Hostname:        "host2",
+					InstanceNr:      1,
+					HttpPort:        50113,
+					HttpsPort:       50114,
+					StartPriority:   "0.3",
+					Features:        "some other features",
+					Dispstatus:      sapcontrol.STATECOLOR_YELLOW,
+					CurrentInstance: false,
 				},
 			},
 		},
@@ -1180,7 +1180,7 @@ func (suite *SAPSystemTestSuite) TestSapControl_NoSapcontrolFolder() {
 	_, err := sapsystem.NewSAPControl(ctx, mockWebService, appFS, "")
 	suite.EqualError(
 		err,
-		"Error finding locally running instances: sapcontrol folder not found: "+
+		"Error finding current instance: sapcontrol folder not found: "+
 			"open /usr/sap/DEV/SYS/global/sapcontrol: file does not exist")
 }
 
@@ -1239,6 +1239,6 @@ func (suite *SAPSystemTestSuite) TestSapControl_MissingProperties() {
 		_, err := sapsystem.NewSAPControl(ctx, mockWebService, appFS, "")
 		suite.EqualError(
 			err,
-			fmt.Sprintf("Error finding locally running instances: Property %s not found", tt.expectedMissingProp))
+			fmt.Sprintf("Error finding current instance: Property %s not found", tt.expectedMissingProp))
 	}
 }

--- a/internal/factsengine/gatherers/sapcontrol_test.go
+++ b/internal/factsengine/gatherers/sapcontrol_test.go
@@ -401,16 +401,16 @@ func (suite *SapControlGathererSuite) TestSapControlGathererGetSystemInstanceLis
 										Value: []entities.FactValue{
 											&entities.FactValueMap{
 												Value: map[string]entities.FactValue{
-													"hostname":        &entities.FactValueString{Value: "host1"},
-													"instance_nr":     &entities.FactValueInt{Value: 0},
-													"running_locally": &entities.FactValueBool{Value: false},
+													"hostname":         &entities.FactValueString{Value: "host1"},
+													"instance_nr":      &entities.FactValueInt{Value: 0},
+													"current_instance": &entities.FactValueBool{Value: false},
 												},
 											},
 											&entities.FactValueMap{
 												Value: map[string]entities.FactValue{
-													"hostname":        &entities.FactValueString{Value: "host2"},
-													"instance_nr":     &entities.FactValueInt{Value: 0},
-													"running_locally": &entities.FactValueBool{Value: false},
+													"hostname":         &entities.FactValueString{Value: "host2"},
+													"instance_nr":      &entities.FactValueInt{Value: 0},
+													"current_instance": &entities.FactValueBool{Value: false},
 												},
 											},
 										},

--- a/internal/factsengine/gatherers/sapcontrol_test.go
+++ b/internal/factsengine/gatherers/sapcontrol_test.go
@@ -401,14 +401,16 @@ func (suite *SapControlGathererSuite) TestSapControlGathererGetSystemInstanceLis
 										Value: []entities.FactValue{
 											&entities.FactValueMap{
 												Value: map[string]entities.FactValue{
-													"hostname":    &entities.FactValueString{Value: "host1"},
-													"instance_nr": &entities.FactValueInt{Value: 0},
+													"hostname":        &entities.FactValueString{Value: "host1"},
+													"instance_nr":     &entities.FactValueInt{Value: 0},
+													"running_locally": &entities.FactValueBool{Value: false},
 												},
 											},
 											&entities.FactValueMap{
 												Value: map[string]entities.FactValue{
-													"hostname":    &entities.FactValueString{Value: "host2"},
-													"instance_nr": &entities.FactValueInt{Value: 0},
+													"hostname":        &entities.FactValueString{Value: "host2"},
+													"instance_nr":     &entities.FactValueInt{Value: 0},
+													"running_locally": &entities.FactValueBool{Value: false},
 												},
 											},
 										},

--- a/test/fixtures/discovery/sap_system/expected_published_sap_system_discovery_application.json
+++ b/test/fixtures/discovery/sap_system/expected_published_sap_system_discovery_application.json
@@ -55,7 +55,8 @@
                 "httpsPort": 50014,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 0,
-                "startPriority": "1"
+                "startPriority": "1",
+                "runningLocally": false
               },
               {
                 "features": "ENQREP",
@@ -64,7 +65,8 @@
                 "httpsPort": 51014,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
-                "startPriority": "0.5"
+                "startPriority": "0.5",
+                "runningLocally": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -73,7 +75,8 @@
                 "httpsPort": 50114,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 1,
-                "startPriority": "3"
+                "startPriority": "3",
+                "runningLocally": false
               },
             {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -82,7 +85,8 @@
                 "httpsPort": 50214,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 2,
-                "startPriority": "3"
+                "startPriority": "3",
+                "runningLocally": true
               }
             ],
             "Processes": [

--- a/test/fixtures/discovery/sap_system/expected_published_sap_system_discovery_application.json
+++ b/test/fixtures/discovery/sap_system/expected_published_sap_system_discovery_application.json
@@ -56,7 +56,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 0,
                 "startPriority": "1",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "features": "ENQREP",
@@ -66,7 +66,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
                 "startPriority": "0.5",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -76,7 +76,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 1,
                 "startPriority": "3",
-                "runningLocally": false
+                "currentInstance": false
               },
             {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -86,7 +86,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 2,
                 "startPriority": "3",
-                "runningLocally": true
+                "currentInstance": true
               }
             ],
             "Processes": [

--- a/test/fixtures/discovery/sap_system/expected_published_sap_system_discovery_database.json
+++ b/test/fixtures/discovery/sap_system/expected_published_sap_system_discovery_database.json
@@ -42,7 +42,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 0,
                 "startPriority": "0.3",
-                "runningLocally": true
+                "currentInstance": true
               }
             ],
             "Processes": [

--- a/test/fixtures/discovery/sap_system/expected_published_sap_system_discovery_database.json
+++ b/test/fixtures/discovery/sap_system/expected_published_sap_system_discovery_database.json
@@ -41,7 +41,8 @@
                 "httpsPort": 50014,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 0,
-                "startPriority": "0.3"
+                "startPriority": "0.3",
+                "runningLocally": true
               }
             ],
             "Processes": [

--- a/test/fixtures/discovery/sap_system/expected_published_sap_system_discovery_diagnostics.json
+++ b/test/fixtures/discovery/sap_system/expected_published_sap_system_discovery_diagnostics.json
@@ -22,7 +22,8 @@
                 "httpPort": 59813,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 98,
-                "startPriority": "3"
+                "startPriority": "3",
+                "runningLocally": true
               }
             ],
             "Processes": [

--- a/test/fixtures/discovery/sap_system/expected_published_sap_system_discovery_diagnostics.json
+++ b/test/fixtures/discovery/sap_system/expected_published_sap_system_discovery_diagnostics.json
@@ -23,7 +23,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 98,
                 "startPriority": "3",
-                "runningLocally": true
+                "currentInstance": true
               }
             ],
             "Processes": [

--- a/test/fixtures/discovery/sap_system/sap_system_discovery_application.json
+++ b/test/fixtures/discovery/sap_system/sap_system_discovery_application.json
@@ -53,7 +53,7 @@
               "dispstatus": "SAPControl-GREEN",
               "instanceNr": 0,
               "startPriority": "1",
-              "runningLocally": false
+              "currentInstance": false
             },
             {
               "features": "ENQREP",
@@ -63,7 +63,7 @@
               "dispstatus": "SAPControl-GREEN",
               "instanceNr": 10,
               "startPriority": "0.5",
-              "runningLocally": false
+              "currentInstance": false
             },
             {
               "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -73,7 +73,7 @@
               "dispstatus": "SAPControl-GREEN",
               "instanceNr": 1,
               "startPriority": "3",
-              "runningLocally": false
+              "currentInstance": false
             },
             {
               "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -83,7 +83,7 @@
               "dispstatus": "SAPControl-GREEN",
               "instanceNr": 2,
               "startPriority": "3",
-              "runningLocally": true
+              "currentInstance": true
             }
           ],
           "Processes": [

--- a/test/fixtures/discovery/sap_system/sap_system_discovery_application.json
+++ b/test/fixtures/discovery/sap_system/sap_system_discovery_application.json
@@ -52,7 +52,8 @@
               "httpsPort": 50014,
               "dispstatus": "SAPControl-GREEN",
               "instanceNr": 0,
-              "startPriority": "1"
+              "startPriority": "1",
+              "runningLocally": false
             },
             {
               "features": "ENQREP",
@@ -61,7 +62,8 @@
               "httpsPort": 51014,
               "dispstatus": "SAPControl-GREEN",
               "instanceNr": 10,
-              "startPriority": "0.5"
+              "startPriority": "0.5",
+              "runningLocally": false
             },
             {
               "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -70,7 +72,8 @@
               "httpsPort": 50114,
               "dispstatus": "SAPControl-GREEN",
               "instanceNr": 1,
-              "startPriority": "3"
+              "startPriority": "3",
+              "runningLocally": false
             },
             {
               "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -79,7 +82,8 @@
               "httpsPort": 50214,
               "dispstatus": "SAPControl-GREEN",
               "instanceNr": 2,
-              "startPriority": "3"
+              "startPriority": "3",
+              "runningLocally": true
             }
           ],
           "Processes": [

--- a/test/fixtures/discovery/sap_system/sap_system_discovery_database.json
+++ b/test/fixtures/discovery/sap_system/sap_system_discovery_database.json
@@ -39,7 +39,7 @@
               "dispstatus": "SAPControl-GREEN",
               "instanceNr": 0,
               "startPriority": "0.3",
-              "runningLocally": true
+              "currentInstance": true
             }
           ],
           "Processes": [

--- a/test/fixtures/discovery/sap_system/sap_system_discovery_database.json
+++ b/test/fixtures/discovery/sap_system/sap_system_discovery_database.json
@@ -38,7 +38,8 @@
               "httpsPort": 50014,
               "dispstatus": "SAPControl-GREEN",
               "instanceNr": 0,
-              "startPriority": "0.3"
+              "startPriority": "0.3",
+              "runningLocally": true
             }
           ],
           "Processes": [

--- a/test/fixtures/discovery/sap_system/sap_system_discovery_diagnostics.json
+++ b/test/fixtures/discovery/sap_system/sap_system_discovery_diagnostics.json
@@ -20,7 +20,7 @@
               "dispstatus": "SAPControl-GREEN",
               "instanceNr": 98,
               "startPriority": "3",
-              "runningLocally": true
+              "currentInstance": true
             }
           ],
           "Processes": [

--- a/test/fixtures/discovery/sap_system/sap_system_discovery_diagnostics.json
+++ b/test/fixtures/discovery/sap_system/sap_system_discovery_diagnostics.json
@@ -19,7 +19,8 @@
               "httpPort": 59813,
               "dispstatus": "SAPControl-GREEN",
               "instanceNr": 98,
-              "startPriority": "3"
+              "startPriority": "3",
+              "runningLocally": true
             }
           ],
           "Processes": [


### PR DESCRIPTION
# Description

When we query the current installed SAP system instances using `sapcontrol`, we cannot be 100% of which of them is the one currently running if the virtual hostname are duplicated.
Until now we did this identification in web: https://github.com/trento-project/web/blob/main/lib/trento/discovery/payloads/sap_system_discovery_payload.ex#L269

It is based on checking the instance number and saplocalhost values from the current profile with the values in the sapcontrol instances list. But if the hostnames are duplicated, we were simply returning the first catch.

A customer came with a scenario like that, where 2 ERS instances have the same virtual hostname. 

Now, we will check this in the agent using some local files that SAP creates during one of its binaries execution, where the content says clearly in which real host this SAP instance is running.

Here some references about the implementation: https://m1bc.home.blog/2019/09/09/getsysteminstancelist-duplicate-entries/

PD: I'm still not 100% sure about the `runningLocally` field name. This field is used to determine if the entry in the sapcontrol instances list is the currently discovered instance. Maybe `runningLocally` is missleading, because the instance could be running locally in this machine but not be the current instance. Maybe I will rename to `currentInstance` or something else

## How was this tested?
UT and manual testing
