### PR TITLE
[TRNT-4317] Pin GHA to SHA instead of tags

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,19 +23,19 @@ jobs:
     if: (github.event_name == 'push' && github.ref == 'refs/heads/main')
     steps:
       - name: trigger docs update in sum.golang.org and pkg.go.dev
-        uses: essentialkaos/godoc-action@v1
+        uses: essentialkaos/godoc-action@1d99db5d7f1c4fc42d26c9910ea374053d6961fb # v1
 
   static-code-analysis:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Read .tool-versions
-        uses: endorama/asdf-parse-tool-versions@v1.5.1
+        uses: endorama/asdf-parse-tool-versions@23a7edd74b0f97626c857c48e32ebbe4ba596a23 # v1.5.1
         id: tool-versions
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: ${{ env.GOLANG_VERSION }}
-      - uses: actions/cache@v5.0.4
+      - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         id: go-cache
         with:
           path: ~/go/pkg/mod
@@ -45,7 +45,7 @@ jobs:
       - name: go fmt check
         run: make fmt-check
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9
         with:
           version: v2.4.0
           skip-cache: true
@@ -59,20 +59,20 @@ jobs:
     env:
       RABBITMQ_URL: amqp://guest:guest@localhost:5675
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Read .tool-versions
-        uses: endorama/asdf-parse-tool-versions@v1.5.1
+        uses: endorama/asdf-parse-tool-versions@23a7edd74b0f97626c857c48e32ebbe4ba596a23 # v1.5.1
         id: tool-versions
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: ${{ env.GOLANG_VERSION }}
-      - uses: actions/cache@v5.0.4
+      - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         id: go-cache
         with:
           path: ~/go/pkg/mod
           key: go-${{ env.GOLANG_VERSION }}-${{ hashFiles('**/go.sum') }}
       - name: "Docker compose dependencies"
-        uses: isbang/compose-action@v2.5.0
+        uses: isbang/compose-action@4894d2492015c1774ee5a13a95b1072093087ec3 # v2.5.0
         with:
           compose-file: "./docker-compose.yaml"
           down-flags: "--volumes"
@@ -95,14 +95,14 @@ jobs:
   test-with-bats:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Read .tool-versions
-        uses: endorama/asdf-parse-tool-versions@v1.5.1
+        uses: endorama/asdf-parse-tool-versions@23a7edd74b0f97626c857c48e32ebbe4ba596a23 # v1.5.1
         id: tool-versions
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: ${{ env.GOLANG_VERSION }}
-      - uses: actions/cache@v5.0.4
+      - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         id: go-cache
         with:
           path: ~/go/pkg/mod
@@ -112,7 +112,7 @@ jobs:
       - name: build trento binary
         run: make build
       - name: Setup BATS
-        uses: mig4/setup-bats@v1
+        uses: mig4/setup-bats@af9a00deb21b5d795cabfeaa8d9060410377686d # v1
         with:
           bats-version: 1.11.1
       - name: run tests

--- a/.github/workflows/dependabot_auto_merge.yaml
+++ b/.github/workflows/dependabot_auto_merge.yaml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Auto-merge
         if: ${{ github.event.workflow_run.conclusion == 'success' }}
-        uses: ridedott/merge-me-action@v2
+        uses: ridedott/merge-me-action@d6325f17fb7e2d3728f83f6872ef7858dddd0dc1 # v2
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PRESET: DEPENDABOT_MINOR

--- a/.github/workflows/obs.yaml
+++ b/.github/workflows/obs.yaml
@@ -35,16 +35,16 @@ jobs:
         CHECKOUT_DIR: /tmp/trento-agent
       options: -u 0:0
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
       - name: Read .tool-versions
-        uses: endorama/asdf-parse-tool-versions@v1.5.1
+        uses: endorama/asdf-parse-tool-versions@23a7edd74b0f97626c857c48e32ebbe4ba596a23 # v1.5.1
         id: tool-versions
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: ${{ env.GOLANG_VERSION }}
-      - uses: actions/cache@v5.0.4
+      - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         id: go-cache
         with:
           path: ~/go/pkg/mod

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
       version: ${{ steps.detect-version.outputs.current-version }}
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 2
           ssh-key: ${{ secrets.RELEASE_KEY }}
@@ -32,7 +32,7 @@ jobs:
       - name: Detect new version
         id: detect-version
         if: steps.check-parent-commit.outputs.sha
-        uses: salsify/action-detect-and-tag-new-version@v2
+        uses: salsify/action-detect-and-tag-new-version@b1778166f13188a9d478e2d1198f993011ba9864 # v2.0.3
         with:
           create-tag: false
           version-command: |
@@ -40,7 +40,7 @@ jobs:
 
       - name: Draft release
         id: draft-release
-        uses: release-drafter/release-drafter@v7
+        uses: release-drafter/release-drafter@139054aeaa9adc52ab36ddf67437541f039b88e2 # v7
         with:
           publish: false
           version: ${{ steps.detect-version.outputs.current-version }}
@@ -50,13 +50,13 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Update CHANGELOG.md
-        uses: stefanzweifel/changelog-updater-action@v1
+        uses: stefanzweifel/changelog-updater-action@a938690fad7edf25368f37e43a1ed1b34303eb36 # v1
         with:
           latest-version: ${{ steps.draft-release.outputs.tag_name }}
           release-notes: ${{ steps.draft-release.outputs.body }}
 
       - name: Commit new changelog
-        uses: stefanzweifel/git-auto-commit-action@v7
+        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7
         with:
           branch: main
           commit_message: "Automatically update CHANGELOG.md for release ${{ steps.detect-version.outputs.current-version }}"
@@ -73,7 +73,7 @@ jobs:
     steps:
       - name: Publish release
         id: publish-release
-        uses: release-drafter/release-drafter@v7
+        uses: release-drafter/release-drafter@139054aeaa9adc52ab36ddf67437541f039b88e2 # v7
         with:
           publish: true
           tag: ${{ needs.pre-release.outputs.version }}


### PR DESCRIPTION
# Description

As security incidents are popping up constantly, it is a good practice to pin the GHA to a specific SHA instead of tags, in case the GHA repository gets compromised. This PR replaces all the versions with the specific SHA.

Related # TRNT-4317


```
==> Summary
    Total uses: references found : 29
    Already pinned (SHA)         : 0
    Pinned in this run           : 27
    Resolved from cache          : 14
    Hardcoded overrides applied  : 0
    Private/inaccessible (logged): 0
    Failed to resolve            : 0
```

## How was this tested?

N/A

