### PR TITLE
Use absolute command paths

### DIFF
--- a/internal/core/cloud/metadata.go
+++ b/internal/core/cloud/metadata.go
@@ -42,7 +42,7 @@ func NewIdentifier(executor utils.CommandExecutor) *Identifier {
 
 func (i *Identifier) identifyAzure() (bool, error) {
 	log.Debug("Checking if the system is running on Azure...")
-	output, err := i.executor.Exec("dmidecode", "-s", "chassis-asset-tag")
+	output, err := i.executor.Exec("/usr/sbin/dmidecode", "-s", "chassis-asset-tag")
 	if err != nil {
 		return false, err
 	}
@@ -55,7 +55,7 @@ func (i *Identifier) identifyAzure() (bool, error) {
 
 func (i *Identifier) identifyAWS() (bool, error) {
 	log.Debug("Checking if the system is running on Aws...")
-	systemVersion, err := i.executor.Exec("dmidecode", "-s", "system-version")
+	systemVersion, err := i.executor.Exec("/usr/sbin/dmidecode", "-s", "system-version")
 	if err != nil {
 		return false, err
 	}
@@ -68,7 +68,7 @@ func (i *Identifier) identifyAWS() (bool, error) {
 		return result, nil
 	}
 
-	systemManufacturer, err := i.executor.Exec("dmidecode", "-s", "system-manufacturer")
+	systemManufacturer, err := i.executor.Exec("/usr/sbin/dmidecode", "-s", "system-manufacturer")
 	if err != nil {
 		return false, err
 	}
@@ -83,7 +83,7 @@ func (i *Identifier) identifyAWS() (bool, error) {
 
 func (i *Identifier) identifyGCP() (bool, error) {
 	log.Debug("Checking if the system is running on Gcp...")
-	output, err := i.executor.Exec("dmidecode", "-s", "bios-vendor")
+	output, err := i.executor.Exec("/usr/sbin/dmidecode", "-s", "bios-vendor")
 	if err != nil {
 		return false, err
 	}
@@ -96,7 +96,7 @@ func (i *Identifier) identifyGCP() (bool, error) {
 
 func (i *Identifier) identifyNutanix() (bool, error) {
 	log.Debug("Checking if the system is running on Nutanix...")
-	output, err := i.executor.Exec("dmidecode")
+	output, err := i.executor.Exec("/usr/sbin/dmidecode")
 	if err != nil {
 		return false, err
 	}
@@ -109,7 +109,7 @@ func (i *Identifier) identifyNutanix() (bool, error) {
 
 func (i *Identifier) identifyKVM() (bool, error) {
 	log.Debug("Checking if the system is running under KVM...")
-	output, err := i.executor.Exec("systemd-detect-virt")
+	output, err := i.executor.Exec("/usr/bin/systemd-detect-virt")
 	if err != nil {
 		return false, err
 	}
@@ -122,7 +122,7 @@ func (i *Identifier) identifyKVM() (bool, error) {
 
 func (i *Identifier) identifyVMware() (bool, error) {
 	log.Debug("Checking if the system is running under VMware...")
-	output, err := i.executor.Exec("systemd-detect-virt")
+	output, err := i.executor.Exec("/usr/bin/systemd-detect-virt")
 	if err != nil {
 		return false, err
 	}

--- a/internal/core/cloud/metadata_test.go
+++ b/internal/core/cloud/metadata_test.go
@@ -73,7 +73,7 @@ func dmidecodeEmpty() []byte {
 
 func (suite *CloudMetadataTestSuite) TestIdentifyCloudProviderErr() {
 	suite.mockExecutor.
-		On("Exec", "dmidecode", "-s", "chassis-asset-tag").
+		On("Exec", "/usr/sbin/dmidecode", "-s", "chassis-asset-tag").
 		Return(nil, errors.New("error"))
 
 	cIdentifier := cloud.NewIdentifier(suite.mockExecutor)
@@ -86,7 +86,7 @@ func (suite *CloudMetadataTestSuite) TestIdentifyCloudProviderErr() {
 
 func (suite *CloudMetadataTestSuite) TestIdentifyCloudProviderAzure() {
 	suite.mockExecutor.
-		On("Exec", "dmidecode", "-s", "chassis-asset-tag").
+		On("Exec", "/usr/sbin/dmidecode", "-s", "chassis-asset-tag").
 		Return(dmidecodeAzure(), nil)
 
 	cIdentifier := cloud.NewIdentifier(suite.mockExecutor)
@@ -99,9 +99,9 @@ func (suite *CloudMetadataTestSuite) TestIdentifyCloudProviderAzure() {
 
 func (suite *CloudMetadataTestSuite) TestIdentifyCloudProviderAWSUsingSystemVersion() {
 	suite.mockExecutor.
-		On("Exec", "dmidecode", "-s", "chassis-asset-tag").
+		On("Exec", "/usr/sbin/dmidecode", "-s", "chassis-asset-tag").
 		Return(dmidecodeEmpty(), nil).
-		On("Exec", "dmidecode", "-s", "system-version").
+		On("Exec", "/usr/sbin/dmidecode", "-s", "system-version").
 		Return(dmidecodeAWSSystem(), nil)
 
 	cIdentifier := cloud.NewIdentifier(suite.mockExecutor)
@@ -114,11 +114,11 @@ func (suite *CloudMetadataTestSuite) TestIdentifyCloudProviderAWSUsingSystemVers
 
 func (suite *CloudMetadataTestSuite) TestIdentifyCloudProviderAWSUsingManufacturer() {
 	suite.mockExecutor.
-		On("Exec", "dmidecode", "-s", "chassis-asset-tag").
+		On("Exec", "/usr/sbin/dmidecode", "-s", "chassis-asset-tag").
 		Return(dmidecodeEmpty(), nil).
-		On("Exec", "dmidecode", "-s", "system-version").
+		On("Exec", "/usr/sbin/dmidecode", "-s", "system-version").
 		Return(dmidecodeEmpty(), nil).
-		On("Exec", "dmidecode", "-s", "system-manufacturer").
+		On("Exec", "/usr/sbin/dmidecode", "-s", "system-manufacturer").
 		Return(dmidecodeAWSManufacturer(), nil)
 
 	cIdentifier := cloud.NewIdentifier(suite.mockExecutor)
@@ -131,13 +131,13 @@ func (suite *CloudMetadataTestSuite) TestIdentifyCloudProviderAWSUsingManufactur
 
 func (suite *CloudMetadataTestSuite) TestIdentifyCloudProviderGCP() {
 	suite.mockExecutor.
-		On("Exec", "dmidecode", "-s", "chassis-asset-tag").
+		On("Exec", "/usr/sbin/dmidecode", "-s", "chassis-asset-tag").
 		Return(dmidecodeEmpty(), nil).
-		On("Exec", "dmidecode", "-s", "system-version").
+		On("Exec", "/usr/sbin/dmidecode", "-s", "system-version").
 		Return(dmidecodeEmpty(), nil).
-		On("Exec", "dmidecode", "-s", "system-manufacturer").
+		On("Exec", "/usr/sbin/dmidecode", "-s", "system-manufacturer").
 		Return(dmidecodeEmpty(), nil).
-		On("Exec", "dmidecode", "-s", "bios-vendor").
+		On("Exec", "/usr/sbin/dmidecode", "-s", "bios-vendor").
 		Return(dmidecodeGCP(), nil)
 
 	cIdentifier := cloud.NewIdentifier(suite.mockExecutor)
@@ -150,15 +150,15 @@ func (suite *CloudMetadataTestSuite) TestIdentifyCloudProviderGCP() {
 
 func (suite *CloudMetadataTestSuite) TestIdentifyProviderNutanix() {
 	suite.mockExecutor.
-		On("Exec", "dmidecode", "-s", "chassis-asset-tag").
+		On("Exec", "/usr/sbin/dmidecode", "-s", "chassis-asset-tag").
 		Return(dmidecodeEmpty(), nil).
-		On("Exec", "dmidecode", "-s", "system-version").
+		On("Exec", "/usr/sbin/dmidecode", "-s", "system-version").
 		Return(dmidecodeEmpty(), nil).
-		On("Exec", "dmidecode", "-s", "system-manufacturer").
+		On("Exec", "/usr/sbin/dmidecode", "-s", "system-manufacturer").
 		Return(dmidecodeEmpty(), nil).
-		On("Exec", "dmidecode", "-s", "bios-vendor").
+		On("Exec", "/usr/sbin/dmidecode", "-s", "bios-vendor").
 		Return(dmidecodeEmpty(), nil).
-		On("Exec", "dmidecode").
+		On("Exec", "/usr/sbin/dmidecode").
 		Return(dmidecodeNutanix(), nil)
 
 	cIdentifier := cloud.NewIdentifier(suite.mockExecutor)
@@ -171,17 +171,17 @@ func (suite *CloudMetadataTestSuite) TestIdentifyProviderNutanix() {
 
 func (suite *CloudMetadataTestSuite) TestIdentifyProviderKVM() {
 	suite.mockExecutor.
-		On("Exec", "dmidecode", "-s", "chassis-asset-tag").
+		On("Exec", "/usr/sbin/dmidecode", "-s", "chassis-asset-tag").
 		Return(dmidecodeEmpty(), nil).
-		On("Exec", "dmidecode", "-s", "system-version").
+		On("Exec", "/usr/sbin/dmidecode", "-s", "system-version").
 		Return(dmidecodeEmpty(), nil).
-		On("Exec", "dmidecode", "-s", "system-manufacturer").
+		On("Exec", "/usr/sbin/dmidecode", "-s", "system-manufacturer").
 		Return(dmidecodeEmpty(), nil).
-		On("Exec", "dmidecode", "-s", "bios-vendor").
+		On("Exec", "/usr/sbin/dmidecode", "-s", "bios-vendor").
 		Return(dmidecodeEmpty(), nil).
-		On("Exec", "dmidecode").
+		On("Exec", "/usr/sbin/dmidecode").
 		Return(dmidecodeEmpty(), nil).
-		On("Exec", "systemd-detect-virt").
+		On("Exec", "/usr/bin/systemd-detect-virt").
 		Return(systemdDetectVirtKVM(), nil)
 
 	cIdentifier := cloud.NewIdentifier(suite.mockExecutor)
@@ -194,17 +194,17 @@ func (suite *CloudMetadataTestSuite) TestIdentifyProviderKVM() {
 
 func (suite *CloudMetadataTestSuite) TestIdentifyProviderVmware() {
 	suite.mockExecutor.
-		On("Exec", "dmidecode", "-s", "chassis-asset-tag").
+		On("Exec", "/usr/sbin/dmidecode", "-s", "chassis-asset-tag").
 		Return(dmidecodeEmpty(), nil).
-		On("Exec", "dmidecode", "-s", "system-version").
+		On("Exec", "/usr/sbin/dmidecode", "-s", "system-version").
 		Return(dmidecodeEmpty(), nil).
-		On("Exec", "dmidecode", "-s", "system-manufacturer").
+		On("Exec", "/usr/sbin/dmidecode", "-s", "system-manufacturer").
 		Return(dmidecodeEmpty(), nil).
-		On("Exec", "dmidecode", "-s", "bios-vendor").
+		On("Exec", "/usr/sbin/dmidecode", "-s", "bios-vendor").
 		Return(dmidecodeEmpty(), nil).
-		On("Exec", "dmidecode").
+		On("Exec", "/usr/sbin/dmidecode").
 		Return(dmidecodeEmpty(), nil).
-		On("Exec", "systemd-detect-virt").
+		On("Exec", "/usr/bin/systemd-detect-virt").
 		Return(systemdDetectVirtVmware(), nil)
 
 	cIdentifier := cloud.NewIdentifier(suite.mockExecutor)
@@ -217,17 +217,17 @@ func (suite *CloudMetadataTestSuite) TestIdentifyProviderVmware() {
 
 func (suite *CloudMetadataTestSuite) TestIdentifyCloudProviderNoCloud() {
 	suite.mockExecutor.
-		On("Exec", "dmidecode", "-s", "chassis-asset-tag").
+		On("Exec", "/usr/sbin/dmidecode", "-s", "chassis-asset-tag").
 		Return(dmidecodeEmpty(), nil).
-		On("Exec", "dmidecode", "-s", "system-version").
+		On("Exec", "/usr/sbin/dmidecode", "-s", "system-version").
 		Return(dmidecodeEmpty(), nil).
-		On("Exec", "dmidecode", "-s", "system-manufacturer").
+		On("Exec", "/usr/sbin/dmidecode", "-s", "system-manufacturer").
 		Return(dmidecodeEmpty(), nil).
-		On("Exec", "dmidecode", "-s", "bios-vendor").
+		On("Exec", "/usr/sbin/dmidecode", "-s", "bios-vendor").
 		Return(dmidecodeEmpty(), nil).
-		On("Exec", "dmidecode").
+		On("Exec", "/usr/sbin/dmidecode").
 		Return(dmidecodeEmpty(), nil).
-		On("Exec", "systemd-detect-virt").
+		On("Exec", "/usr/bin/systemd-detect-virt").
 		Return(systemdDetectVirtEmpty(), nil)
 
 	cIdentifier := cloud.NewIdentifier(suite.mockExecutor)
@@ -242,7 +242,7 @@ func (suite *CloudMetadataTestSuite) TestNewCloudInstanceAzure() {
 	ctx := context.TODO()
 
 	suite.mockExecutor.
-		On("Exec", "dmidecode", "-s", "chassis-asset-tag").
+		On("Exec", "/usr/sbin/dmidecode", "-s", "chassis-asset-tag").
 		Return(dmidecodeAzure(), nil)
 
 	body := io.NopCloser(bytes.NewReader([]byte(`{"compute":{"name":"test"}}`)))
@@ -268,9 +268,9 @@ func (suite *CloudMetadataTestSuite) TestNewCloudInstanceAzure() {
 func (suite *CloudMetadataTestSuite) TestNewCloudInstanceAWS() {
 	ctx := context.TODO()
 	suite.mockExecutor.
-		On("Exec", "dmidecode", "-s", "chassis-asset-tag").
+		On("Exec", "/usr/sbin/dmidecode", "-s", "chassis-asset-tag").
 		Return(dmidecodeEmpty(), nil).
-		On("Exec", "dmidecode", "-s", "system-version").
+		On("Exec", "/usr/sbin/dmidecode", "-s", "system-version").
 		Return(dmidecodeAWSSystem(), nil)
 
 	tokenResponseBody := io.NopCloser(bytes.NewReader([]byte("token")))
@@ -314,9 +314,9 @@ func (suite *CloudMetadataTestSuite) TestNewCloudInstanceAWS() {
 func (suite *CloudMetadataTestSuite) TestNewAWSCloudInstanceWithoutMetadata() {
 	ctx := context.TODO()
 	suite.mockExecutor.
-		On("Exec", "dmidecode", "-s", "chassis-asset-tag").
+		On("Exec", "/usr/sbin/dmidecode", "-s", "chassis-asset-tag").
 		Return(dmidecodeEmpty(), nil).
-		On("Exec", "dmidecode", "-s", "system-version").
+		On("Exec", "/usr/sbin/dmidecode", "-s", "system-version").
 		Return(dmidecodeAWSSystem(), nil)
 
 	disabledIMDSResponse := &http.Response{
@@ -339,15 +339,15 @@ func (suite *CloudMetadataTestSuite) TestNewAWSCloudInstanceWithoutMetadata() {
 func (suite *CloudMetadataTestSuite) TestNewInstanceNutanix() {
 	ctx := context.TODO()
 	suite.mockExecutor.
-		On("Exec", "dmidecode", "-s", "chassis-asset-tag").
+		On("Exec", "/usr/sbin/dmidecode", "-s", "chassis-asset-tag").
 		Return(dmidecodeEmpty(), nil).
-		On("Exec", "dmidecode", "-s", "system-version").
+		On("Exec", "/usr/sbin/dmidecode", "-s", "system-version").
 		Return(dmidecodeEmpty(), nil).
-		On("Exec", "dmidecode", "-s", "system-manufacturer").
+		On("Exec", "/usr/sbin/dmidecode", "-s", "system-manufacturer").
 		Return(dmidecodeEmpty(), nil).
-		On("Exec", "dmidecode", "-s", "bios-vendor").
+		On("Exec", "/usr/sbin/dmidecode", "-s", "bios-vendor").
 		Return(dmidecodeEmpty(), nil).
-		On("Exec", "dmidecode").
+		On("Exec", "/usr/sbin/dmidecode").
 		Return(dmidecodeNutanix(), nil)
 
 	c, err := cloud.NewCloudInstance(ctx, suite.mockExecutor, suite.mockHTTPClient)
@@ -361,17 +361,17 @@ func (suite *CloudMetadataTestSuite) TestNewInstanceNutanix() {
 func (suite *CloudMetadataTestSuite) TestNewInstanceKVM() {
 	ctx := context.TODO()
 	suite.mockExecutor.
-		On("Exec", "dmidecode", "-s", "chassis-asset-tag").
+		On("Exec", "/usr/sbin/dmidecode", "-s", "chassis-asset-tag").
 		Return(dmidecodeEmpty(), nil).
-		On("Exec", "dmidecode", "-s", "system-version").
+		On("Exec", "/usr/sbin/dmidecode", "-s", "system-version").
 		Return(dmidecodeEmpty(), nil).
-		On("Exec", "dmidecode", "-s", "system-manufacturer").
+		On("Exec", "/usr/sbin/dmidecode", "-s", "system-manufacturer").
 		Return(dmidecodeEmpty(), nil).
-		On("Exec", "dmidecode", "-s", "bios-vendor").
+		On("Exec", "/usr/sbin/dmidecode", "-s", "bios-vendor").
 		Return(dmidecodeEmpty(), nil).
-		On("Exec", "dmidecode").
+		On("Exec", "/usr/sbin/dmidecode").
 		Return(dmidecodeEmpty(), nil).
-		On("Exec", "systemd-detect-virt").
+		On("Exec", "/usr/bin/systemd-detect-virt").
 		Return(systemdDetectVirtKVM(), nil)
 
 	c, err := cloud.NewCloudInstance(ctx, suite.mockExecutor, suite.mockHTTPClient)
@@ -385,17 +385,17 @@ func (suite *CloudMetadataTestSuite) TestNewInstanceKVM() {
 func (suite *CloudMetadataTestSuite) TestNewCloudInstanceNoCloud() {
 	ctx := context.TODO()
 	suite.mockExecutor.
-		On("Exec", "dmidecode", "-s", "chassis-asset-tag").
+		On("Exec", "/usr/sbin/dmidecode", "-s", "chassis-asset-tag").
 		Return(dmidecodeEmpty(), nil).
-		On("Exec", "dmidecode", "-s", "system-version").
+		On("Exec", "/usr/sbin/dmidecode", "-s", "system-version").
 		Return(dmidecodeEmpty(), nil).
-		On("Exec", "dmidecode", "-s", "system-manufacturer").
+		On("Exec", "/usr/sbin/dmidecode", "-s", "system-manufacturer").
 		Return(dmidecodeEmpty(), nil).
-		On("Exec", "dmidecode", "-s", "bios-vendor").
+		On("Exec", "/usr/sbin/dmidecode", "-s", "bios-vendor").
 		Return(dmidecodeEmpty(), nil).
-		On("Exec", "dmidecode").
+		On("Exec", "/usr/sbin/dmidecode").
 		Return(dmidecodeEmpty(), nil).
-		On("Exec", "systemd-detect-virt").
+		On("Exec", "/usr/bin/systemd-detect-virt").
 		Return(systemdDetectVirtEmpty(), nil)
 
 	c, err := cloud.NewCloudInstance(ctx, suite.mockExecutor, suite.mockHTTPClient)

--- a/internal/core/cluster/cluster_test.go
+++ b/internal/core/cluster/cluster_test.go
@@ -23,7 +23,7 @@ func TestClusterTestSuite(t *testing.T) {
 
 func (suite *ClusterTestSuite) TestNewClusterWithDiscoveryTools() {
 	mockCommand := new(mocks.CommandExecutor)
-	mockCommand.On("Exec", "dmidecode", "-s", "chassis-asset-tag").
+	mockCommand.On("Exec", "/usr/sbin/dmidecode", "-s", "chassis-asset-tag").
 		Return([]byte("7783-7084-3265-9085-8269-3286-77"), nil)
 	mockCommand.On("Exec", "/usr/sbin/sbd", "-d", "/dev/vdb", "dump").Return(mockSbdDump(), nil)
 	mockCommand.On("Exec", "/usr/sbin/sbd", "-d", "/dev/vdb", "list").Return(mockSbdList(), nil)
@@ -49,7 +49,7 @@ func (suite *ClusterTestSuite) TestNewClusterWithDiscoveryTools() {
 
 func (suite *ClusterTestSuite) TestNewClusterDisklessSBD() {
 	mockCommand := new(mocks.CommandExecutor)
-	mockCommand.On("Exec", "dmidecode", "-s", "chassis-asset-tag").
+	mockCommand.On("Exec", "/usr/sbin/dmidecode", "-s", "chassis-asset-tag").
 		Return([]byte("7783-7084-3265-9085-8269-3286-77"), nil)
 
 	c, err := cluster.NewClusterWithDiscoveryTools(&cluster.DiscoveryTools{

--- a/internal/core/sapsystem/sapinstance.go
+++ b/internal/core/sapsystem/sapinstance.go
@@ -115,7 +115,7 @@ func runPythonSupport(executor utils.CommandExecutor, sid, instance, script stri
 	cmdPath := path.Join(sapInstallationPath, sid, instance, "exe/python_support", script)
 	cmd := fmt.Sprintf("python %s --sapcontrol=1", cmdPath)
 	// Even with a error return code, some data is available
-	srData, err := executor.Exec("su", "-lc", cmd, user)
+	srData, err := executor.Exec("/usr/bin/su", "-lc", cmd, user)
 	if err != nil {
 		log.Warn(errors.Wrap(err, "Error running python_support command"))
 	}
@@ -136,7 +136,7 @@ func hdbnsutilSrstate(executor utils.CommandExecutor, sid, instance string) map[
 	user := fmt.Sprintf("%sadm", strings.ToLower(sid))
 	cmdPath := path.Join(sapInstallationPath, sid, instance, "exe", "hdbnsutil")
 	cmd := fmt.Sprintf("%s -sr_state -sapcontrol=1", cmdPath)
-	srData, err := executor.Exec("su", "-lc", cmd, user)
+	srData, err := executor.Exec("/usr/bin/su", "-lc", cmd, user)
 	if err != nil {
 		log.Warn(errors.Wrap(err, "Error running hdbnsutil command"))
 	}

--- a/internal/core/sapsystem/sapsystem.go
+++ b/internal/core/sapsystem/sapsystem.go
@@ -403,7 +403,7 @@ func getUniqueIDHana(fs afero.Fs, sid string) (string, error) {
 func getUniqueIDApplication(executor utils.CommandExecutor, sid string) (string, error) {
 	user := fmt.Sprintf("%sadm", strings.ToLower(sid))
 	cmd := fmt.Sprintf(sappfparCmd, sid)
-	sappfpar, err := executor.Exec("su", "-lc", cmd, user)
+	sappfpar, err := executor.Exec("/usr/bin/su", "-lc", cmd, user)
 	if err != nil {
 		return "", fmt.Errorf("error running sappfpar command with sid %s", sid)
 	}

--- a/internal/core/sapsystem/sapsystem_test.go
+++ b/internal/core/sapsystem/sapsystem_test.go
@@ -217,7 +217,7 @@ func (suite *SAPSystemTestSuite) TestNewSAPSystem() {
 	}
 
 	sappfparCmd := "sappfpar SAPSYSTEMNAME SAPGLOBALHOST SAPFQDN SAPDBHOST dbs/hdb/dbname dbs/hdb/schema rdisp/msp/msserv rdisp/msserv_internal name=DEV"
-	mockCommand.On("Exec", "su", "-lc", sappfparCmd, "devadm").Return(mockSappfpar(), nil)
+	mockCommand.On("Exec", "/usr/bin/su", "-lc", sappfparCmd, "devadm").Return(mockSappfpar(), nil)
 
 	system, err := sapsystem.NewSAPSystem(ctx, appFS, mockCommand, mockWebServiceConnector, "/usr/sap/DEV")
 
@@ -260,11 +260,11 @@ key2 = value2
 
 	mockWebServiceConnector.On("New", "01").Return(fakeNewWebService("HDB00", "HDB"))
 	mockCommand.
-		On("Exec", "su", "-lc", "python /usr/sap/DEV/HDB00/exe/python_support/systemReplicationStatus.py --sapcontrol=1", "devadm").
+		On("Exec", "/usr/bin/su", "-lc", "python /usr/sap/DEV/HDB00/exe/python_support/systemReplicationStatus.py --sapcontrol=1", "devadm").
 		Return(mockSystemReplicationStatus(), nil).
-		On("Exec", "su", "-lc", "python /usr/sap/DEV/HDB00/exe/python_support/landscapeHostConfiguration.py --sapcontrol=1", "devadm").
+		On("Exec", "/usr/bin/su", "-lc", "python /usr/sap/DEV/HDB00/exe/python_support/landscapeHostConfiguration.py --sapcontrol=1", "devadm").
 		Return(mockLandscapeHostConfiguration(), nil).
-		On("Exec", "su", "-lc", "/usr/sap/DEV/HDB00/exe/hdbnsutil -sr_state -sapcontrol=1", "devadm").
+		On("Exec", "/usr/bin/su", "-lc", "/usr/sap/DEV/HDB00/exe/hdbnsutil -sr_state -sapcontrol=1", "devadm").
 		Return(mockHdbnsutilSrstate(), nil)
 
 	system, err := sapsystem.NewSAPSystem(ctx, appFS, mockCommand, mockWebServiceConnector, "/usr/sap/DEV")
@@ -283,7 +283,7 @@ func (suite *SAPSystemTestSuite) TestDetectSystemId_Application() {
 
 	mockWebServiceConnector.On("New", "01").Return(fakeNewWebService("HDB00", "MESSAGESERVER|ENQUE"))
 	sappfparCmd := "sappfpar SAPSYSTEMNAME SAPGLOBALHOST SAPFQDN SAPDBHOST dbs/hdb/dbname dbs/hdb/schema rdisp/msp/msserv rdisp/msserv_internal name=DEV"
-	mockCommand.On("Exec", "su", "-lc", sappfparCmd, "devadm").Return(mockSappfpar(), nil)
+	mockCommand.On("Exec", "/usr/bin/su", "-lc", sappfparCmd, "devadm").Return(mockSappfpar(), nil)
 
 	system, err := sapsystem.NewSAPSystem(ctx, appFS, mockCommand, mockWebServiceConnector, "/usr/sap/DEV")
 
@@ -494,15 +494,15 @@ func (suite *SAPSystemTestSuite) TestNewSAPInstanceDatabase() {
 		},
 	}, nil)
 
-	mockCommand.On("Exec", "su", "-lc", "python /usr/sap/PRD/HDB01/exe/python_support/systemReplicationStatus.py --sapcontrol=1", "prdadm").Return(
+	mockCommand.On("Exec", "/usr/bin/su", "-lc", "python /usr/sap/PRD/HDB01/exe/python_support/systemReplicationStatus.py --sapcontrol=1", "prdadm").Return(
 		mockSystemReplicationStatus(), nil,
 	)
 
-	mockCommand.On("Exec", "su", "-lc", "python /usr/sap/PRD/HDB01/exe/python_support/landscapeHostConfiguration.py --sapcontrol=1", "prdadm").Return(
+	mockCommand.On("Exec", "/usr/bin/su", "-lc", "python /usr/sap/PRD/HDB01/exe/python_support/landscapeHostConfiguration.py --sapcontrol=1", "prdadm").Return(
 		mockLandscapeHostConfiguration(), nil,
 	)
 
-	mockCommand.On("Exec", "su", "-lc", "/usr/sap/PRD/HDB01/exe/hdbnsutil -sr_state -sapcontrol=1", "prdadm").Return(
+	mockCommand.On("Exec", "/usr/bin/su", "-lc", "/usr/sap/PRD/HDB01/exe/hdbnsutil -sr_state -sapcontrol=1", "prdadm").Return(
 		mockHdbnsutilSrstate(), nil,
 	)
 
@@ -1159,11 +1159,11 @@ func (suite *SAPSystemTestSuite) TestDetectType_Database() {
 
 	mockCommand := new(mocks.CommandExecutor)
 	mockCommand.
-		On("Exec", "su", "-lc", "python /usr/sap/HDB/HDB00/exe/python_support/systemReplicationStatus.py --sapcontrol=1", "hdbadm").
+		On("Exec", "/usr/bin/su", "-lc", "python /usr/sap/HDB/HDB00/exe/python_support/systemReplicationStatus.py --sapcontrol=1", "hdbadm").
 		Return(mockSystemReplicationStatus(), nil).
-		On("Exec", "su", "-lc", "python /usr/sap/HDB/HDB00/exe/python_support/landscapeHostConfiguration.py --sapcontrol=1", "hdbadm").
+		On("Exec", "/usr/bin/su", "-lc", "python /usr/sap/HDB/HDB00/exe/python_support/landscapeHostConfiguration.py --sapcontrol=1", "hdbadm").
 		Return(mockLandscapeHostConfiguration(), nil).
-		On("Exec", "su", "-lc", "/usr/sap/HDB/HDB00/exe/hdbnsutil -sr_state -sapcontrol=1", "hdbadm").
+		On("Exec", "/usr/bin/su", "-lc", "/usr/sap/HDB/HDB00/exe/hdbnsutil -sr_state -sapcontrol=1", "hdbadm").
 		Return(mockHdbnsutilSrstate(), nil)
 
 	instance, err := sapsystem.NewSAPInstance(ctx, mockWebService, mockCommand, appFS)

--- a/internal/discovery/mocks/discovered_cluster_mock.go
+++ b/internal/discovery/mocks/discovered_cluster_mock.go
@@ -29,7 +29,7 @@ func mockSbdList() []byte {
 
 func NewDiscoveredClusterMock() *cluster.Cluster {
 	mockCommand := new(mocksUtils.CommandExecutor)
-	mockCommand.On("Exec", "dmidecode", "-s", "chassis-asset-tag").
+	mockCommand.On("Exec", "/usr/sbin/dmidecode", "-s", "chassis-asset-tag").
 		Return([]byte("7783-7084-3265-9085-8269-3286-77"), nil)
 	mockCommand.On("Exec", "/usr/sbin/sbd", "-d", "/dev/vdb", "dump").Return(mockSbdDump(), nil)
 	mockCommand.On("Exec", "/usr/sbin/sbd", "-d", "/dev/vdb", "list").Return(mockSbdList(), nil)

--- a/internal/factsengine/gatherers/ascsers_cluster_test.go
+++ b/internal/factsengine/gatherers/ascsers_cluster_test.go
@@ -60,7 +60,7 @@ func (suite *AscsErsClusterTestSuite) TestAscsErsClusterGatherCmdNotFound() {
 
 func (suite *AscsErsClusterTestSuite) TestAscsErsClusterGatherCacheCastingError() {
 	cache := factscache.NewFactsCache()
-	_, err := cache.GetOrUpdate("/usr/sbin/cibadmin", func(_ ...interface{}) (interface{}, error) {
+	_, err := cache.GetOrUpdate("cibadmin", func(_ ...interface{}) (interface{}, error) {
 		return 1, nil
 	})
 	suite.NoError(err)
@@ -280,7 +280,7 @@ func (suite *AscsErsClusterTestSuite) TestAscsErsClusterGather() {
 
 	entries := suite.cache.Entries()
 	expectedEntries := []string{
-		"/usr/sbin/cibadmin",
+		"cibadmin",
 		"sapcontrol:GetProcessList:PRD:00",
 		"sapcontrol:GetProcessList:PRD:10",
 		"sapcontrol:GetProcessList:DEV:01",

--- a/internal/factsengine/gatherers/ascsers_cluster_test.go
+++ b/internal/factsengine/gatherers/ascsers_cluster_test.go
@@ -38,7 +38,7 @@ func (suite *AscsErsClusterTestSuite) SetupTest() {
 }
 
 func (suite *AscsErsClusterTestSuite) TestAscsErsClusterGatherCmdNotFound() {
-	suite.mockExecutor.On("ExecContext", mock.Anything, "cibadmin", "--query", "--local").Return(
+	suite.mockExecutor.On("ExecContext", mock.Anything, "/usr/sbin/cibadmin", "--query", "--local").Return(
 		[]byte{}, errors.New("cibadmin not found"))
 
 	p := gatherers.NewAscsErsClusterGatherer(suite.mockExecutor, suite.webService, nil)
@@ -60,7 +60,7 @@ func (suite *AscsErsClusterTestSuite) TestAscsErsClusterGatherCmdNotFound() {
 
 func (suite *AscsErsClusterTestSuite) TestAscsErsClusterGatherCacheCastingError() {
 	cache := factscache.NewFactsCache()
-	_, err := cache.GetOrUpdate("cibadmin", func(_ ...interface{}) (interface{}, error) {
+	_, err := cache.GetOrUpdate("/usr/sbin/cibadmin", func(_ ...interface{}) (interface{}, error) {
 		return 1, nil
 	})
 	suite.NoError(err)
@@ -86,7 +86,7 @@ func (suite *AscsErsClusterTestSuite) TestAscsErsClusterGatherInvalidInstanceNam
 	lFile, _ := os.Open(helpers.GetFixturePath("gatherers/cibadmin_multisid_invalid.xml"))
 	content, _ := io.ReadAll(lFile)
 
-	suite.mockExecutor.On("ExecContext", mock.Anything, "cibadmin", "--query", "--local").Return(
+	suite.mockExecutor.On("ExecContext", mock.Anything, "/usr/sbin/cibadmin", "--query", "--local").Return(
 		content, nil)
 
 	p := gatherers.NewAscsErsClusterGatherer(suite.mockExecutor, suite.webService, nil)
@@ -111,7 +111,7 @@ func (suite *AscsErsClusterTestSuite) TestAscsErsClusterGatherInvalidInstanceNum
 		helpers.GetFixturePath("gatherers/cibadmin_multisid_invalid_instance_number.xml"))
 	content, _ := io.ReadAll(lFile)
 
-	suite.mockExecutor.On("ExecContext", mock.Anything, "cibadmin", "--query", "--local").Return(
+	suite.mockExecutor.On("ExecContext", mock.Anything, "/usr/sbin/cibadmin", "--query", "--local").Return(
 		content, nil)
 
 	p := gatherers.NewAscsErsClusterGatherer(suite.mockExecutor, suite.webService, nil)
@@ -137,7 +137,7 @@ func (suite *AscsErsClusterTestSuite) TestAscsErsClusterGather() {
 	lFile, _ := os.Open(helpers.GetFixturePath("gatherers/cibadmin_multisid.xml"))
 	content, _ := io.ReadAll(lFile)
 
-	suite.mockExecutor.On("ExecContext", mock.Anything, "cibadmin", "--query", "--local").Return(
+	suite.mockExecutor.On("ExecContext", mock.Anything, "/usr/sbin/cibadmin", "--query", "--local").Return(
 		content, nil)
 
 	mockWebServicePRDASCS00 := new(sapControlMocks.WebService)
@@ -280,7 +280,7 @@ func (suite *AscsErsClusterTestSuite) TestAscsErsClusterGather() {
 
 	entries := suite.cache.Entries()
 	expectedEntries := []string{
-		"cibadmin",
+		"/usr/sbin/cibadmin",
 		"sapcontrol:GetProcessList:PRD:00",
 		"sapcontrol:GetProcessList:PRD:10",
 		"sapcontrol:GetProcessList:DEV:01",

--- a/internal/factsengine/gatherers/cibadmin.go
+++ b/internal/factsengine/gatherers/cibadmin.go
@@ -10,8 +10,8 @@ import (
 )
 
 const (
-	CibAdminGathererName  = "cibadmin"
-	CibAdminGathererCache = "cibadmin"
+	CibAdminGathererName  = "/usr/sbin/cibadmin"
+	CibAdminGathererCache = "/usr/sbin/cibadmin"
 )
 
 // nolint:gochecknoglobals
@@ -53,7 +53,7 @@ func makeMemoizeCibAdmin(ctx context.Context) func(...interface{}) (interface{},
 		if !ok {
 			return nil, ImplementationError.Wrap("error using memoizeCibAdmin. executor must be 1st argument")
 		}
-		return executor.ExecContext(ctx, "cibadmin", "--query", "--local")
+		return executor.ExecContext(ctx, "/usr/sbin/cibadmin", "--query", "--local")
 	}
 
 }

--- a/internal/factsengine/gatherers/cibadmin.go
+++ b/internal/factsengine/gatherers/cibadmin.go
@@ -10,8 +10,8 @@ import (
 )
 
 const (
-	CibAdminGathererName  = "/usr/sbin/cibadmin"
-	CibAdminGathererCache = "/usr/sbin/cibadmin"
+	CibAdminGathererName  = "cibadmin"
+	CibAdminGathererCache = "cibadmin"
 )
 
 // nolint:gochecknoglobals

--- a/internal/factsengine/gatherers/cibadmin_test.go
+++ b/internal/factsengine/gatherers/cibadmin_test.go
@@ -245,12 +245,12 @@ func (suite *CibAdminTestSuite) TestCibAdminGatherWithCache() {
 	suite.NoError(err)
 
 	entries := cache.Entries()
-	suite.ElementsMatch([]string{"/usr/sbin/cibadmin"}, entries)
+	suite.ElementsMatch([]string{"cibadmin"}, entries)
 }
 
 func (suite *CibAdminTestSuite) TestCibAdminGatherCacheCastingError() {
 	cache := factscache.NewFactsCache()
-	_, err := cache.GetOrUpdate("/usr/sbin/cibadmin", func(_ ...interface{}) (interface{}, error) {
+	_, err := cache.GetOrUpdate("cibadmin", func(_ ...interface{}) (interface{}, error) {
 		return 1, nil
 	})
 	suite.NoError(err)

--- a/internal/factsengine/gatherers/cibadmin_test.go
+++ b/internal/factsengine/gatherers/cibadmin_test.go
@@ -39,7 +39,7 @@ func (suite *CibAdminTestSuite) SetupTest() {
 }
 
 func (suite *CibAdminTestSuite) TestCibAdminGatherCmdNotFound() {
-	suite.mockExecutor.On("ExecContext", mock.Anything, "cibadmin", "--query", "--local").Return(
+	suite.mockExecutor.On("ExecContext", mock.Anything, "/usr/sbin/cibadmin", "--query", "--local").Return(
 		suite.cibAdminOutput, errors.New("cibadmin not found"))
 
 	p := gatherers.NewCibAdminGatherer(suite.mockExecutor, nil)
@@ -60,7 +60,7 @@ func (suite *CibAdminTestSuite) TestCibAdminGatherCmdNotFound() {
 }
 
 func (suite *CibAdminTestSuite) TestCibAdminInvalidXML() {
-	suite.mockExecutor.On("ExecContext", mock.Anything, "cibadmin", "--query", "--local").Return(
+	suite.mockExecutor.On("ExecContext", mock.Anything, "/usr/sbin/cibadmin", "--query", "--local").Return(
 		[]byte("invalid"), nil)
 
 	p := gatherers.NewCibAdminGatherer(suite.mockExecutor, nil)
@@ -81,7 +81,7 @@ func (suite *CibAdminTestSuite) TestCibAdminInvalidXML() {
 }
 
 func (suite *CibAdminTestSuite) TestCibAdminGather() {
-	suite.mockExecutor.On("ExecContext", mock.Anything, "cibadmin", "--query", "--local").Return(
+	suite.mockExecutor.On("ExecContext", mock.Anything, "/usr/sbin/cibadmin", "--query", "--local").Return(
 		suite.cibAdminOutput, nil)
 
 	p := gatherers.NewCibAdminGatherer(suite.mockExecutor, nil)
@@ -212,7 +212,7 @@ func (suite *CibAdminTestSuite) TestCibAdminGather() {
 }
 
 func (suite *CibAdminTestSuite) TestCibAdminGatherWithCache() {
-	suite.mockExecutor.On("ExecContext", mock.Anything, "cibadmin", "--query", "--local").
+	suite.mockExecutor.On("ExecContext", mock.Anything, "/usr/sbin/cibadmin", "--query", "--local").
 		Return(suite.cibAdminOutput, nil).
 		Once()
 
@@ -245,12 +245,12 @@ func (suite *CibAdminTestSuite) TestCibAdminGatherWithCache() {
 	suite.NoError(err)
 
 	entries := cache.Entries()
-	suite.ElementsMatch([]string{"cibadmin"}, entries)
+	suite.ElementsMatch([]string{"/usr/sbin/cibadmin"}, entries)
 }
 
 func (suite *CibAdminTestSuite) TestCibAdminGatherCacheCastingError() {
 	cache := factscache.NewFactsCache()
-	_, err := cache.GetOrUpdate("cibadmin", func(_ ...interface{}) (interface{}, error) {
+	_, err := cache.GetOrUpdate("/usr/sbin/cibadmin", func(_ ...interface{}) (interface{}, error) {
 		return 1, nil
 	})
 	suite.NoError(err)

--- a/internal/factsengine/gatherers/dispwork.go
+++ b/internal/factsengine/gatherers/dispwork.go
@@ -82,7 +82,7 @@ func (g *DispWorkGatherer) Gather(ctx context.Context, factsRequests []entities.
 		sid := filepath.Base(systemPath)
 		sapUser := fmt.Sprintf("%sadm", strings.ToLower(sid))
 
-		dispWorkOutput, err := g.executor.ExecContext(ctx, "su", "-", sapUser, "-c", "\"disp+work\"")
+		dispWorkOutput, err := g.executor.ExecContext(ctx, "/usr/bin/su", "-", sapUser, "-c", "\"disp+work\"")
 		switch {
 		case ctx.Err() != nil:
 			return nil, ctx.Err()

--- a/internal/factsengine/gatherers/dispwork_test.go
+++ b/internal/factsengine/gatherers/dispwork_test.go
@@ -50,13 +50,13 @@ func (suite *DispWorkGathererTestSuite) TestDispWorkGatheringSuccess() {
 	unsortedOutputFile, _ := os.Open(helpers.GetFixturePath("gatherers/dispwork-unsorted.output"))
 	unsortedOutput, _ := io.ReadAll(unsortedOutputFile)
 	suite.mockExecutor.
-		On("ExecContext", mock.Anything, "su", "-", "prdadm", "-c", "\"disp+work\"").
+		On("ExecContext", mock.Anything, "/usr/bin/su", "-", "prdadm", "-c", "\"disp+work\"").
 		Return(validOutput, nil).
-		On("ExecContext", mock.Anything, "su", "-", "qasadm", "-c", "\"disp+work\"").
+		On("ExecContext", mock.Anything, "/usr/bin/su", "-", "qasadm", "-c", "\"disp+work\"").
 		Return(partialOutput, nil).
-		On("ExecContext", mock.Anything, "su", "-", "qa2adm", "-c", "\"disp+work\"").
+		On("ExecContext", mock.Anything, "/usr/bin/su", "-", "qa2adm", "-c", "\"disp+work\"").
 		Return(unsortedOutput, nil).
-		On("ExecContext", mock.Anything, "su", "-", "devadm", "-c", "\"disp+work\"").
+		On("ExecContext", mock.Anything, "/usr/bin/su", "-", "devadm", "-c", "\"disp+work\"").
 		Return(nil, errors.New("some error"))
 
 	g := gatherers.NewDispWorkGatherer(suite.fs, suite.mockExecutor)

--- a/internal/factsengine/gatherers/mountinfo.go
+++ b/internal/factsengine/gatherers/mountinfo.go
@@ -92,7 +92,7 @@ func (g *MountInfoGatherer) Gather(ctx context.Context, factsRequests []entities
 					Options:    mount.Options,
 				}
 
-				blkidOuptut, err := g.executor.ExecContext(ctx, "blkid", foundMountInfoResult.Source, "-o", "export")
+				blkidOuptut, err := g.executor.ExecContext(ctx, "/sbin/blkid", foundMountInfoResult.Source, "-o", "export")
 				if err != nil {
 					log.Warnf("blkid command failed for source %s: %s", foundMountInfoResult.Source, err)
 				} else if fields, err := envparse.Parse(strings.NewReader(string(blkidOuptut))); err != nil {

--- a/internal/factsengine/gatherers/mountinfo_test.go
+++ b/internal/factsengine/gatherers/mountinfo_test.go
@@ -67,11 +67,11 @@ TYPE=xfs
 `)
 
 	suite.mockExecutor.
-		On("ExecContext", mock.Anything, "blkid", "10.1.1.10:/sapmnt", "-o", "export").
+		On("ExecContext", mock.Anything, "/sbin/blkid", "10.1.1.10:/sapmnt", "-o", "export").
 		Return(nil, fmt.Errorf("blkid error")).
-		On("ExecContext", mock.Anything, "blkid", "/dev/mapper/vg_hana-lv_data", "-o", "export").
+		On("ExecContext", mock.Anything, "/sbin/blkid", "/dev/mapper/vg_hana-lv_data", "-o", "export").
 		Return(blkidOutput, nil).
-		On("ExecContext", mock.Anything, "blkid", "/dev/mapper/vg_hana-lv_log", "-o", "export").
+		On("ExecContext", mock.Anything, "/sbin/blkid", "/dev/mapper/vg_hana-lv_log", "-o", "export").
 		Return(blkidOutputNoUUID, nil)
 
 	requestedFacts := []entities.FactRequest{

--- a/internal/factsengine/gatherers/sbddump.go
+++ b/internal/factsengine/gatherers/sbddump.go
@@ -123,7 +123,7 @@ func getSBDDumpFactValueMap(
 	ctx context.Context,
 	executor utils.CommandExecutor,
 	device string) (*entities.FactValueMap, error) {
-	SBDDump, err := executor.ExecContext(ctx, "sbd", "-d", device, "dump")
+	SBDDump, err := executor.ExecContext(ctx, "/usr/sbin/sbd", "-d", device, "dump")
 	if err != nil {
 		return nil, fmt.Errorf("Error while dumping information for device %s: %w", device, err)
 	}

--- a/internal/factsengine/gatherers/sbddump_test.go
+++ b/internal/factsengine/gatherers/sbddump_test.go
@@ -53,8 +53,8 @@ func (suite *SBDDumpTestSuite) TestSBDDumpUnableToDumpDevice() {
 
 	mockOutputFile, _ := os.Open(helpers.GetFixturePath("gatherers/dev.vdc.sbddump.output"))
 	mockOutput, _ := io.ReadAll(mockOutputFile)
-	mockExecutor.On("ExecContext", mock.Anything, "sbd", "-d", "/dev/vdb", "dump").Return(nil, errors.New("a failure"))
-	mockExecutor.On("ExecContext", mock.Anything, "sbd", "-d", "/dev/vdc", "dump").Return(mockOutput, nil)
+	mockExecutor.On("ExecContext", mock.Anything, "/usr/sbin/sbd", "-d", "/dev/vdb", "dump").Return(nil, errors.New("a failure"))
+	mockExecutor.On("ExecContext", mock.Anything, "/usr/sbin/sbd", "-d", "/dev/vdc", "dump").Return(mockOutput, nil)
 
 	sbdDumpGatherer := gatherers.NewSBDDumpGatherer(
 		mockExecutor,
@@ -107,8 +107,8 @@ func (suite *SBDDumpTestSuite) TestSBDDumpGatherer() {
 	deviceVDCMockOutputFile, _ := os.Open(helpers.GetFixturePath("gatherers/dev.vdc.sbddump.output"))
 	deviceVDCMockOutput, _ := io.ReadAll(deviceVDCMockOutputFile)
 
-	mockExecutor.On("ExecContext", mock.Anything, "sbd", "-d", "/dev/vdb", "dump").Return(deviceVDBMockOutput, nil)
-	mockExecutor.On("ExecContext", mock.Anything, "sbd", "-d", "/dev/vdc", "dump").Return(deviceVDCMockOutput, nil)
+	mockExecutor.On("ExecContext", mock.Anything, "/usr/sbin/sbd", "-d", "/dev/vdb", "dump").Return(deviceVDBMockOutput, nil)
+	mockExecutor.On("ExecContext", mock.Anything, "/usr/sbin/sbd", "-d", "/dev/vdc", "dump").Return(deviceVDCMockOutput, nil)
 
 	sbdDumpGatherer := gatherers.NewSBDDumpGatherer(
 		mockExecutor,

--- a/internal/factsengine/gatherers/sysctl.go
+++ b/internal/factsengine/gatherers/sysctl.go
@@ -49,7 +49,7 @@ func (s *SysctlGatherer) Gather(ctx context.Context, factsRequests []entities.Fa
 	facts := []entities.Fact{}
 	log.Infof("Starting %s facts gathering process", SysctlGathererName)
 
-	output, err := s.executor.ExecContext(ctx, "sysctl", "-a")
+	output, err := s.executor.ExecContext(ctx, "/sbin/sysctl", "-a")
 	if err != nil {
 		return nil, SysctlCommandError.Wrap(err.Error())
 	}

--- a/internal/factsengine/gatherers/sysctl_test.go
+++ b/internal/factsengine/gatherers/sysctl_test.go
@@ -33,7 +33,7 @@ func (suite *SysctlTestSuite) SetupTest() {
 func (suite *SysctlTestSuite) TestSysctlGathererNoArgumentProvided() {
 	mockOutputFile, _ := os.Open(helpers.GetFixturePath("gatherers/sysctl.output"))
 	mockOutput, _ := io.ReadAll(mockOutputFile)
-	suite.mockExecutor.On("ExecContext", mock.Anything, "sysctl", "-a").Return(mockOutput, nil)
+	suite.mockExecutor.On("ExecContext", mock.Anything, "/sbin/sysctl", "-a").Return(mockOutput, nil)
 
 	c := gatherers.NewSysctlGatherer(suite.mockExecutor)
 
@@ -77,7 +77,7 @@ func (suite *SysctlTestSuite) TestSysctlGathererNoArgumentProvided() {
 func (suite *SysctlTestSuite) TestSysctlGathererNonExistingKey() {
 	mockOutputFile, _ := os.Open(helpers.GetFixturePath("gatherers/sysctl.output"))
 	mockOutput, _ := io.ReadAll(mockOutputFile)
-	suite.mockExecutor.On("ExecContext", mock.Anything, "sysctl", "-a").Return(mockOutput, nil)
+	suite.mockExecutor.On("ExecContext", mock.Anything, "/sbin/sysctl", "-a").Return(mockOutput, nil)
 
 	c := gatherers.NewSysctlGatherer(suite.mockExecutor)
 
@@ -107,7 +107,7 @@ func (suite *SysctlTestSuite) TestSysctlGathererNonExistingKey() {
 }
 
 func (suite *SysctlTestSuite) TestSysctlCommandNotFound() {
-	suite.mockExecutor.On("ExecContext", mock.Anything, "sysctl", "-a").Return(nil, exec.ErrNotFound)
+	suite.mockExecutor.On("ExecContext", mock.Anything, "/sbin/sysctl", "-a").Return(nil, exec.ErrNotFound)
 
 	c := gatherers.NewSysctlGatherer(suite.mockExecutor)
 
@@ -134,7 +134,7 @@ func (suite *SysctlTestSuite) TestSysctlCommandNotFound() {
 func (suite *SysctlTestSuite) TestSysctlGatherer() {
 	mockOutputFile, _ := os.Open(helpers.GetFixturePath("gatherers/sysctl.output"))
 	mockOutput, _ := io.ReadAll(mockOutputFile)
-	suite.mockExecutor.On("ExecContext", mock.Anything, "sysctl", "-a").Return(mockOutput, nil)
+	suite.mockExecutor.On("ExecContext", mock.Anything, "/sbin/sysctl", "-a").Return(mockOutput, nil)
 
 	c := gatherers.NewSysctlGatherer(suite.mockExecutor)
 
@@ -162,7 +162,7 @@ func (suite *SysctlTestSuite) TestSysctlGatherer() {
 func (suite *SysctlTestSuite) TestSysctlGathererPartialKey() {
 	mockOutputFile, _ := os.Open(helpers.GetFixturePath("gatherers/sysctl.output"))
 	mockOutput, _ := io.ReadAll(mockOutputFile)
-	suite.mockExecutor.On("ExecContext", mock.Anything, "sysctl", "-a").Return(mockOutput, nil)
+	suite.mockExecutor.On("ExecContext", mock.Anything, "/sbin/sysctl", "-a").Return(mockOutput, nil)
 
 	c := gatherers.NewSysctlGatherer(suite.mockExecutor)
 
@@ -195,7 +195,7 @@ func (suite *SysctlTestSuite) TestSysctlGathererPartialKey() {
 func (suite *SysctlTestSuite) TestSysctlGathererEmptyValue() {
 	mockOutputFile, _ := os.Open(helpers.GetFixturePath("gatherers/sysctl.output"))
 	mockOutput, _ := io.ReadAll(mockOutputFile)
-	suite.mockExecutor.On("ExecContext", mock.Anything, "sysctl", "-a").Return(mockOutput, nil)
+	suite.mockExecutor.On("ExecContext", mock.Anything, "/sbin/sysctl", "-a").Return(mockOutput, nil)
 
 	c := gatherers.NewSysctlGatherer(suite.mockExecutor)
 

--- a/internal/factsengine/gatherers/verifypassword.go
+++ b/internal/factsengine/gatherers/verifypassword.go
@@ -153,7 +153,7 @@ func (g *VerifyPasswordGatherer) Gather(
 }
 
 func (g *VerifyPasswordGatherer) getHash(ctx context.Context, user string) (string, error) {
-	shadow, err := g.executor.ExecContext(ctx, "getent", "shadow", user)
+	shadow, err := g.executor.ExecContext(ctx, "/usr/bin/getent", "shadow", user)
 	if err != nil {
 		return "", errors.Wrap(err, "Error getting hash")
 	}

--- a/internal/factsengine/gatherers/verifypassword_test.go
+++ b/internal/factsengine/gatherers/verifypassword_test.go
@@ -30,7 +30,7 @@ func (suite *PasswordTestSuite) TestPasswordGatherEqual() {
 		"cP8uJJpHzJ7ufTPjYuWoVF4s.3MUdOR9iwcO.6E3uCHX1waqypjey458NKGE9O7lnWpV/" +
 		"qd2tg1:19029::::::")
 
-	suite.mockExecutor.On("ExecContext", mock.Anything, "getent", "shadow", "hacluster").Return(
+	suite.mockExecutor.On("ExecContext", mock.Anything, "/usr/bin/getent", "shadow", "hacluster").Return(
 		shadow, nil)
 
 	verifyPasswordGatherer := gatherers.NewVerifyPasswordGatherer(suite.mockExecutor)
@@ -63,7 +63,7 @@ func (suite *PasswordTestSuite) TestPasswordGatherNotEqual() {
 		"cP8uJJpHzJ7ufTPjYuWoVF4s.3MUdOR9iwcO.6E3uCHX1waqypjey458NKGE9O7lnWpV" +
 		"/qd2tg1:19029::::::")
 
-	suite.mockExecutor.On("ExecContext", mock.Anything, "getent", "shadow", "hacluster").Return(
+	suite.mockExecutor.On("ExecContext", mock.Anything, "/usr/bin/getent", "shadow", "hacluster").Return(
 		shadow, nil)
 
 	verifyPasswordGatherer := gatherers.NewVerifyPasswordGatherer(suite.mockExecutor)
@@ -93,13 +93,13 @@ func (suite *PasswordTestSuite) TestPasswordGatherNotEqual() {
 
 func (suite *PasswordTestSuite) TestPasswordGatherBloquedPassword() {
 	suite.mockExecutor.
-		On("ExecContext", mock.Anything, "getent", "shadow", "hacluster").
+		On("ExecContext", mock.Anything, "/usr/bin/getent", "shadow", "hacluster").
 		Return([]byte("hacluster:!:19029::::::"), nil).
 		Once().
-		On("ExecContext", mock.Anything, "getent", "shadow", "hacluster").
+		On("ExecContext", mock.Anything, "/usr/bin/getent", "shadow", "hacluster").
 		Return([]byte("hacluster:!$6$WFEgSAefduOyvLCN$MprO90E:19029::::::"), nil).
 		Once().
-		On("ExecContext", mock.Anything, "getent", "shadow", "hacluster").
+		On("ExecContext", mock.Anything, "/usr/bin/getent", "shadow", "hacluster").
 		Return([]byte("hacluster:*:19029::::::"), nil)
 
 	verifyPasswordGatherer := gatherers.NewVerifyPasswordGatherer(suite.mockExecutor)
@@ -164,7 +164,7 @@ func (suite *PasswordTestSuite) TestPasswordGatherBloquedPassword() {
 func (suite *PasswordTestSuite) TestPasswordGatherNoPassword() {
 	shadow := []byte("hacluster::19029::::::")
 
-	suite.mockExecutor.On("ExecContext", mock.Anything, "getent", "shadow", "hacluster").Return(
+	suite.mockExecutor.On("ExecContext", mock.Anything, "/usr/bin/getent", "shadow", "hacluster").Return(
 		shadow, nil)
 
 	verifyPasswordGatherer := gatherers.NewVerifyPasswordGatherer(suite.mockExecutor)
@@ -201,7 +201,7 @@ func (suite *PasswordTestSuite) TestPasswordGatherDifferentEncType() {
 		"cP8uJJpHzJ7ufTPjYuWoVF4s.3MUdOR9iwcO.6E3uCHX1waqypjey458NKGE9O7lnWpV/" +
 		"qd2tg1:19029::::::")
 
-	suite.mockExecutor.On("ExecContext", mock.Anything, "getent", "shadow", "hacluster").Return(
+	suite.mockExecutor.On("ExecContext", mock.Anything, "/usr/bin/getent", "shadow", "hacluster").Return(
 		shadow, nil)
 
 	verifyPasswordGatherer := gatherers.NewVerifyPasswordGatherer(suite.mockExecutor)
@@ -236,7 +236,7 @@ func (suite *PasswordTestSuite) TestPasswordGatherDifferentEncType() {
 func (suite *PasswordTestSuite) TestPasswordGatherInvalidShadowOutput() {
 	shadow := []byte("hacluster:hash:")
 
-	suite.mockExecutor.On("ExecContext", mock.Anything, "getent", "shadow", "hacluster").Return(
+	suite.mockExecutor.On("ExecContext", mock.Anything, "/usr/bin/getent", "shadow", "hacluster").Return(
 		shadow, nil)
 
 	verifyPasswordGatherer := gatherers.NewVerifyPasswordGatherer(suite.mockExecutor)


### PR DESCRIPTION
Use an absolute path when executing an external program on the host machine. 

Paths are defined according to a standard installation of `SUSE Linux Enterprise Server 15`