### PR TITLE
Discovery cluster offline host

### DIFF
--- a/internal/core/cluster/cluster.go
+++ b/internal/core/cluster/cluster.go
@@ -130,7 +130,6 @@ func isHostOnline(discoveryTools *DiscoveryTools) bool {
 	}
 
 	return true
-
 }
 
 func makeOfflineHostPayload(detectedCluster BasicInfo) (*Cluster, error) {

--- a/internal/core/cluster/cluster.go
+++ b/internal/core/cluster/cluster.go
@@ -144,7 +144,7 @@ func isHostOnline(discoveryTools *DiscoveryTools) bool {
 
 }
 
-func makeOfflineHostPayload(detectedCluster ClusterBase) (*Cluster, error) {
+func makeOfflineHostPayload(detectedCluster BasicInfo) (*Cluster, error) {
 	return &Cluster{
 		ID:     detectedCluster.ID,
 		Name:   detectedCluster.Name,

--- a/internal/core/cluster/cluster.go
+++ b/internal/core/cluster/cluster.go
@@ -72,6 +72,10 @@ func NewCluster() (*Cluster, error) {
 }
 
 func NewClusterWithDiscoveryTools(discoveryTools *DiscoveryTools) (*Cluster, error) {
+	return makeOnlineHostPayload(discoveryTools)
+}
+
+func makeOnlineHostPayload(discoveryTools *DiscoveryTools) (*Cluster, error) {
 	cibParser := cib.NewCibAdminParser(discoveryTools.CibAdmPath)
 
 	cibConfig, err := cibParser.Parse()

--- a/internal/core/cluster/cluster.go
+++ b/internal/core/cluster/cluster.go
@@ -152,7 +152,7 @@ func makeOfflineHostPayload(detectedCluster BasicInfo) (*Cluster, error) {
 	}, nil
 }
 
-func makeOnlineHostPayload(detectedCluster ClusterBase, discoveryTools *DiscoveryTools) (*Cluster, error) {
+func makeOnlineHostPayload(detectedCluster BasicInfo, discoveryTools *DiscoveryTools) (*Cluster, error) {
 	cibParser := cib.NewCibAdminParser(discoveryTools.CibAdmPath)
 
 	cibConfig, err := cibParser.Parse()

--- a/internal/core/cluster/cluster.go
+++ b/internal/core/cluster/cluster.go
@@ -98,8 +98,8 @@ func NewClusterWithDiscoveryTools(discoveryTools *DiscoveryTools) (*Cluster, err
 	}
 
 	if !isOnline {
-		return makeOfflineHostPayload(detectedCluster)
-	}
+func detectCluster(discoveryTools *DiscoveryTools) (BasicInfo, bool, error) {
+	noCluster := BasicInfo{}
 	return makeOnlineHostPayload(detectedCluster, discoveryTools)
 }
 

--- a/internal/core/cluster/cluster.go
+++ b/internal/core/cluster/cluster.go
@@ -113,7 +113,7 @@ func detectCluster(discoveryTools *DiscoveryTools) (ClusterBase, bool, error) {
 		if _, err := os.Stat(filepath); os.IsNotExist(err) {
 			return noCluster, false, nil
 		} else if err != nil {
-			return noCluster, err, false
+			return noCluster, false, err
 		}
 	}
 

--- a/internal/core/cluster/cluster.go
+++ b/internal/core/cluster/cluster.go
@@ -111,7 +111,7 @@ func detectCluster(discoveryTools *DiscoveryTools) (ClusterBase, bool, error) {
 		discoveryTools.CorosyncConfigPath} {
 
 		if _, err := os.Stat(filepath); os.IsNotExist(err) {
-			return noCluster, nil, false
+			return noCluster, false, nil
 		} else if err != nil {
 			return noCluster, err, false
 		}

--- a/internal/core/cluster/cluster.go
+++ b/internal/core/cluster/cluster.go
@@ -50,7 +50,7 @@ type Cluster struct {
 	Cib      cib.Root
 	Crmmon   crmmon.Root
 	ID       string `json:"Id"`
-	Name     string
+	Name     string `json:"Name,omitempty"`
 	SBD      SBD
 	DC       bool
 	Provider string
@@ -108,7 +108,7 @@ func detectCluster(discoveryTools *DiscoveryTools) (BasicInfo, bool, error) {
 
 	name, err := getCorosyncClusterName(discoveryTools.CorosyncConfigPath)
 	if err != nil {
-		return noCluster, false, err
+		return noCluster, false, fmt.Errorf("error getting corosync cluster name: %w", err)
 	}
 
 	return BasicInfo{
@@ -204,7 +204,7 @@ func getCorosyncClusterName(corosyncConfigPath string) (string, error) {
 	name, ok := corosyncConf.Totem["cluster_name"].(string)
 
 	if !ok {
-		return "", fmt.Errorf("cluster_name not found or not a string in corosync.conf")
+		return "", nil
 	}
 	return name, nil
 }

--- a/internal/core/cluster/cluster.go
+++ b/internal/core/cluster/cluster.go
@@ -136,7 +136,7 @@ func isHostOnline(discoveryTools *DiscoveryTools) bool {
 		active := systemctl.IsActive(service)
 		if !active {
 			slog.Warn("Service is not active", "service", service)
-			return false, nil
+			return false
 		}
 	}
 

--- a/internal/core/cluster/cluster.go
+++ b/internal/core/cluster/cluster.go
@@ -117,7 +117,7 @@ func detectCluster(discoveryTools *DiscoveryTools) (ClusterBase, bool, error) {
 		return noCluster, false, err
 	}
 
-	return BasicInfo{
+	name, err := getCorosyncClusterName(discoveryTools.CorosyncConfigPath)
 	if err != nil {
 		return noCluster, false, err
 	}

--- a/internal/core/cluster/cluster.go
+++ b/internal/core/cluster/cluster.go
@@ -98,8 +98,8 @@ func NewClusterWithDiscoveryTools(discoveryTools *DiscoveryTools) (*Cluster, err
 	return makeOnlineHostPayload(detectedCluster, discoveryTools)
 }
 
-func detectCluster(discoveryTools *DiscoveryTools) (ClusterBase, bool, error) {
-	noCluster := ClusterBase{}
+func detectCluster(discoveryTools *DiscoveryTools) (BasicInfo, bool, error) {
+	noCluster := BasicInfo{}
 
 	for _, filepath := range []string{
 		discoveryTools.CorosyncKeyPath,
@@ -122,7 +122,7 @@ func detectCluster(discoveryTools *DiscoveryTools) (ClusterBase, bool, error) {
 		return noCluster, false, err
 	}
 
-	return ClusterBase{
+	return BasicInfo{
 		ID:   id,
 		Name: name,
 	}, true, nil

--- a/internal/core/cluster/cluster.go
+++ b/internal/core/cluster/cluster.go
@@ -84,7 +84,7 @@ func NewCluster() (*Cluster, error) {
 }
 
 func NewClusterWithDiscoveryTools(discoveryTools *DiscoveryTools) (*Cluster, error) {
-	detectedCluster, err, found := detectCluster(discoveryTools)
+	detectedCluster, found, err := detectCluster(discoveryTools)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/core/cluster/cluster.go
+++ b/internal/core/cluster/cluster.go
@@ -129,7 +129,7 @@ func detectCluster(discoveryTools *DiscoveryTools) (ClusterBase, bool, error) {
 
 }
 
-func isHostOnline(discoveryTools *DiscoveryTools) (bool, error) {
+func isHostOnline(discoveryTools *DiscoveryTools) bool {
 	systemctl := systemctl.NewSystemctl(discoveryTools.CommandExecutor)
 
 	for _, service := range []string{"corosync", "pacemaker"} {

--- a/internal/core/cluster/cluster.go
+++ b/internal/core/cluster/cluster.go
@@ -122,7 +122,7 @@ func detectCluster(discoveryTools *DiscoveryTools) (ClusterBase, bool, error) {
 		return noCluster, false, err
 	}
 
-	name, err := getCorosyncClusterName(discoveryTools.CorosyncConfigPath)
+	return BasicInfo{
 	if err != nil {
 		return noCluster, false, err
 	}

--- a/internal/core/cluster/cluster.go
+++ b/internal/core/cluster/cluster.go
@@ -103,7 +103,7 @@ func NewClusterWithDiscoveryTools(discoveryTools *DiscoveryTools) (*Cluster, err
 	return makeOnlineHostPayload(detectedCluster, discoveryTools)
 }
 
-func detectCluster(discoveryTools *DiscoveryTools) (ClusterBase, error, bool) {
+func detectCluster(discoveryTools *DiscoveryTools) (ClusterBase, bool, error) {
 	noCluster := ClusterBase{}
 
 	for _, filepath := range []string{

--- a/internal/core/cluster/cluster.go
+++ b/internal/core/cluster/cluster.go
@@ -41,7 +41,7 @@ type DiscoveryTools struct {
 	CommandExecutor    utils.CommandExecutor
 }
 
-type ClusterBase struct {
+type BasicInfo struct {
 	ID   string
 	Name string
 }

--- a/internal/core/cluster/cluster.go
+++ b/internal/core/cluster/cluster.go
@@ -119,7 +119,7 @@ func detectCluster(discoveryTools *DiscoveryTools) (ClusterBase, bool, error) {
 
 	id, err := getCorosyncAuthkeyMd5(discoveryTools.CorosyncKeyPath)
 	if err != nil {
-		return noCluster, err, false
+		return noCluster, false, err
 	}
 
 	name, err := getCorosyncClusterName(discoveryTools.CorosyncConfigPath)

--- a/internal/core/cluster/cluster.go
+++ b/internal/core/cluster/cluster.go
@@ -124,7 +124,7 @@ func detectCluster(discoveryTools *DiscoveryTools) (ClusterBase, bool, error) {
 
 	name, err := getCorosyncClusterName(discoveryTools.CorosyncConfigPath)
 	if err != nil {
-		return noCluster, err, false
+		return noCluster, false, err
 	}
 
 	return ClusterBase{

--- a/internal/core/cluster/cluster.go
+++ b/internal/core/cluster/cluster.go
@@ -86,10 +86,10 @@ func NewCluster() (*Cluster, error) {
 func NewClusterWithDiscoveryTools(discoveryTools *DiscoveryTools) (*Cluster, error) {
 	detectedCluster, found, err := detectCluster(discoveryTools)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error detecting cluster: %w", err)
 	}
 	if !found {
-		return nil, nil
+		return nil, fmt.Errorf("no cluster detected")
 	}
 
 	if !isHostOnline(discoveryTools) {

--- a/internal/core/cluster/cluster.go
+++ b/internal/core/cluster/cluster.go
@@ -93,8 +93,8 @@ func NewClusterWithDiscoveryTools(discoveryTools *DiscoveryTools) (*Cluster, err
 	}
 
 	if !isHostOnline(discoveryTools) {
-func detectCluster(discoveryTools *DiscoveryTools) (BasicInfo, bool, error) {
-	noCluster := BasicInfo{}
+		return makeOfflineHostPayload(detectedCluster)
+	}
 	return makeOnlineHostPayload(detectedCluster, discoveryTools)
 }
 

--- a/internal/core/cluster/cluster.go
+++ b/internal/core/cluster/cluster.go
@@ -130,7 +130,7 @@ func detectCluster(discoveryTools *DiscoveryTools) (ClusterBase, bool, error) {
 	return ClusterBase{
 		ID:   id,
 		Name: name,
-	}, nil, true
+	}, true, nil
 
 }
 

--- a/internal/core/cluster/cluster.go
+++ b/internal/core/cluster/cluster.go
@@ -140,7 +140,7 @@ func isHostOnline(discoveryTools *DiscoveryTools) bool {
 		}
 	}
 
-	return true, nil
+	return true
 
 }
 

--- a/internal/core/cluster/cluster.go
+++ b/internal/core/cluster/cluster.go
@@ -92,12 +92,7 @@ func NewClusterWithDiscoveryTools(discoveryTools *DiscoveryTools) (*Cluster, err
 		return nil, nil
 	}
 
-	isOnline, err := isHostOnline(discoveryTools)
-	if err != nil {
-		return nil, fmt.Errorf("error checking if host is online: %w", err)
-	}
-
-	if !isOnline {
+	if !isHostOnline(discoveryTools) {
 func detectCluster(discoveryTools *DiscoveryTools) (BasicInfo, bool, error) {
 	noCluster := BasicInfo{}
 	return makeOnlineHostPayload(detectedCluster, discoveryTools)

--- a/internal/core/cluster/cluster.go
+++ b/internal/core/cluster/cluster.go
@@ -101,17 +101,6 @@ func NewClusterWithDiscoveryTools(discoveryTools *DiscoveryTools) (*Cluster, err
 func detectCluster(discoveryTools *DiscoveryTools) (BasicInfo, bool, error) {
 	noCluster := BasicInfo{}
 
-	for _, filepath := range []string{
-		discoveryTools.CorosyncKeyPath,
-		discoveryTools.CorosyncConfigPath} {
-
-		if _, err := os.Stat(filepath); os.IsNotExist(err) {
-			return noCluster, false, nil
-		} else if err != nil {
-			return noCluster, false, err
-		}
-	}
-
 	id, err := getCorosyncAuthkeyMd5(discoveryTools.CorosyncKeyPath)
 	if err != nil {
 		return noCluster, false, err

--- a/internal/core/cluster/cluster_test.go
+++ b/internal/core/cluster/cluster_test.go
@@ -123,7 +123,7 @@ func (suite *ClusterTestSuite) TestNewClusterCorosyncNotConfigured() {
 	})
 
 	suite.Nil(c)
-	suite.NoError(err)
+	suite.Error(err)
 
 }
 
@@ -141,7 +141,7 @@ func (suite *ClusterTestSuite) TestNewClusterCorosyncNoAuthkeyConfigured() {
 	})
 
 	suite.Nil(c)
-	suite.NoError(err)
+	suite.Error(err)
 }
 
 func (suite *ClusterTestSuite) TestIsDC() {

--- a/internal/core/cluster/cluster_test.go
+++ b/internal/core/cluster/cluster_test.go
@@ -82,6 +82,7 @@ func (suite *ClusterTestSuite) TestNewClusterDisklessSBD() {
 	suite.NoError(err)
 }
 
+//nolint:dupl
 func (suite *ClusterTestSuite) TestNewClusterWithOfflineHost() {
 	mockCommand := new(mocks.MockCommandExecutor)
 	mockCommand.On("Exec", "/usr/sbin/dmidecode", "-s", "chassis-asset-tag").
@@ -109,6 +110,7 @@ func (suite *ClusterTestSuite) TestNewClusterWithOfflineHost() {
 	suite.NoError(err)
 }
 
+//nolint:dupl
 func (suite *ClusterTestSuite) TestNewClusterWithOfflineHostNoName() {
 	mockCommand := new(mocks.MockCommandExecutor)
 	mockCommand.On("Exec", "/usr/sbin/dmidecode", "-s", "chassis-asset-tag").

--- a/internal/core/cluster/corosync/parser.go
+++ b/internal/core/cluster/corosync/parser.go
@@ -27,7 +27,7 @@ func (c *Parser) Parse() (Conf, error) {
 	defer f.Close()
 
 	scanner := bufio.NewScanner(f)
-	config := parseCorisyncConf(scanner)
+	config := parseCorosyncConf(scanner)
 
 	if err := scanner.Err(); err != nil {
 		return Conf{}, fmt.Errorf("error reading corosync.conf: %w", err)
@@ -41,7 +41,7 @@ func NewCorosyncParser(configPath string) *Parser {
 	return &Parser{configPath: configPath}
 }
 
-func parseCorisyncConf(scanner *bufio.Scanner) map[string]interface{} {
+func parseCorosyncConf(scanner *bufio.Scanner) map[string]interface{} {
 	root := make(map[string]interface{})
 	stack := []map[string]interface{}{root}
 	for scanner.Scan() {

--- a/internal/core/cluster/corosync/parser.go
+++ b/internal/core/cluster/corosync/parser.go
@@ -1,0 +1,87 @@
+package corosync
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+)
+
+type Parser struct {
+	configPath string
+}
+
+type CorosyncConf struct {
+	Totem    map[string]interface{} `json:"totem"`
+	Logging  map[string]interface{} `json:"logging"`
+	Quorum   map[string]interface{} `json:"quorum"`
+	Nodelist map[string]interface{} `json:"nodelist"`
+}
+
+func (c *Parser) Parse() (CorosyncConf, error) {
+	f, err := os.Open(c.configPath)
+	if err != nil {
+		return CorosyncConf{}, fmt.Errorf("error opening corosync.conf: %w", err)
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	config := parseSection(scanner)
+
+	if err := scanner.Err(); err != nil {
+		return CorosyncConf{}, fmt.Errorf("error reading corosync.conf: %w", err)
+	}
+
+	return mapToCorosyncConf(config)
+
+}
+
+func NewCorosyncParser(configPath string) *Parser {
+	return &Parser{configPath: configPath}
+}
+
+// Recursively parses a section.
+func parseSection(scanner *bufio.Scanner) map[string]interface{} {
+	config := make(map[string]interface{})
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		// skip comments and empty lines
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		// end of section
+		if line == "}" {
+			break
+		}
+
+		// if line ends with '{', it's a nested section
+		// otherwise, it's a key-value pair
+		if strings.HasSuffix(line, "{") {
+			key := strings.TrimSpace(line[:len(line)-1])
+			config[key] = parseSection(scanner)
+		} else if sep := strings.Index(line, ":"); sep > -1 {
+			key := strings.TrimSpace(line[:sep])
+			value := strings.TrimSpace(line[sep+1:])
+			config[key] = value
+		}
+	}
+
+	return config
+}
+
+func mapToCorosyncConf(data map[string]interface{}) (CorosyncConf, error) {
+
+	b, err := json.Marshal(data)
+	if err != nil {
+		return CorosyncConf{}, fmt.Errorf("error marshalling map to JSON: %w", err)
+	}
+
+	var result CorosyncConf
+	if err := json.Unmarshal(b, &result); err != nil {
+		return CorosyncConf{}, fmt.Errorf("error unmarshalling JSON to struct: %w", err)
+	}
+
+	return result, nil
+
+}

--- a/internal/core/cluster/corosync/parser.go
+++ b/internal/core/cluster/corosync/parser.go
@@ -12,17 +12,17 @@ type Parser struct {
 	configPath string
 }
 
-type CorosyncConf struct {
+type Conf struct {
 	Totem    map[string]interface{} `json:"totem"`
 	Logging  map[string]interface{} `json:"logging"`
 	Quorum   map[string]interface{} `json:"quorum"`
 	Nodelist map[string]interface{} `json:"nodelist"`
 }
 
-func (c *Parser) Parse() (CorosyncConf, error) {
+func (c *Parser) Parse() (Conf, error) {
 	f, err := os.Open(c.configPath)
 	if err != nil {
-		return CorosyncConf{}, fmt.Errorf("error opening corosync.conf: %w", err)
+		return Conf{}, fmt.Errorf("error opening corosync.conf: %w", err)
 	}
 	defer f.Close()
 
@@ -30,7 +30,7 @@ func (c *Parser) Parse() (CorosyncConf, error) {
 	config := parseSection(scanner)
 
 	if err := scanner.Err(); err != nil {
-		return CorosyncConf{}, fmt.Errorf("error reading corosync.conf: %w", err)
+		return Conf{}, fmt.Errorf("error reading corosync.conf: %w", err)
 	}
 
 	return mapToCorosyncConf(config)
@@ -70,16 +70,16 @@ func parseSection(scanner *bufio.Scanner) map[string]interface{} {
 	return config
 }
 
-func mapToCorosyncConf(data map[string]interface{}) (CorosyncConf, error) {
+func mapToCorosyncConf(data map[string]interface{}) (Conf, error) {
 
 	b, err := json.Marshal(data)
 	if err != nil {
-		return CorosyncConf{}, fmt.Errorf("error marshalling map to JSON: %w", err)
+		return Conf{}, fmt.Errorf("error marshalling map to JSON: %w", err)
 	}
 
-	var result CorosyncConf
+	var result Conf
 	if err := json.Unmarshal(b, &result); err != nil {
-		return CorosyncConf{}, fmt.Errorf("error unmarshalling JSON to struct: %w", err)
+		return Conf{}, fmt.Errorf("error unmarshalling JSON to struct: %w", err)
 	}
 
 	return result, nil

--- a/internal/core/cluster/corosync/parser_test.go
+++ b/internal/core/cluster/corosync/parser_test.go
@@ -31,3 +31,24 @@ func (suite *ParserTestSuite) TestFailingParse() {
 	_, err := p.Parse()
 	suite.Error(err)
 }
+
+func (suite *ParserTestSuite) TestParseBrokenFile() {
+	file := helpers.GetFixturePath("discovery/cluster/corosync_broken.conf")
+
+	p := corosync.NewCorosyncParser(file)
+	data, err := p.Parse()
+	suite.NoError(err)
+	suite.Equal("hana_cluster", data.Totem["cluster_name"])
+}
+
+func (suite *ParserTestSuite) TestParseEmptyFile() {
+	file := helpers.GetFixturePath("discovery/cluster/corosync_empty.conf")
+
+	p := corosync.NewCorosyncParser(file)
+	data, err := p.Parse()
+	suite.NoError(err)
+	suite.Empty(data.Totem)
+	suite.Empty(data.Logging)
+	suite.Empty(data.Quorum)
+	suite.Empty(data.Nodelist)
+}

--- a/internal/core/cluster/corosync/parser_test.go
+++ b/internal/core/cluster/corosync/parser_test.go
@@ -23,3 +23,11 @@ func (suite *ParserTestSuite) TestParse() {
 	suite.NoError(err)
 	suite.Equal("hana_cluster", data.Totem["cluster_name"])
 }
+
+func (suite *ParserTestSuite) TestFailingParse() {
+	file := helpers.GetFixturePath("NOT_EXISTING_FILE")
+
+	p := corosync.NewCorosyncParser(file)
+	_, err := p.Parse()
+	suite.Error(err)
+}

--- a/internal/core/cluster/corosync/parser_test.go
+++ b/internal/core/cluster/corosync/parser_test.go
@@ -1,0 +1,25 @@
+package corosync_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/trento-project/agent/internal/core/cluster/corosync"
+	"github.com/trento-project/agent/test/helpers"
+)
+
+type ParserTestSuite struct {
+	suite.Suite
+}
+
+func TestParserTestSuite(t *testing.T) {
+	suite.Run(t, new(ParserTestSuite))
+}
+func (suite *ParserTestSuite) TestParse() {
+	file := helpers.GetFixturePath("discovery/cluster/corosync.conf")
+
+	p := corosync.NewCorosyncParser(file)
+	data, err := p.Parse()
+	suite.NoError(err)
+	suite.Equal("hana_cluster", data.Totem["cluster_name"])
+}

--- a/internal/core/cluster/systemctl/systemctl.go
+++ b/internal/core/cluster/systemctl/systemctl.go
@@ -1,0 +1,21 @@
+package systemctl
+
+import (
+	"github.com/trento-project/agent/pkg/utils"
+)
+
+type Systemctl struct {
+	CommandExecutor utils.CommandExecutor
+}
+
+func NewSystemctl(commandExecutor utils.CommandExecutor) *Systemctl {
+	return &Systemctl{
+		CommandExecutor: commandExecutor,
+	}
+}
+
+func (s *Systemctl) IsActive(serviceName string) bool {
+	_, err := s.CommandExecutor.Exec("systemctl", "is-active", serviceName)
+	// If the service is active, the command returns 0 exit code.
+	return err == nil
+}

--- a/internal/core/cluster/systemctl/systemctl_test.go
+++ b/internal/core/cluster/systemctl/systemctl_test.go
@@ -1,0 +1,38 @@
+package systemctl_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/trento-project/agent/internal/core/cluster/systemctl"
+	"github.com/trento-project/agent/pkg/utils/mocks"
+)
+
+type SystemctlTestSuite struct {
+	suite.Suite
+}
+
+func TestSystemctlTestSuite(t *testing.T) {
+	suite.Run(t, new(SystemctlTestSuite))
+}
+
+func (suite *SystemctlTestSuite) TestIsActive() {
+	mockCommand := new(mocks.MockCommandExecutor)
+	mockCommand.On("Exec", "systemctl", "is-active", "test-service").Return([]byte("active"), nil)
+
+	systemctl := systemctl.NewSystemctl(mockCommand)
+	active := systemctl.IsActive("test-service")
+
+	suite.True(active)
+}
+
+func (suite *SystemctlTestSuite) TestIsNotActive() {
+	mockCommand := new(mocks.MockCommandExecutor)
+	mockCommand.On("Exec", "systemctl", "is-active", "test-service").Return([]byte("inactive"), errors.New(""))
+
+	systemctl := systemctl.NewSystemctl(mockCommand)
+	active := systemctl.IsActive("test-service")
+
+	suite.False(active)
+}

--- a/internal/discovery/mocks/discovered_cluster_mock.go
+++ b/internal/discovery/mocks/discovered_cluster_mock.go
@@ -37,12 +37,13 @@ func NewDiscoveredClusterMock() *cluster.Cluster {
 	mockCommand.On("Exec", "/usr/sbin/sbd", "-d", "/dev/vdc", "list").Return(mockSbdList(), nil)
 
 	cluster, _ := cluster.NewClusterWithDiscoveryTools(&cluster.DiscoveryTools{
-		CibAdmPath:      helpers.GetFixturePath("discovery/cluster/fake_cibadmin.sh"),
-		CrmmonAdmPath:   helpers.GetFixturePath("discovery/cluster/fake_crm_mon.sh"),
-		CorosyncKeyPath: helpers.GetFixturePath("discovery/cluster/authkey"),
-		SBDPath:         "/usr/sbin/sbd",
-		SBDConfigPath:   helpers.GetFixturePath("discovery/cluster/sbd/sbd_config"),
-		CommandExecutor: mockCommand,
+		CibAdmPath:         helpers.GetFixturePath("discovery/cluster/fake_cibadmin.sh"),
+		CrmmonAdmPath:      helpers.GetFixturePath("discovery/cluster/fake_crm_mon.sh"),
+		CorosyncKeyPath:    helpers.GetFixturePath("discovery/cluster/authkey"),
+		CorosyncConfigPath: helpers.GetFixturePath("discovery/cluster/corosync.conf"),
+		SBDPath:            "/usr/sbin/sbd",
+		SBDConfigPath:      helpers.GetFixturePath("discovery/cluster/sbd/sbd_config"),
+		CommandExecutor:    mockCommand,
 	})
 
 	cluster.Provider = cloud.Azure

--- a/internal/discovery/mocks/discovered_cluster_mock.go
+++ b/internal/discovery/mocks/discovered_cluster_mock.go
@@ -35,6 +35,8 @@ func NewDiscoveredClusterMock() *cluster.Cluster {
 	mockCommand.On("Exec", "/usr/sbin/sbd", "-d", "/dev/vdb", "list").Return(mockSbdList(), nil)
 	mockCommand.On("Exec", "/usr/sbin/sbd", "-d", "/dev/vdc", "dump").Return(mockSbdDump(), nil)
 	mockCommand.On("Exec", "/usr/sbin/sbd", "-d", "/dev/vdc", "list").Return(mockSbdList(), nil)
+	mockCommand.On("Exec", "systemctl", "is-active", "corosync").Return([]byte("active"), nil)
+	mockCommand.On("Exec", "systemctl", "is-active", "pacemaker").Return([]byte("active"), nil)
 
 	cluster, _ := cluster.NewClusterWithDiscoveryTools(&cluster.DiscoveryTools{
 		CibAdmPath:         helpers.GetFixturePath("discovery/cluster/fake_cibadmin.sh"),

--- a/test/fixtures/discovery/cluster/corosync.conf
+++ b/test/fixtures/discovery/cluster/corosync.conf
@@ -1,0 +1,54 @@
+totem {
+        version: 2
+        cluster_name: hana_cluster
+        clear_node_high_bit: yes
+        interface {
+                ringnumber: 0
+                mcastport: 5405
+                ttl: 1
+        }
+
+        transport: udpu
+        crypto_hash: sha1
+        crypto_cipher: aes256
+        token: 30000
+        join: 60
+        max_messages: 20
+        token_retransmits_before_loss_const: 6
+        consensus: 36000
+        secauth: on
+}
+
+logging {
+        fileline: off
+        to_stderr: no
+        to_logfile: no
+        logfile: /var/log/cluster/corosync.log
+        to_syslog: yes
+        debug: off
+        timestamp: on
+        logger_subsys {
+                subsys: QUORUM
+                debug: off
+        }
+
+}
+
+nodelist {
+        node {
+                ring0_addr: 10.0.1.10
+                nodeid: 1
+        }
+
+        node {
+                ring0_addr: 10.0.2.11
+                nodeid: 2
+        }
+
+}
+
+quorum {
+        provider: corosync_votequorum
+        expected_votes: 2
+        two_node: 1
+}

--- a/test/fixtures/discovery/cluster/corosync_broken.conf
+++ b/test/fixtures/discovery/cluster/corosync_broken.conf
@@ -1,0 +1,27 @@
+totem {
+        version: 2
+        cluster_name: hana_cluster
+        clear_node_high_bit: yes
+        interface {
+                ringnumber: 0
+                mcastport: 5405
+                ttl: 1
+        }
+
+        transport: udpu
+        crypto_hash: sha1
+        crypto_cipher: aes256
+        token: 30000
+        join: 60
+        max_messages: 20
+        token_retransmits_before_loss_const: 6
+        consensus: 36000
+        secauth: on
+}
+
+logging {
+        fileline: off
+        to_stderr: no
+        to_logfile: no
+        logfile: /var/log/cluster/corosync.log
+        to_syslog: yes

--- a/test/fixtures/discovery/cluster/corosync_noname.conf
+++ b/test/fixtures/discovery/cluster/corosync_noname.conf
@@ -1,0 +1,53 @@
+totem {
+        version: 2
+        clear_node_high_bit: yes
+        interface {
+                ringnumber: 0
+                mcastport: 5405
+                ttl: 1
+        }
+
+        transport: udpu
+        crypto_hash: sha1
+        crypto_cipher: aes256
+        token: 30000
+        join: 60
+        max_messages: 20
+        token_retransmits_before_loss_const: 6
+        consensus: 36000
+        secauth: on
+}
+
+logging {
+        fileline: off
+        to_stderr: no
+        to_logfile: no
+        logfile: /var/log/cluster/corosync.log
+        to_syslog: yes
+        debug: off
+        timestamp: on
+        logger_subsys {
+                subsys: QUORUM
+                debug: off
+        }
+
+}
+
+nodelist {
+        node {
+                ring0_addr: 10.0.1.10
+                nodeid: 1
+        }
+
+        node {
+                ring0_addr: 10.0.2.11
+                nodeid: 2
+        }
+
+}
+
+quorum {
+        provider: corosync_votequorum
+        expected_votes: 2
+        two_node: 1
+}

--- a/test/fixtures/discovery/cluster/expected_published_cluster_discovery.json
+++ b/test/fixtures/discovery/cluster/expected_published_cluster_discovery.json
@@ -1037,6 +1037,7 @@
     "Id": "47d1190ffb4f781974c8356d7f863b03",
     "Name": "hana_cluster",
     "DC": false,
-    "Provider": "azure"
+    "Provider": "azure",
+    "Online": true
   }
 }


### PR DESCRIPTION
Enhance cluster discovery so that it will send data to the collector even when the current host is offline.

The key point is that the cluster is detected by reading static configuration files rather than using CLI commands.

A host is defined online when `corosync` and `pacemaker` services are not active.

Depends on https://github.com/trento-project/web/pull/3647