### PR TITLE
Use discoveries as list instead of map to guarantee order

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -29,7 +29,7 @@ var (
 type Agent struct {
 	config          *Config
 	collectorClient collector.Client
-	discoveries     map[string]discovery.Discovery
+	discoveries     []discovery.Discovery
 }
 
 type Config struct {
@@ -46,15 +46,13 @@ func NewAgent(config *Config) (*Agent, error) {
 	agentClient := http.Client{Timeout: 30 * time.Second}
 	collectorClient := collector.NewCollectorClient(config.DiscoveriesConfig.CollectorConfig, &agentClient)
 
-	discoveries := map[string]discovery.Discovery{
-		discovery.ClusterDiscoveryID: discovery.NewClusterDiscovery(collectorClient, *config.DiscoveriesConfig),
-		discovery.SAPDiscoveryID:     discovery.NewSAPSystemsDiscovery(collectorClient, *config.DiscoveriesConfig),
-		discovery.CloudDiscoveryID:   discovery.NewCloudDiscovery(collectorClient, *config.DiscoveriesConfig),
-		discovery.SubscriptionDiscoveryID: discovery.NewSubscriptionDiscovery(
-			collectorClient, config.InstanceName, *config.DiscoveriesConfig),
-		discovery.HostDiscoveryID: discovery.NewHostDiscovery(
-			collectorClient, config.InstanceName, config.PrometheusTargets, *config.DiscoveriesConfig),
-		discovery.SaptuneDiscoveryID: discovery.NewSaptuneDiscovery(collectorClient, *config.DiscoveriesConfig),
+	discoveries := []discovery.Discovery{
+		discovery.NewClusterDiscovery(collectorClient, *config.DiscoveriesConfig),
+		discovery.NewSAPSystemsDiscovery(collectorClient, *config.DiscoveriesConfig),
+		discovery.NewCloudDiscovery(collectorClient, *config.DiscoveriesConfig),
+		discovery.NewSubscriptionDiscovery(collectorClient, config.InstanceName, *config.DiscoveriesConfig),
+		discovery.NewHostDiscovery(collectorClient, config.InstanceName, config.PrometheusTargets, *config.DiscoveriesConfig),
+		discovery.NewSaptuneDiscovery(collectorClient, *config.DiscoveriesConfig),
 	}
 
 	agent := &Agent{

--- a/internal/discovery/policy.go
+++ b/internal/discovery/policy.go
@@ -23,7 +23,7 @@ func ListenRequests(
 	ctx context.Context,
 	agentID string,
 	amqpServiceURL string,
-	discoveries map[string]Discovery,
+	discoveries []Discovery,
 ) error {
 	log.Infof("Subscribing agent %s to the discovery requests on %s", agentID, amqpServiceURL)
 	queue := fmt.Sprintf(agentsQueue, agentID)
@@ -44,9 +44,14 @@ func ListenRequests(
 		}
 	}()
 
+	discoveriesMap := make(map[string]Discovery)
+	for _, d := range discoveries {
+		discoveriesMap[d.GetID()] = d
+	}
+
 	if err := amqpAdapter.Listen(
 		func(_ string, event []byte) error {
-			return HandleEvent(ctx, event, agentID, discoveries)
+			return HandleEvent(ctx, event, agentID, discoveriesMap)
 		}); err != nil {
 		return err
 	}

--- a/internal/discovery/policy_integration_test.go
+++ b/internal/discovery/policy_integration_test.go
@@ -69,9 +69,12 @@ func (suite *PolicyIntegrationTestSuite) TestDiscoveryIntegration() {
 	ctx, ctxCancel := context.WithCancel(context.Background())
 	g, groupCtx := errgroup.WithContext(ctx)
 
-	discoveries := make(map[string]discovery.Discovery)
 	testDiscovery := mocks.NewDiscovery(suite.T())
-	discoveries["test_discovery"] = testDiscovery
+	discoveries := []discovery.Discovery{testDiscovery}
+
+	testDiscovery.
+		On("GetID").
+		Return("test_discovery")
 
 	testDiscovery.
 		On("Discover", mock.Anything).


### PR DESCRIPTION
# Description

Revert the change I did in the PR that implemented the listening of discovery requests.
https://github.com/trento-project/agent/pull/424

In that PR, I changed the discoveries from a list to a map, ignoring completely that in golang maps order is not deterministic. This would cause random emission of discovery events.

PD: at the end, this is not that critical. it affects only the first time when the loops start, as after that, each discovery enters in its on loop with its own intervals, and they are not dependent between them. Nevertheless, it adds some "determinism" in the start, which is good.

## How was this tested?

UT and integration tests