### PR TITLE
Use the default POSIX locale for consistent output

### DIFF
--- a/pkg/utils/commandexecutor.go
+++ b/pkg/utils/commandexecutor.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
 	"syscall"
 )
@@ -18,14 +19,14 @@ type Executor struct{}
 
 func (e Executor) Exec(name string, arg ...string) ([]byte, error) {
 	cmd := exec.Command(name, arg...)
-	cmd.Env["LC_ALL"] = "C"
+	cmd.Env = append(os.Environ(), "LC_ALL=C")
 
 	return cmd.Output()
 }
 
 func (e Executor) ExecContext(ctx context.Context, name string, arg ...string) ([]byte, error) {
 	cmd := exec.CommandContext(ctx, name, arg...)
-	cmd.Env["LC_ALL"] = "C"
+	cmd.Env = append(os.Environ(), "LC_ALL=C")
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	cmd.Cancel = func() error {
 		err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)


### PR DESCRIPTION
This commit introduces a change to ensure commands always provide a predictable output, regardless of the system locale

For more info see the POSIX.1-2024 page under "7.2 POSIX Locale" https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/V1_chap07.html