### PR TITLE
Use latest version of endorama/asdf-parse-tool-versions to avoid using deprecated set-output command in gh actions.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Read .tool-versions
-        uses: endorama/asdf-parse-tool-versions@v1
+        uses: endorama/asdf-parse-tool-versions@v1.3.4
         id: tool-versions
       - uses: actions/setup-go@v5
         with:
@@ -58,7 +58,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Read .tool-versions
-        uses: endorama/asdf-parse-tool-versions@v1
+        uses: endorama/asdf-parse-tool-versions@v1.3.4
         id: tool-versions
       - uses: actions/setup-go@v5
         with:
@@ -95,7 +95,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Read .tool-versions
-        uses: endorama/asdf-parse-tool-versions@v1
+        uses: endorama/asdf-parse-tool-versions@v1.3.4
         id: tool-versions
       - uses: actions/setup-go@v5
         with:

--- a/.github/workflows/obs.yaml
+++ b/.github/workflows/obs.yaml
@@ -39,7 +39,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Read .tool-versions
-        uses: endorama/asdf-parse-tool-versions@v1
+        uses: endorama/asdf-parse-tool-versions@v1.3.4
         id: tool-versions
       - uses: actions/setup-go@v5
         with:


### PR DESCRIPTION
# Description

Use latest version of endorama/asdf-parse-tool-versions to avoid using deprecated set-output command in gh actions.

Fixes # (issue)
https://jira.suse.com/browse/TRNT-3819
## Did you add the right label?

Remember to add the right labels to this PR.

- [ ] **DONE**

## How was this tested?

Describe the tests that have been added/changed for this new behavior.

- [ ] **DONE**

## Did you update the documentation?

Remember to ask yourself if your PR requires changes to the following documentation:

- [Manual installation guide](https://github.com/trento-project/docs/blob/main/guides/manual-installation.md)
- [Trento Ansible guide](https://github.com/trento-project/ansible/blob/main/README.md)
- [Trento Agent guides](https://github.com/trento-project/agent/tree/main/docs)

Add a documentation PR or write that no changes are required for the documentation.

- [ ] **DONE**
