### PR TITLE
Add managed field to crm_mon group

### DIFF
--- a/internal/core/cluster/crmmon/data.go
+++ b/internal/core/cluster/crmmon/data.go
@@ -2,6 +2,10 @@ package crmmon
 
 // *** crm_mon XML unserialization structures
 
+import (
+	"encoding/xml"
+)
+
 type Root struct {
 	Version string `xml:"version,attr"`
 	Summary struct {
@@ -91,5 +95,19 @@ type Clone struct {
 
 type Group struct {
 	ID        string     `xml:"id,attr" json:"Id"`
+	Managed   bool       `xml:"managed,attr"`
 	Resources []Resource `xml:"resource"`
+}
+
+// UnmarshalXML of Group to set Managed field default value to true
+func (g *Group) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	type resultGroup Group // new type to prevent recursion
+	item := resultGroup{
+		Managed: true,
+	}
+	if err := d.DecodeElement(&item, &start); err != nil {
+		return err
+	}
+	*g = (Group)(item)
+	return nil
 }

--- a/internal/core/cluster/crmmon/parser_test.go
+++ b/internal/core/cluster/crmmon/parser_test.go
@@ -81,12 +81,14 @@ func (suite *ParserTestSuite) TestParseGroups() {
 	suite.Equal(2, len(data.Groups))
 
 	suite.Equal("grp_HA1_ASCS00", data.Groups[0].ID)
+	suite.Equal(false, data.Groups[0].Managed)
 	suite.Equal(3, len(data.Groups[0].Resources))
 	suite.Equal("rsc_ip_HA1_ASCS00", data.Groups[0].Resources[0].ID)
 	suite.Equal("rsc_fs_HA1_ASCS00", data.Groups[0].Resources[1].ID)
 	suite.Equal("rsc_sap_HA1_ASCS00", data.Groups[0].Resources[2].ID)
 
 	suite.Equal("grp_HA1_ERS10", data.Groups[1].ID)
+	suite.Equal(true, data.Groups[1].Managed)
 	suite.Equal(3, len(data.Groups[1].Resources))
 	suite.Equal("rsc_ip_HA1_ERS10", data.Groups[1].Resources[0].ID)
 	suite.Equal("rsc_fs_HA1_ERS10", data.Groups[1].Resources[1].ID)

--- a/test/fixtures/discovery/cluster/expected_published_cluster_discovery.json
+++ b/test/fixtures/discovery/cluster/expected_published_cluster_discovery.json
@@ -850,6 +850,7 @@
       "Groups": [
         {
           "Id": "grp_HA1_ASCS00",
+          "Managed": false,
           "Resources": [
             {
               "Id": "rsc_ip_HA1_ASCS00",
@@ -906,6 +907,7 @@
         },
         {
           "Id": "grp_HA1_ERS10",
+          "Managed": true,
           "Resources": [
             {
               "Id": "rsc_ip_HA1_ERS10",

--- a/test/fixtures/discovery/cluster/fake_crm_mon.sh
+++ b/test/fixtures/discovery/cluster/fake_crm_mon.sh
@@ -53,7 +53,7 @@ cat <<EOF
             <resource id="clusterfs" resource_agent="ocf::heartbeat:Filesystem" role="Stopped" active="false" orphaned="false" blocked="false" managed="true" failed="false" failure_ignored="false" nodes_running_on="0"/>
             <resource id="clusterfs" resource_agent="ocf::heartbeat:Filesystem" role="Stopped" active="false" orphaned="false" blocked="false" managed="true" failed="false" failure_ignored="false" nodes_running_on="0"/>
         </clone>
-        <group id="grp_HA1_ASCS00" number_resources="3" >
+        <group id="grp_HA1_ASCS00" number_resources="3" managed="false" >
              <resource id="rsc_ip_HA1_ASCS00" resource_agent="ocf::heartbeat:IPaddr2" role="Started" active="true" orphaned="false" blocked="false" managed="true" failed="false" failure_ignored="false" nodes_running_on="1" >
                  <node name="node01" id="1084783375" cached="false"/>
              </resource>


### PR DESCRIPTION
# Description

It turns out that `crm_mon` group output *can* have the `managed` field.
Even though it is not mandatory. Apparently it is added once the group maintenance value is changed the first time.
Either way, if the field doesn't exist, `managed` value is true (it is not in maintenance).

This PR sends the value so we can use it in the frontend to show the value and decide to which new value to change during maintenance change operation.

We need to do the `Unmarshall` function as otherwise the default value is `false`, but in our particular case, we need to have true. Some refs: https://pkg.go.dev/encoding/xml#Unmarshal

@abravosuse just for your awareness. This will improve the usage of the resource maintenance change for "group" resources

## How was this tested?

UT
