### PR TITLE
Fix log-level usage

### DIFF
--- a/internal/agent/config.go
+++ b/internal/agent/config.go
@@ -24,8 +24,6 @@ func InitConfig(configName string) error {
 	bindEnv()
 
 	viper.SetConfigType("yaml")
-	setLogLevel(viper.GetString("log-level"))
-	setLogFormatter("2006-01-02 15:04:05")
 
 	cfgFile := viper.GetString("config")
 	if cfgFile != "" {
@@ -66,6 +64,9 @@ func InitConfig(configName string) error {
 	if configFile := viper.ConfigFileUsed(); configFile != "" {
 		log.Infof("Using config file: %s", configFile)
 	}
+
+	setLogLevel(viper.GetString("log-level"))
+	setLogFormatter("2006-01-02 15:04:05")
 
 	return nil
 }

--- a/internal/agent/config_test.go
+++ b/internal/agent/config_test.go
@@ -1,0 +1,84 @@
+package agent_test
+
+import (
+	"bytes"
+	"os"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/suite"
+	"github.com/trento-project/agent/cmd"
+)
+
+type ConfigTestSuite struct {
+	suite.Suite
+	cmd *cobra.Command
+}
+
+func TestConfigTestSuite(t *testing.T) {
+	suite.Run(t, new(ConfigTestSuite))
+}
+
+func (suite *ConfigTestSuite) SetupTest() {
+	os.Clearenv()
+
+	cmd := cmd.NewRootCmd()
+
+	for _, command := range cmd.Commands() {
+		command.Run = func(_ *cobra.Command, _ []string) {
+			// do nothing
+		}
+	}
+
+	var b bytes.Buffer
+	cmd.SetOut(&b)
+
+	suite.cmd = cmd
+}
+
+func (suite *ConfigTestSuite) TearDownTest() {
+	viper.Reset()
+}
+
+func (suite *ConfigTestSuite) TestLoadingDefaultLogLevel() {
+	suite.cmd.SetArgs([]string{
+		"start",
+	})
+	_ = suite.cmd.Execute()
+
+	defaultLogLevel := viper.GetString("log-level")
+	suite.Equal("info", defaultLogLevel)
+}
+
+func (suite *ConfigTestSuite) TestOverridesLogLevelFromArgs() {
+	defaultLogLevel := viper.GetString("log-level")
+	suite.Equal("info", defaultLogLevel)
+
+	suite.cmd.SetArgs([]string{
+		"--log-level",
+		"error",
+		"start",
+	})
+
+	_ = suite.cmd.Execute()
+
+	overriddenLogLevel := viper.GetString("log-level")
+	suite.Equal("error", overriddenLogLevel)
+}
+
+func (suite *ConfigTestSuite) TestLoadingCorrectLevelFromConfigFile() {
+	defaultLogLevel := viper.GetString("log-level")
+	suite.Equal("info", defaultLogLevel)
+
+	suite.cmd.SetArgs([]string{
+		"--config",
+		"../../test/fixtures/config/agent.yaml",
+		"start",
+	})
+
+	_ = suite.cmd.Execute()
+
+	overriddenLogLevel := viper.GetString("log-level")
+	suite.Equal("warning", overriddenLogLevel)
+}

--- a/test/fixtures/config/agent.yaml
+++ b/test/fixtures/config/agent.yaml
@@ -9,3 +9,4 @@ api-key: some-api-key
 force-agent-id: some-agent-id
 facts-service-url: amqp://guest:guest@serviceurl:5672
 node-exporter-target: 10.0.0.5:9100
+log-level: warning


### PR DESCRIPTION
# Description

Currently the `log-level` was not properly taken into account when coming from a config file.

This fixes the isse.

Addresses https://github.com/trento-project/wanda/issues/617 wrt agent, of course.