### PR TITLE
Systemd units discovery

### DIFF
--- a/internal/core/hosts/discovered_host.go
+++ b/internal/core/hosts/discovered_host.go
@@ -1,17 +1,17 @@
 package hosts
 
 type DiscoveredHost struct {
-	OSVersion                string             `json:"os_version"`
-	Architecture             string             `json:"arch"`
-	HostIPAddresses          []string           `json:"ip_addresses"`
-	Netmasks                 []int              `json:"netmasks"`
-	HostName                 string             `json:"hostname"`
-	CPUCount                 int                `json:"cpu_count"`
-	SocketCount              int                `json:"socket_count"`
-	TotalMemoryMB            uint64             `json:"total_memory_mb"`
-	AgentVersion             string             `json:"agent_version"`
-	InstallationSource       string             `json:"installation_source"`
-	FullyQualifiedDomainName *string            `json:"fully_qualified_domain_name,omitempty"`
-	PrometheusTargets        map[string]string  `json:"prometheus_targets"`
-	SystemdUnits             SystemdUnitsStatus `json:"systemd_units"`
+	OSVersion                string            `json:"os_version"`
+	Architecture             string            `json:"arch"`
+	HostIPAddresses          []string          `json:"ip_addresses"`
+	Netmasks                 []int             `json:"netmasks"`
+	HostName                 string            `json:"hostname"`
+	CPUCount                 int               `json:"cpu_count"`
+	SocketCount              int               `json:"socket_count"`
+	TotalMemoryMB            uint64            `json:"total_memory_mb"`
+	AgentVersion             string            `json:"agent_version"`
+	InstallationSource       string            `json:"installation_source"`
+	FullyQualifiedDomainName *string           `json:"fully_qualified_domain_name,omitempty"`
+	PrometheusTargets        map[string]string `json:"prometheus_targets"`
+	SystemdUnits             []UnitInfo        `json:"systemd_units"`
 }

--- a/internal/core/hosts/discovered_host.go
+++ b/internal/core/hosts/discovered_host.go
@@ -1,16 +1,17 @@
 package hosts
 
 type DiscoveredHost struct {
-	OSVersion                string            `json:"os_version"`
-	Architecture             string            `json:"arch"`
-	HostIPAddresses          []string          `json:"ip_addresses"`
-	Netmasks                 []int             `json:"netmasks"`
-	HostName                 string            `json:"hostname"`
-	CPUCount                 int               `json:"cpu_count"`
-	SocketCount              int               `json:"socket_count"`
-	TotalMemoryMB            uint64            `json:"total_memory_mb"`
-	AgentVersion             string            `json:"agent_version"`
-	InstallationSource       string            `json:"installation_source"`
-	FullyQualifiedDomainName *string           `json:"fully_qualified_domain_name,omitempty"`
-	PrometheusTargets        map[string]string `json:"prometheus_targets"`
+	OSVersion                string             `json:"os_version"`
+	Architecture             string             `json:"arch"`
+	HostIPAddresses          []string           `json:"ip_addresses"`
+	Netmasks                 []int              `json:"netmasks"`
+	HostName                 string             `json:"hostname"`
+	CPUCount                 int                `json:"cpu_count"`
+	SocketCount              int                `json:"socket_count"`
+	TotalMemoryMB            uint64             `json:"total_memory_mb"`
+	AgentVersion             string             `json:"agent_version"`
+	InstallationSource       string             `json:"installation_source"`
+	FullyQualifiedDomainName *string            `json:"fully_qualified_domain_name,omitempty"`
+	PrometheusTargets        map[string]string  `json:"prometheus_targets"`
+	SystemdUnits             SystemdUnitsStatus `json:"systemd_units"`
 }

--- a/internal/core/hosts/host.go
+++ b/internal/core/hosts/host.go
@@ -1,0 +1,67 @@
+package hosts
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/trento-project/agent/internal/core/hosts/systemd"
+)
+
+var relevantSystemdUnits = []string{"pacemaker.service"}
+
+type UnitInfo struct {
+	UnitFileState string `json:"unit_file_state"`
+}
+
+type SystemdUnitsStatus map[string]UnitInfo
+
+func DefaultUnitInfo(units ...string) SystemdUnitsStatus {
+	defaultInfo := make(SystemdUnitsStatus)
+	if len(units) == 0 {
+		units = relevantSystemdUnits
+	}
+	for _, unit := range units {
+		defaultInfo[unit] = UnitInfo{
+			UnitFileState: "unknown",
+		}
+	}
+	return defaultInfo
+}
+
+func GetSystemdUnitsStatus(ctx context.Context, units ...string) SystemdUnitsStatus {
+	dbus, err := systemd.NewDbusConnector(ctx)
+	if err != nil {
+		slog.Error("Error while creating dbus connection", "error", err)
+	}
+	return getSystemdUnitsStatus(ctx, dbus, units...)
+}
+
+func GetSystemdUnitsStatusWithCustomDbus(ctx context.Context, dbus systemd.DbusConnector, units ...string) SystemdUnitsStatus {
+	return getSystemdUnitsStatus(ctx, dbus, units...)
+}
+
+func getSystemdUnitsStatus(ctx context.Context, dbus systemd.DbusConnector, units ...string) SystemdUnitsStatus {
+	unitsInfo := DefaultUnitInfo(units...)
+
+	if dbus == nil {
+		return unitsInfo
+	}
+
+	defer dbus.Close()
+
+	for unit := range unitsInfo {
+		unitProperties, err := dbus.GetUnitPropertiesContext(ctx, unit)
+		if err != nil {
+			slog.Error("Error getting systemd unit properties", "unit", unit, "error", err)
+			continue
+		}
+		unitFileState, ok := unitProperties["UnitFileState"]
+		if !ok {
+			slog.Warn("UnitFileState not found in properties", "unit", unit, "properties", unitProperties)
+			continue
+		}
+		unitsInfo[unit] = UnitInfo{UnitFileState: unitFileState.(string)}
+	}
+
+	return unitsInfo
+}

--- a/internal/core/hosts/host_test.go
+++ b/internal/core/hosts/host_test.go
@@ -1,0 +1,103 @@
+package hosts_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/trento-project/agent/internal/core/hosts"
+	"github.com/trento-project/agent/internal/core/hosts/systemd/mocks"
+)
+
+type HostTestSuite struct {
+	suite.Suite
+	dbusMock *mocks.MockDbusConnector
+}
+
+func TestHost(t *testing.T) {
+	suite.Run(t, new(HostTestSuite))
+}
+
+func (suite *HostTestSuite) SetupTest() {
+	suite.dbusMock = mocks.NewMockDbusConnector(suite.T())
+}
+
+func (suite *HostTestSuite) TestDefaultUnitInfo() {
+	result := hosts.DefaultUnitInfo()
+
+	expectedSystemdUnits := hosts.SystemdUnitsStatus{
+		"pacemaker.service": {
+			UnitFileState: "unknown",
+		},
+	}
+
+	suite.EqualValues(expectedSystemdUnits, result)
+}
+
+func (suite *HostTestSuite) TestDefaultUnitInfoWithCustomUnits() {
+	result := hosts.DefaultUnitInfo("pacemaker.service", "another.service")
+
+	expectedSystemdUnits := hosts.SystemdUnitsStatus{
+		"pacemaker.service": {UnitFileState: "unknown"},
+		"another.service":   {UnitFileState: "unknown"},
+	}
+
+	suite.EqualValues(expectedSystemdUnits, result)
+}
+
+func (suite *HostTestSuite) TestDefaultUnitInfoOnDbusConnectionError() {
+	ctx := context.Background()
+
+	// nil dbus mock simulates an error in creating the dbus connection
+	result := hosts.GetSystemdUnitsStatusWithCustomDbus(ctx, nil)
+
+	suite.EqualValues(hosts.DefaultUnitInfo(), result)
+}
+
+func (suite *HostTestSuite) TestUnableToGetProperties() {
+	ctx := context.Background()
+
+	getPropertiesCall := suite.dbusMock.
+		On("GetUnitPropertiesContext", ctx, "pacemaker.service").
+		Return(nil, fmt.Errorf("error getting properties"))
+	suite.dbusMock.On("Close").
+		Return().
+		Once().
+		NotBefore(getPropertiesCall)
+
+	result := hosts.GetSystemdUnitsStatusWithCustomDbus(ctx, suite.dbusMock)
+
+	suite.EqualValues(hosts.DefaultUnitInfo(), result)
+}
+
+func (suite *HostTestSuite) TestAbleToGetPartialUnitsInfo() {
+	ctx := context.Background()
+
+	units := []string{"pacemaker.service", "another.service", "yet.another.service"}
+
+	getPacemakerPropertiesCall := suite.dbusMock.
+		On("GetUnitPropertiesContext", ctx, "pacemaker.service").
+		Return(nil, fmt.Errorf("error getting properties"))
+	getAnotherServicePropertiesCall := suite.dbusMock.
+		On("GetUnitPropertiesContext", ctx, "another.service").
+		Return(map[string]any{"UnitFileState": "enabled"}, nil).
+		NotBefore(getPacemakerPropertiesCall)
+	getYetAnotherServicePropertiesCall := suite.dbusMock.
+		On("GetUnitPropertiesContext", ctx, "yet.another.service").
+		Return(map[string]any{"UnitFileState": "disabled"}, nil).
+		NotBefore(getAnotherServicePropertiesCall)
+	suite.dbusMock.On("Close").
+		Return().
+		Once().
+		NotBefore(getYetAnotherServicePropertiesCall)
+
+	result := hosts.GetSystemdUnitsStatusWithCustomDbus(ctx, suite.dbusMock, units...)
+
+	expectedSystemdUnits := hosts.SystemdUnitsStatus{
+		"pacemaker.service":   {UnitFileState: "unknown"},
+		"another.service":     {UnitFileState: "enabled"},
+		"yet.another.service": {UnitFileState: "disabled"},
+	}
+	suite.EqualValues(expectedSystemdUnits, result)
+}

--- a/internal/core/hosts/systemd/dbus.go
+++ b/internal/core/hosts/systemd/dbus.go
@@ -11,6 +11,10 @@ import (
 type DbusConnector interface {
 	GetUnitPropertiesContext(ctx context.Context, unit string) (map[string]any, error)
 	ListUnitsByNamesContext(ctx context.Context, units []string) ([]dbus.UnitStatus, error)
+	// NewWithContext establishes a connection to any available bus and authenticates.
+	// Callers should call Close() when done with the connection.
+	// see https://pkg.go.dev/github.com/coreos/go-systemd/v22@v22.5.0/dbus#NewWithContext
+	Close()
 }
 
 func NewDbusConnector(ctx context.Context) (DbusConnector, error) {

--- a/internal/core/hosts/systemd/mocks/mock_DbusConnector.go
+++ b/internal/core/hosts/systemd/mocks/mock_DbusConnector.go
@@ -22,6 +22,38 @@ func (_m *MockDbusConnector) EXPECT() *MockDbusConnector_Expecter {
 	return &MockDbusConnector_Expecter{mock: &_m.Mock}
 }
 
+// Close provides a mock function with given fields:
+func (_m *MockDbusConnector) Close() {
+	_m.Called()
+}
+
+// MockDbusConnector_Close_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Close'
+type MockDbusConnector_Close_Call struct {
+	*mock.Call
+}
+
+// Close is a helper method to define mock.On call
+func (_e *MockDbusConnector_Expecter) Close() *MockDbusConnector_Close_Call {
+	return &MockDbusConnector_Close_Call{Call: _e.mock.On("Close")}
+}
+
+func (_c *MockDbusConnector_Close_Call) Run(run func()) *MockDbusConnector_Close_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockDbusConnector_Close_Call) Return() *MockDbusConnector_Close_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *MockDbusConnector_Close_Call) RunAndReturn(run func()) *MockDbusConnector_Close_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetUnitPropertiesContext provides a mock function with given fields: ctx, unit
 func (_m *MockDbusConnector) GetUnitPropertiesContext(ctx context.Context, unit string) (map[string]interface{}, error) {
 	ret := _m.Called(ctx, unit)

--- a/internal/discovery/host.go
+++ b/internal/discovery/host.go
@@ -67,6 +67,8 @@ func (d HostDiscovery) Discover(ctx context.Context) (string, error) {
 
 	updatedPrometheusTargets := updatePrometheusTargets(d.prometheusTargets, ipAddresses)
 
+	systemdUnits := []string{"pacemaker.service"}
+
 	host := hosts.DiscoveredHost{
 		OSVersion:                getOSVersion(),
 		Architecture:             getArch(),
@@ -80,7 +82,7 @@ func (d HostDiscovery) Discover(ctx context.Context) (string, error) {
 		InstallationSource:       version.InstallationSource,
 		FullyQualifiedDomainName: getHostFQDN(),
 		PrometheusTargets:        updatedPrometheusTargets,
-		SystemdUnits:             hosts.GetSystemdUnitsStatus(ctx),
+		SystemdUnits:             hosts.GetSystemdUnitsStatus(ctx, systemdUnits),
 	}
 
 	err = d.collectorClient.Publish(ctx, d.id, host)

--- a/internal/discovery/host.go
+++ b/internal/discovery/host.go
@@ -80,6 +80,7 @@ func (d HostDiscovery) Discover(ctx context.Context) (string, error) {
 		InstallationSource:       version.InstallationSource,
 		FullyQualifiedDomainName: getHostFQDN(),
 		PrometheusTargets:        updatedPrometheusTargets,
+		SystemdUnits:             hosts.GetSystemdUnitsStatus(ctx),
 	}
 
 	err = d.collectorClient.Publish(ctx, d.id, host)

--- a/internal/discovery/mocks/discovered_host_mock.go
+++ b/internal/discovery/mocks/discovered_host_mock.go
@@ -22,14 +22,17 @@ func NewDiscoveredHostMock() hosts.DiscoveredHost {
 		PrometheusTargets: map[string]string{
 			"node_exporter": "10.1.1.4:9100",
 		},
-		SystemdUnits: hosts.SystemdUnitsStatus{
-			"pacemaker.service": hosts.UnitInfo{
+		SystemdUnits: []hosts.UnitInfo{
+			{
+				Name:          "pacemaker.service",
 				UnitFileState: "enabled",
 			},
-			"another.service": hosts.UnitInfo{
+			{
+				Name:          "another.service",
 				UnitFileState: "disabled",
 			},
-			"yet.another.service": hosts.UnitInfo{
+			{
+				Name:          "yet.another.service",
 				UnitFileState: "unknown",
 			},
 		},

--- a/internal/discovery/mocks/discovered_host_mock.go
+++ b/internal/discovery/mocks/discovered_host_mock.go
@@ -22,5 +22,16 @@ func NewDiscoveredHostMock() hosts.DiscoveredHost {
 		PrometheusTargets: map[string]string{
 			"node_exporter": "10.1.1.4:9100",
 		},
+		SystemdUnits: hosts.SystemdUnitsStatus{
+			"pacemaker.service": hosts.UnitInfo{
+				UnitFileState: "enabled",
+			},
+			"another.service": hosts.UnitInfo{
+				UnitFileState: "disabled",
+			},
+			"yet.another.service": hosts.UnitInfo{
+				UnitFileState: "unknown",
+			},
+		},
 	}
 }

--- a/test/fixtures/discovery/host/expected_published_host_discovery.json
+++ b/test/fixtures/discovery/host/expected_published_host_discovery.json
@@ -23,6 +23,17 @@
     "fully_qualified_domain_name": "com.example.trento.host",
     "prometheus_targets": {
       "node_exporter": "10.1.1.4:9100"
+    },
+    "systemd_units": {
+      "pacemaker.service": {
+        "unit_file_state": "enabled"
+      },
+      "another.service": {
+        "unit_file_state": "disabled"
+      },
+      "yet.another.service": {
+        "unit_file_state": "unknown"
+      }
     }
   }
 }

--- a/test/fixtures/discovery/host/expected_published_host_discovery.json
+++ b/test/fixtures/discovery/host/expected_published_host_discovery.json
@@ -24,16 +24,19 @@
     "prometheus_targets": {
       "node_exporter": "10.1.1.4:9100"
     },
-    "systemd_units": {
-      "pacemaker.service": {
+    "systemd_units": [
+      {
+        "name": "pacemaker.service",
         "unit_file_state": "enabled"
       },
-      "another.service": {
+      {
+        "name": "another.service",
         "unit_file_state": "disabled"
       },
-      "yet.another.service": {
+      {
+        "name": "yet.another.service",
         "unit_file_state": "unknown"
       }
-    }
+    ]
   }
 }


### PR DESCRIPTION
# Description

This PR enhances the host discovery by adding relevant information about relevant systemd units.

As of now it only returns whether the unit file is enabled/disabled at boot and only `pacemaker.service` is among the relevant units.

I considered the alternative to return a list like
```json
"enabled_services":["foo.service", "bar.service"]
```
but that turns out to be quite limited and quite soon because:
- we might need some other information besides the file status
- not being in `enabled_services` list would not necessarily mean being disabled - ie we might not have been able to determine whether it is enabled or not

That said the proposed shape turns out being more flexible and future-proof.

Another consideration: I couldn't find any function that allows us to retrieve the needed information for a list of units [see doc](https://pkg.go.dev/github.com/coreos/go-systemd/v22/dbus), that's why we do it in a loop.
I didn't want to add concurrent systemd calls for a list of 1 element now 😅 If the list of the relevant units grows substantially we can consider doing the extraction concurrently.

Next:
- handle in web in a backward compatible manner (?)
- show the information somewhere in the ui
- use the new information to allow/disallow relevant operations

## How was this tested?

Automatic tests.