### PR TITLE
Use adoc in spec file docs

### DIFF
--- a/packaging/suse/trento-agent.spec
+++ b/packaging/suse/trento-agent.spec
@@ -84,8 +84,8 @@ install -d -m 0640 %{buildroot}%{_sysconfdir}/trento/plugins
 
 %files
 %defattr(-,root,root)
-%doc *.md
-%doc docs/*.md
+%doc *.adoc
+%doc docs/*.adoc
 %license LICENSE
 %{_bindir}/%{binaryname}
 %{_unitdir}/%{binaryname}.service


### PR DESCRIPTION
# Description

Fix rpm spec file `doc` usage pointing to adoc files
