### PR TITLE
Update packaging and service files for SLES 16

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ which are part of the [SUSE Linux Enterprise Server for SAP Applications](https:
 
 These could in theory also be installed and configured on other distributions providing the same functionalities, but this use case is not within the scope of the active development.
 
-In addition to that, _Trento Agent_ also requires the [Prometheus node_exporter component](https://github.com/prometheus/node_exporter) to be running to collect host information for the monitoring functionality.
+In addition to that, _Trento Agent_ also wants the [Prometheus node_exporter component](https://github.com/prometheus/node_exporter) to be running to collect host information for the monitoring functionality.
 
 The resource footprint of _Trento Agent_ should not impact the performance of the host it runs on.
 
@@ -142,7 +142,7 @@ containers, etc.) makes little sense, as they won't be able as the discovery mec
 
 > NOTE: Suggested installation instructions for SUSE-based distributions, adjust accordingly
 
-Install and start `node_exporter`:
+Install and start `node_exporter` (Optional):
 
 ```shell
 zypper in -y golang-github-prometheus-node_exporter

--- a/README.md
+++ b/README.md
@@ -142,12 +142,14 @@ containers, etc.) makes little sense, as they won't be able as the discovery mec
 
 > NOTE: Suggested installation instructions for SUSE-based distributions, adjust accordingly
 
-Install and start `node_exporter` (Optional):
+*Optionally* install and start `node_exporter`:
 
 ```shell
 zypper in -y golang-github-prometheus-node_exporter
 systemctl start prometheus-node_exporter
 ```
+
+> NOTE: The `prometheus-node_exporter` zypper package might or might not be available depending on the SLES version.
 
 To start the trento agent:
 

--- a/packaging/suse/trento-agent.spec
+++ b/packaging/suse/trento-agent.spec
@@ -29,10 +29,8 @@ Source1:        vendor.tar.gz
 ExclusiveArch:  aarch64 x86_64 ppc64le s390x
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildRequires:  golang(API) = 1.23
-%if 0%{?suse_version} && 0%{?suse_version} < 1600
 # Prometheus Node Exporter is not available in SLES 16
-Requires:       golang-github-prometheus-node_exporter
-%endif
+Recommends:     golang-github-prometheus-node_exporter
 Provides:       %{name} = %{version}-%{release}
 Provides:       trento = %{version}-%{release}
 Provides:       trento-premium = %{version}-%{release}

--- a/packaging/suse/trento-agent.spec
+++ b/packaging/suse/trento-agent.spec
@@ -29,7 +29,10 @@ Source1:        vendor.tar.gz
 ExclusiveArch:  aarch64 x86_64 ppc64le s390x
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildRequires:  golang(API) = 1.23
+%if 0%{?suse_version} && 0%{?suse_version} < 1600
+# Prometheus Node Exporter is not available in SLES 16
 Requires:       golang-github-prometheus-node_exporter
+%endif
 Provides:       %{name} = %{version}-%{release}
 Provides:       trento = %{version}-%{release}
 Provides:       trento-premium = %{version}-%{release}

--- a/packaging/systemd/trento-agent.service
+++ b/packaging/systemd/trento-agent.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Trento agent service
-Requires=prometheus-node_exporter.service
+Wants=prometheus-node_exporter.service
 After=prometheus-node_exporter.service
 
 [Service]


### PR DESCRIPTION
Prometheus Node Exporter is not available in SLES 16, so the retirements for it need to be relaxed.  This only affects the systemd unit file, which now can start when the node exporter is not installed or fails to start

## How was this tested?

Manual testing and tests already in place

## Did you update the documentation?

Remember to ask yourself if your PR requires changes to the following documentation:

- [Manual installation guide](https://github.com/trento-project/docs/blob/main/guides/manual-installation.md)
- [Trento Ansible guide](https://github.com/trento-project/ansible/blob/main/README.md)
- [Trento Agent guides](https://github.com/trento-project/agent/tree/main/docs)

Add a documentation PR or write that no changes are required for the documentation.

- [x] **DONE**
