### PR TITLE
Fix required CI workflow name for dependabot auto-merge to properly work.

### DIFF
--- a/.github/workflows/dependabot_auto_merge.yaml
+++ b/.github/workflows/dependabot_auto_merge.yaml
@@ -5,7 +5,7 @@ on:
     types:
       - completed
     workflows:
-      - CI
+      - Continuous Integration
 
 jobs:
   auto-merge:


### PR DESCRIPTION
# Description

while checking this dependabot pr https://github.com/trento-project/agent/pull/570 I realised that CI.yaml `name:` attribute was modified 10 months ago, causing the dependabot auto-merge job to not work because it was not finding any job with that name, I just updated the name of the required workflow to make it work again.

On another topic, perhaps we as a team need to discuss how necessary is this job, given that we have maintenance shifts where we manually check dependabot pr's

Fixes # (issue)

## Did you add the right label?

Remember to add the right labels to this PR.

- [ ] **DONE**

## How was this tested?

Describe the tests that have been added/changed for this new behavior.

- [ ] **DONE**

## Did you update the documentation?

Remember to ask yourself if your PR requires changes to the following documentation:

- [Manual installation guide](https://github.com/trento-project/docs/blob/main/guides/manual-installation.md)
- [Trento Ansible guide](https://github.com/trento-project/ansible/blob/main/README.md)
- [Trento Agent guides](https://github.com/trento-project/agent/tree/main/docs)

Add a documentation PR or write that no changes are required for the documentation.

- [ ] **DONE**
