### PR TITLE
Discover tenant

### DIFF
--- a/internal/core/sapsystem/sapsystem.go
+++ b/internal/core/sapsystem/sapsystem.go
@@ -442,7 +442,7 @@ func getUniqueIDDiagnostics(fs afero.Fs) (string, error) {
 }
 
 func getTenant(sid string, profile map[string]string, executor utils.CommandExecutor) (string, error) {
-	var ssfsEnabled bool = false
+	var ssfsEnabled = false
 	user := fmt.Sprintf("%sadm", strings.ToLower(sid))
 
 	ssfsConnect, found := profile["rsdb/ssfs_connect"]

--- a/internal/core/sapsystem/sapsystem_test.go
+++ b/internal/core/sapsystem/sapsystem_test.go
@@ -19,6 +19,8 @@ import (
 	"github.com/trento-project/agent/test/helpers"
 )
 
+const sappfparCmd string = "sappfpar SAPSYSTEMNAME SAPGLOBALHOST SAPFQDN SAPDBHOST dbs/hdb/dbname dbs/hdb/schema rdisp/msp/msserv rdisp/msserv_internal name=DEV"
+
 type SAPSystemTestSuite struct {
 	suite.Suite
 }
@@ -216,7 +218,6 @@ func (suite *SAPSystemTestSuite) TestNewSAPSystem() {
 		"vmcj/enable":                                  "off",
 	}
 
-	sappfparCmd := "sappfpar SAPSYSTEMNAME SAPGLOBALHOST SAPFQDN SAPDBHOST dbs/hdb/dbname dbs/hdb/schema rdisp/msp/msserv rdisp/msserv_internal name=DEV"
 	mockCommand.On("Exec", "su", "-lc", sappfparCmd, "devadm").Return(mockSappfpar(), nil)
 
 	system, err := sapsystem.NewSAPSystem(ctx, appFS, mockCommand, mockWebServiceConnector, "/usr/sap/DEV")
@@ -253,7 +254,6 @@ OS-User      : devadm
 	suite.NoError(err)
 
 	mockWebServiceConnector.On("New", "01").Return(fakeNewWebService("HDB00", "MESSAGESERVER|ENQUE"))
-	sappfparCmd := "sappfpar SAPSYSTEMNAME SAPGLOBALHOST SAPFQDN SAPDBHOST dbs/hdb/dbname dbs/hdb/schema rdisp/msp/msserv rdisp/msserv_internal name=DEV"
 	mockCommand.
 		On("Exec", "su", "-lc", sappfparCmd, "devadm").Return(mockSappfpar(), nil).
 		On("Exec", "su", "-lc", "rsecssfx get DB_CONNECT/DEFAULT_DB_CON_ENV", "devadm").Return(rsecssfxOutput, nil)
@@ -299,7 +299,6 @@ not_found = 0
 		suite.NoError(err)
 
 		mockWebServiceConnector.On("New", "01").Return(fakeNewWebService("HDB00", "MESSAGESERVER|ENQUE"))
-		sappfparCmd := "sappfpar SAPSYSTEMNAME SAPGLOBALHOST SAPFQDN SAPDBHOST dbs/hdb/dbname dbs/hdb/schema rdisp/msp/msserv rdisp/msserv_internal name=DEV"
 		mockCommand.
 			On("Exec", "su", "-lc", sappfparCmd, "devadm").Return(mockSappfpar(), nil).
 			On("Exec", "su", "-lc", "hdbuserstore list DEFAULT", "devadm").Return(hdbuserStoreOutput, nil)
@@ -364,7 +363,6 @@ rsdb/ssfs_connect = 1
 		suite.NoError(err)
 
 		mockWebServiceConnector.On("New", "01").Return(fakeNewWebService("HDB00", "MESSAGESERVER|ENQUE"))
-		sappfparCmd := "sappfpar SAPSYSTEMNAME SAPGLOBALHOST SAPFQDN SAPDBHOST dbs/hdb/dbname dbs/hdb/schema rdisp/msp/msserv rdisp/msserv_internal name=DEV"
 		mockCommand.
 			On("Exec", "su", "-lc", sappfparCmd, "devadm").Return(mockSappfpar(), nil).
 			On("Exec", "su", "-lc", tt.command, "devadm").Return(malformedOutput, tt.commandOutputErr)
@@ -433,7 +431,6 @@ func (suite *SAPSystemTestSuite) TestDetectSystemId_Application() {
 	mockWebServiceConnector := new(sapControlMocks.WebServiceConnector)
 
 	mockWebServiceConnector.On("New", "01").Return(fakeNewWebService("HDB00", "MESSAGESERVER|ENQUE"))
-	sappfparCmd := "sappfpar SAPSYSTEMNAME SAPGLOBALHOST SAPFQDN SAPDBHOST dbs/hdb/dbname dbs/hdb/schema rdisp/msp/msserv rdisp/msserv_internal name=DEV"
 	mockCommand.
 		On("Exec", "su", "-lc", sappfparCmd, "devadm").Return(mockSappfpar(), nil).
 		On("Exec", "su", "-lc", "hdbuserstore list DEFAULT", "devadm").Return([]byte("DATABASE: tenant"), nil)

--- a/test/fixtures/discovery/sap_system/expected_published_sap_system_discovery_application.json
+++ b/test/fixtures/discovery/sap_system/expected_published_sap_system_discovery_application.json
@@ -7,6 +7,7 @@
       "SID": "HA1",
       "Type": 2,
       "DBAddress": "10.74.1.12",
+      "Tenant": "PRD",
       "Profile": {
         "SAPDBHOST": "10.74.1.12",
         "gw/acl_mode": "1",

--- a/test/fixtures/discovery/sap_system/expected_published_sap_system_discovery_database.json
+++ b/test/fixtures/discovery/sap_system/expected_published_sap_system_discovery_database.json
@@ -7,6 +7,7 @@
       "SID": "PRD",
       "Type": 1,
       "DBAddress": "",
+      "Tenant": "",
       "Profile": {
         "SAPGLOBALHOST": "vmhana01",
         "SAPSYSTEMNAME": "PRD",

--- a/test/fixtures/discovery/sap_system/expected_published_sap_system_discovery_diagnostics.json
+++ b/test/fixtures/discovery/sap_system/expected_published_sap_system_discovery_diagnostics.json
@@ -7,6 +7,7 @@
       "SID": "DAA",
       "Type": 3,
       "DBAddress": "",
+      "Tenant": "",
       "Profile": {},
       "Databases": null,
       "Instances": [

--- a/test/fixtures/discovery/sap_system/sap_system_discovery_application.json
+++ b/test/fixtures/discovery/sap_system/sap_system_discovery_application.json
@@ -4,6 +4,7 @@
     "SID": "HA1",
     "Type": 2,
     "DBAddress": "10.74.1.12",
+    "Tenant": "PRD",
     "Profile": {
       "SAPDBHOST": "10.74.1.12",
       "gw/acl_mode": "1",

--- a/test/fixtures/discovery/sap_system/sap_system_discovery_database.json
+++ b/test/fixtures/discovery/sap_system/sap_system_discovery_database.json
@@ -4,6 +4,7 @@
     "SID": "PRD",
     "Type": 1,
     "DBAddress": "",
+    "Tenant": "",
     "Profile": {
       "SAPGLOBALHOST": "vmhana01",
       "SAPSYSTEMNAME": "PRD",

--- a/test/fixtures/discovery/sap_system/sap_system_discovery_diagnostics.json
+++ b/test/fixtures/discovery/sap_system/sap_system_discovery_diagnostics.json
@@ -4,6 +4,7 @@
     "SID": "DAA",
     "Type": 3,
     "DBAddress": "",
+    "Tenant": "",
     "Profile": {},
     "Databases": null,
     "Instances": [


### PR DESCRIPTION
# Description

Discover the SAP system tenant using `hdbuserstore` or `ssfs` storage.
Until now, the truth of source for the tenant has been the `dbs/hdb/dbname` entry in the profile file.
It turned out that this file is not mandatory to have. 

This PR replaces the discovery of the `tenant` field using different methods. The `Tenant` is sent in a explicit field so web is able to parse it.

Based on the `rsdb/ssfs_connect` entry in the profile.
- If `0` or not existing. The tenant is obtained running the `hdbuserstore list DEFAULT` command
- If `1`. The tenant is obtained running `rsecssfx` command

The `Tenant` field can be an empty string as well, as the tenant value is not known in all SAP instances. Only application server instances like ABAP or JAVA have this information.

## How was this tested?
UT and manual testing
