### PR TITLE
Bump trento-contracts dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/spf13/viper v1.20.1
 	github.com/stretchr/testify v1.11.1
 	github.com/tklauser/go-sysconf v0.3.10 // indirect
-	github.com/trento-project/contracts/go v0.2.1-0.20250414095955-ee9fb410ccc4
+	github.com/trento-project/contracts/go v0.2.1-0.20250908123711-67fe0387f4f6
 	github.com/vektra/mockery/v2 v2.53.5
 	github.com/wagslane/go-rabbitmq v0.15.0
 	golang.org/x/sync v0.16.0

--- a/go.sum
+++ b/go.sum
@@ -137,8 +137,8 @@ github.com/tklauser/numcpus v0.4.0 h1:E53Dm1HjH1/R2/aoCtXtPgzmElmn51aOkhCFSuZq//
 github.com/tklauser/numcpus v0.4.0/go.mod h1:1+UI3pD8NW14VMwdgJNJ1ESk2UnwhAnz5hMwiKKqXCQ=
 github.com/tredoe/osutil v1.5.0 h1:UGVxbbHRoZi8xXVmbNZ2vgG6XoJ15ndE4LniiQ3rJKg=
 github.com/tredoe/osutil v1.5.0/go.mod h1:TEzphzUUunysbdDRfdOgqkg10POQbnfIPV50ynqOfIg=
-github.com/trento-project/contracts/go v0.2.1-0.20250414095955-ee9fb410ccc4 h1:aQu3P0srz7Stdd2NmRJtbERyPc6ago/+ONIhoEXU/Nw=
-github.com/trento-project/contracts/go v0.2.1-0.20250414095955-ee9fb410ccc4/go.mod h1:+n291lEyfN8CuDyCPq331NOI7cS8X7DdHKnGCLwxtas=
+github.com/trento-project/contracts/go v0.2.1-0.20250908123711-67fe0387f4f6 h1:KzUUyayntTo/B89v5QpyB3YvFcAnwKiI+Hp1NmGMNR0=
+github.com/trento-project/contracts/go v0.2.1-0.20250908123711-67fe0387f4f6/go.mod h1:uehfl2C2QiinLJozft+hZnWmrSehnpyyWLs9Q1j3Qpw=
 github.com/trento-project/workbench v0.0.0-20250822082959-2c177e6358bf h1:QghBHNyUK6WJiTSI9ALwf/udETf3l2CK9m4WYq2ONT4=
 github.com/trento-project/workbench v0.0.0-20250822082959-2c177e6358bf/go.mod h1:boLLIOIGyIHNEsub3cqABD1uGmM206AtOPTTa0bIbRo=
 github.com/vektra/mockery/v2 v2.53.5 h1:iktAY68pNiMvLoHxKqlSNSv/1py0QF/17UGrrAMYDI8=


### PR DESCRIPTION
We now pull in the latest available version.
