### PR TITLE
Add Architecture Discovery

### DIFF
--- a/internal/core/hosts/discovered_host.go
+++ b/internal/core/hosts/discovered_host.go
@@ -2,6 +2,7 @@ package hosts
 
 type DiscoveredHost struct {
 	OSVersion                string            `json:"os_version"`
+	Architecture             string            `json:"arch"`
 	HostIPAddresses          []string          `json:"ip_addresses"`
 	Netmasks                 []int             `json:"netmasks"`
 	HostName                 string            `json:"hostname"`

--- a/internal/discovery/host.go
+++ b/internal/discovery/host.go
@@ -69,6 +69,7 @@ func (d HostDiscovery) Discover(ctx context.Context) (string, error) {
 
 	host := hosts.DiscoveredHost{
 		OSVersion:                getOSVersion(),
+		Architecture:             getArch(),
 		HostIPAddresses:          ipAddresses,
 		Netmasks:                 netmasks,
 		HostName:                 d.host,
@@ -168,6 +169,15 @@ func getOSVersion() string {
 		log.Errorf("Error while getting host info: %s", err)
 	}
 	return infoStat.PlatformVersion
+}
+
+// getArch returns the agent's architecture as specified by uname -m
+func getArch() string {
+	infoStat, err := host.Info()
+	if err != nil {
+		log.Errorf("Error while getting host info: %s", err)
+	}
+	return infoStat.KernelArch
 }
 
 func getTotalMemoryMB() uint64 {

--- a/internal/discovery/mocks/discovered_host_mock.go
+++ b/internal/discovery/mocks/discovered_host_mock.go
@@ -1,12 +1,15 @@
 package mocks
 
-import "github.com/trento-project/agent/internal/core/hosts"
+import (
+	"github.com/trento-project/agent/internal/core/hosts"
+)
 
 func NewDiscoveredHostMock() hosts.DiscoveredHost {
 	fqdn := "com.example.trento.host"
 
 	return hosts.DiscoveredHost{
 		OSVersion:                "15-SP2",
+		Architecture:             "x86_64",
 		HostIPAddresses:          []string{"10.1.1.4", "10.1.1.5", "10.1.1.6"},
 		Netmasks:                 []int{24, 16, 32},
 		HostName:                 "thehostnamewherethediscoveryhappened",

--- a/test/fixtures/discovery/host/expected_published_host_discovery.json
+++ b/test/fixtures/discovery/host/expected_published_host_discovery.json
@@ -3,6 +3,7 @@
   "discovery_type": "host_discovery",
   "payload": {
     "os_version": "15-SP2",
+    "arch": "x86_64",
     "ip_addresses": [
       "10.1.1.4",
       "10.1.1.5",


### PR DESCRIPTION
# Description

This commit adds architecture discovery to the agent's metadata.  It uses the format of the Linux kernel and therefore is equivalent to the output of `uname -m`

Fixes # (issue)

## Did you add the right label?

Remember to add the right labels to this PR.

- [x] **DONE**

## How was this tested?

Describe the tests that have been added/changed for this new behavior.

- [x] **DONE**

## Did you update the documentation?

Remember to ask yourself if your PR requires changes to the following documentation:

- [Manual installation guide](https://github.com/trento-project/docs/blob/main/guides/manual-installation.md)
- [Trento Ansible guide](https://github.com/trento-project/ansible/blob/main/README.md)
- [Trento Agent guides](https://github.com/trento-project/agent/tree/main/docs)

Add a documentation PR or write that no changes are required for the documentation.

- [ ] **DONE**
