### PR TITLE
Add status gatherer

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -14,6 +14,7 @@ import (
 	"github.com/trento-project/agent/internal/agent"
 	"github.com/trento-project/agent/internal/discovery"
 	"github.com/trento-project/agent/internal/discovery/collector"
+	"github.com/trento-project/agent/internal/identity"
 )
 
 const prometheusModePush = "push"
@@ -96,7 +97,7 @@ func LoadConfig(fileSystem afero.Fs) (*agent.Config, error) {
 
 	agentID := viper.GetString("force-agent-id")
 	if agentID == "" {
-		id, err := agent.GetAgentID(fileSystem)
+		id, err := identity.GetAgentID(fileSystem)
 		if err != nil {
 			return nil, fmt.Errorf("could not get the agent ID: %w", err)
 		}

--- a/cmd/facts.go
+++ b/cmd/facts.go
@@ -11,12 +11,14 @@ import (
 	"os/signal"
 	"syscall"
 
+	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 
 	"github.com/trento-project/agent/internal/agent"
 	"github.com/trento-project/agent/internal/factsengine/gatherers"
+	"github.com/trento-project/agent/internal/identity"
 	"github.com/trento-project/agent/pkg/factsengine/entities"
 	"github.com/trento-project/agent/pkg/utils"
 )
@@ -90,7 +92,15 @@ func gather(cmd *cobra.Command, _ []string) {
 
 	slog.SetDefault(logger)
 
-	gathererRegistry := gatherers.NewRegistry(gatherers.StandardGatherers())
+	agentID, err := identity.GetAgentID(afero.NewOsFs())
+	if err != nil {
+		slog.Error("Could not derive agent ID", "error", err)
+		os.Exit(1)
+	}
+
+	gathererRegistry := gatherers.NewRegistry(gatherers.StandardGatherers(gatherers.Config{
+		AgentID: agentID,
+	}))
 
 	slog.Info("loading plugins")
 
@@ -181,7 +191,7 @@ func list(*cobra.Command, []string) {
 
 	slog.SetDefault(logger)
 
-	gathererRegistry := gatherers.NewRegistry(gatherers.StandardGatherers())
+	gathererRegistry := gatherers.NewRegistry(gatherers.StandardGatherers(gatherers.Config{}))
 
 	slog.Info("loading plugins")
 

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	"github.com/trento-project/agent/internal/agent"
+	"github.com/trento-project/agent/internal/identity"
 	"github.com/trento-project/agent/pkg/utils"
 )
 
@@ -164,7 +165,7 @@ func generateAlloy(_ *cobra.Command, _ []string) error {
 
 	agentID := viper.GetString("force-agent-id")
 	if agentID == "" {
-		id, err := agent.GetAgentID(afero.NewOsFs())
+		id, err := identity.GetAgentID(afero.NewOsFs())
 		if err != nil {
 			return fmt.Errorf("could not get the agent ID: %w", err)
 		}

--- a/cmd/id.go
+++ b/cmd/id.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
-	"github.com/trento-project/agent/internal/agent"
+	"github.com/trento-project/agent/internal/identity"
 )
 
 func NewAgentIDCmd() *cobra.Command {
@@ -16,7 +16,7 @@ func NewAgentIDCmd() *cobra.Command {
 		Use:   "id",
 		Short: "Print the agent identifier",
 		RunE: func(_ *cobra.Command, _ []string) error {
-			agentID, err := agent.GetAgentID(afero.NewOsFs())
+			agentID, err := identity.GetAgentID(afero.NewOsFs())
 			if err != nil {
 				return err
 			}

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -8,13 +8,10 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"strings"
 	"time"
 
 	"log/slog"
 
-	"github.com/google/uuid"
-	"github.com/spf13/afero"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/trento-project/agent/internal/discovery"
@@ -23,12 +20,6 @@ import (
 	"github.com/trento-project/agent/internal/factsengine/gatherers"
 	"github.com/trento-project/agent/internal/operations"
 	"github.com/trento-project/agent/internal/operations/operator"
-)
-
-const machineIDPath = "/etc/machine-id"
-
-var (
-	trentoNamespace = uuid.Must(uuid.Parse("fb92284e-aa5e-47f6-a883-bf9469e7a0dc")) //nolint
 )
 
 type Agent struct {
@@ -72,21 +63,13 @@ func NewAgent(config *Config) (*Agent, error) {
 	return agent, nil
 }
 
-func GetAgentID(fileSystem afero.Fs) (string, error) {
-	machineIDBytes, err := afero.ReadFile(fileSystem, machineIDPath)
-	if err != nil {
-		return "", err
-	}
-
-	machineID := strings.TrimSpace(string(machineIDBytes))
-	agentID := uuid.NewSHA1(trentoNamespace, []byte(machineID))
-
-	return agentID.String(), nil
-}
-
 // Start the Agent. This will start the discovery ticker and the heartbeat ticker
 func (a *Agent) Start(ctx context.Context) error {
-	gathererRegistry := gatherers.NewRegistry(gatherers.StandardGatherers())
+	gathererRegistry := gatherers.NewRegistry(
+		gatherers.StandardGatherers(
+			gatherers.Config{AgentID: a.config.AgentID},
+		),
+	)
 
 	c := factsengine.NewFactsEngine(a.config.AgentID, a.config.FactsServiceURL, *gathererRegistry)
 	slog.Info("Starting fact gathering service...")

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -22,14 +22,6 @@ func TestAgentTestSuite(t *testing.T) {
 	suite.Run(t, new(AgentTestSuite))
 }
 
-func (suite *AgentTestSuite) TestAgentGetAgentID() {
-	fileSystem := helpers.MockMachineIDFile()
-	agentID, err := agent.GetAgentID(fileSystem)
-
-	suite.NoError(err)
-	suite.Equal(helpers.DummyAgentID, agentID)
-}
-
 func (suite *AgentTestSuite) TestAgentFailsWithInvalidFactsServiceURL() {
 	config := &agent.Config{
 		AgentID:      helpers.DummyAgentID,

--- a/internal/factsengine/gatherers/gatherer.go
+++ b/internal/factsengine/gatherers/gatherer.go
@@ -30,9 +30,6 @@ type Config struct {
 
 func StandardGatherers(config Config) FactGatherersTree {
 	return FactGatherersTree{
-		StatusGathererName: map[string]FactGatherer{
-			"v1": NewStatusGatherer(config.AgentID),
-		},
 		AscsErsClusterGathererName: map[string]FactGatherer{
 			"v1": NewDefaultAscsErsClusterGatherer(),
 		},
@@ -104,6 +101,9 @@ func StandardGatherers(config Config) FactGatherersTree {
 		},
 		SBDDumpGathererName: map[string]FactGatherer{
 			"v1": NewDefaultSBDDumpGatherer(),
+		},
+		StatusGathererName: map[string]FactGatherer{
+			"v1": NewStatusGatherer(config.AgentID),
 		},
 		SudoersGathererName: map[string]FactGatherer{
 			"v1": NewDefaultSudoersGatherer(),

--- a/internal/factsengine/gatherers/gatherer.go
+++ b/internal/factsengine/gatherers/gatherer.go
@@ -26,6 +26,9 @@ type FactGathererWithCache interface {
 
 func StandardGatherers() FactGatherersTree {
 	return FactGatherersTree{
+		StatusGathererName: map[string]FactGatherer{
+			"v1": NewDefaultStatusGatherer(),
+		},
 		AscsErsClusterGathererName: map[string]FactGatherer{
 			"v1": NewDefaultAscsErsClusterGatherer(),
 		},

--- a/internal/factsengine/gatherers/gatherer.go
+++ b/internal/factsengine/gatherers/gatherer.go
@@ -24,10 +24,14 @@ type FactGathererWithCache interface {
 	SetCache(cache *factscache.FactsCache)
 }
 
-func StandardGatherers() FactGatherersTree {
+type Config struct {
+	AgentID string
+}
+
+func StandardGatherers(config Config) FactGatherersTree {
 	return FactGatherersTree{
 		StatusGathererName: map[string]FactGatherer{
-			"v1": NewDefaultStatusGatherer(),
+			"v1": NewStatusGatherer(config.AgentID),
 		},
 		AscsErsClusterGathererName: map[string]FactGatherer{
 			"v1": NewDefaultAscsErsClusterGatherer(),

--- a/internal/factsengine/gatherers/status.go
+++ b/internal/factsengine/gatherers/status.go
@@ -1,0 +1,77 @@
+package gatherers
+
+import (
+	"context"
+	"strings"
+
+	"log/slog"
+
+	"github.com/google/uuid"
+	"github.com/spf13/afero"
+	"github.com/trento-project/agent/pkg/factsengine/entities"
+	"github.com/trento-project/agent/version"
+)
+
+const (
+	StatusGathererName  = "status"
+	statusMachineIDPath = "/etc/machine-id"
+)
+
+// nolint:gochecknoglobals
+var (
+	trentoAgentNamespace = uuid.Must(uuid.Parse("fb92284e-aa5e-47f6-a883-bf9469e7a0dc"))
+
+	StatusMachineIDError = entities.FactGatheringError{
+		Type:    "status-machine-id-error",
+		Message: "error reading machine ID",
+	}
+)
+
+type StatusGatherer struct {
+	fs            afero.Fs
+	machineIDPath string
+}
+
+func NewDefaultStatusGatherer() *StatusGatherer {
+	return NewStatusGatherer(afero.NewOsFs(), statusMachineIDPath)
+}
+
+func NewStatusGatherer(fs afero.Fs, machineIDPath string) *StatusGatherer {
+	return &StatusGatherer{
+		fs:            fs,
+		machineIDPath: machineIDPath,
+	}
+}
+
+func (g *StatusGatherer) Gather(ctx context.Context, factsRequests []entities.FactRequest) ([]entities.Fact, error) {
+	facts := []entities.Fact{}
+	slog.Info("Starting facts gathering process", "gatherer", StatusGathererName)
+
+	machineIDBytes, err := afero.ReadFile(g.fs, g.machineIDPath)
+	if err != nil {
+		slog.Error("Error reading machine ID", "error", err)
+		return facts, StatusMachineIDError.Wrap(err.Error())
+	}
+
+	machineID := strings.TrimSpace(string(machineIDBytes))
+	agentID := uuid.NewSHA1(trentoAgentNamespace, []byte(machineID)).String()
+
+	statusValue := &entities.FactValueMap{
+		Value: map[string]entities.FactValue{
+			"agent_id": &entities.FactValueString{Value: agentID},
+			"version":  &entities.FactValueString{Value: version.Version},
+		},
+	}
+
+	for _, requestedFact := range factsRequests {
+		fact := entities.NewFactGatheredWithRequest(requestedFact, statusValue)
+		facts = append(facts, fact)
+	}
+
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+
+	slog.Info("Requested facts gathered", "gatherer", StatusGathererName)
+	return facts, nil
+}

--- a/internal/factsengine/gatherers/status.go
+++ b/internal/factsengine/gatherers/status.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
 package gatherers
 
 import (

--- a/internal/factsengine/gatherers/status.go
+++ b/internal/factsengine/gatherers/status.go
@@ -2,44 +2,22 @@ package gatherers
 
 import (
 	"context"
-	"strings"
 
 	"log/slog"
 
-	"github.com/google/uuid"
-	"github.com/spf13/afero"
 	"github.com/trento-project/agent/pkg/factsengine/entities"
 	"github.com/trento-project/agent/version"
 )
 
-const (
-	StatusGathererName  = "status"
-	statusMachineIDPath = "/etc/machine-id"
-)
-
-// nolint:gochecknoglobals
-var (
-	trentoAgentNamespace = uuid.Must(uuid.Parse("fb92284e-aa5e-47f6-a883-bf9469e7a0dc"))
-
-	StatusMachineIDError = entities.FactGatheringError{
-		Type:    "status-machine-id-error",
-		Message: "error reading machine ID",
-	}
-)
+const StatusGathererName = "status"
 
 type StatusGatherer struct {
-	fs            afero.Fs
-	machineIDPath string
+	agentID string
 }
 
-func NewDefaultStatusGatherer() *StatusGatherer {
-	return NewStatusGatherer(afero.NewOsFs(), statusMachineIDPath)
-}
-
-func NewStatusGatherer(fs afero.Fs, machineIDPath string) *StatusGatherer {
+func NewStatusGatherer(agentID string) *StatusGatherer {
 	return &StatusGatherer{
-		fs:            fs,
-		machineIDPath: machineIDPath,
+		agentID: agentID,
 	}
 }
 
@@ -47,18 +25,9 @@ func (g *StatusGatherer) Gather(ctx context.Context, factsRequests []entities.Fa
 	facts := []entities.Fact{}
 	slog.Info("Starting facts gathering process", "gatherer", StatusGathererName)
 
-	machineIDBytes, err := afero.ReadFile(g.fs, g.machineIDPath)
-	if err != nil {
-		slog.Error("Error reading machine ID", "error", err)
-		return facts, StatusMachineIDError.Wrap(err.Error())
-	}
-
-	machineID := strings.TrimSpace(string(machineIDBytes))
-	agentID := uuid.NewSHA1(trentoAgentNamespace, []byte(machineID)).String()
-
 	statusValue := &entities.FactValueMap{
 		Value: map[string]entities.FactValue{
-			"agent_id": &entities.FactValueString{Value: agentID},
+			"agent_id": &entities.FactValueString{Value: g.agentID},
 			"version":  &entities.FactValueString{Value: version.Version},
 		},
 	}

--- a/internal/factsengine/gatherers/status_test.go
+++ b/internal/factsengine/gatherers/status_test.go
@@ -1,0 +1,100 @@
+package gatherers_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/suite"
+	"github.com/trento-project/agent/internal/factsengine/gatherers"
+	"github.com/trento-project/agent/pkg/factsengine/entities"
+)
+
+type StatusGathererTestSuite struct {
+	suite.Suite
+}
+
+func TestStatusGathererTestSuite(t *testing.T) {
+	suite.Run(t, new(StatusGathererTestSuite))
+}
+
+func (suite *StatusGathererTestSuite) newFsWithMachineID(machineID string) afero.Fs {
+	fs := afero.NewMemMapFs()
+	_ = afero.WriteFile(fs, "/etc/machine-id", []byte(machineID+"\n"), 0644)
+	return fs
+}
+
+func (suite *StatusGathererTestSuite) TestStatusGathererSuccess() {
+	fs := suite.newFsWithMachineID("abc123")
+	g := gatherers.NewStatusGatherer(fs, "/etc/machine-id")
+
+	factRequests := []entities.FactRequest{
+		{
+			Name:     "status",
+			Gatherer: "status@v1",
+			CheckID:  "check1",
+		},
+	}
+
+	factResults, err := g.Gather(context.Background(), factRequests)
+
+	suite.NoError(err)
+	suite.Len(factResults, 1)
+
+	resultMap, ok := factResults[0].Value.(*entities.FactValueMap)
+	suite.Require().True(ok)
+	suite.Equal("check1", factResults[0].CheckID)
+	agentID, ok := resultMap.Value["agent_id"].(*entities.FactValueString)
+	suite.Require().True(ok)
+	suite.NotEmpty(agentID.Value)
+	suite.IsType(&entities.FactValueString{}, resultMap.Value["version"])
+}
+
+func (suite *StatusGathererTestSuite) TestStatusGathererMultipleRequests() {
+	fs := suite.newFsWithMachineID("abc123")
+	g := gatherers.NewStatusGatherer(fs, "/etc/machine-id")
+
+	factRequests := []entities.FactRequest{
+		{Name: "status", Gatherer: "status@v1", CheckID: "check1"},
+		{Name: "status", Gatherer: "status@v1", CheckID: "check2"},
+	}
+
+	factResults, err := g.Gather(context.Background(), factRequests)
+
+	suite.NoError(err)
+	suite.Len(factResults, 2)
+	suite.Equal(factResults[0].Value, factResults[1].Value)
+}
+
+func (suite *StatusGathererTestSuite) TestStatusGathererMachineIDNotFound() {
+	fs := afero.NewMemMapFs()
+	g := gatherers.NewStatusGatherer(fs, "/etc/machine-id")
+
+	factRequests := []entities.FactRequest{
+		{Name: "status", Gatherer: "status@v1"},
+	}
+
+	_, err := g.Gather(context.Background(), factRequests)
+
+	suite.EqualError(err, "fact gathering error: status-machine-id-error - error reading machine ID: "+
+		"open /etc/machine-id: file does not exist")
+}
+
+func (suite *StatusGathererTestSuite) TestStatusGathererContextCancelled() {
+	fs := suite.newFsWithMachineID("abc123")
+	g := gatherers.NewStatusGatherer(fs, "/etc/machine-id")
+
+	factsRequest := []entities.FactRequest{{
+		Name:     "status",
+		Gatherer: "status@v1",
+		CheckID:  "check1",
+	}}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	factResults, err := g.Gather(ctx, factsRequest)
+
+	suite.Error(err)
+	suite.Empty(factResults)
+}

--- a/internal/factsengine/gatherers/status_test.go
+++ b/internal/factsengine/gatherers/status_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
 package gatherers_test
 
 import (

--- a/internal/factsengine/gatherers/status_test.go
+++ b/internal/factsengine/gatherers/status_test.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"testing"
 
-	"github.com/spf13/afero"
 	"github.com/stretchr/testify/suite"
 	"github.com/trento-project/agent/internal/factsengine/gatherers"
 	"github.com/trento-project/agent/pkg/factsengine/entities"
 )
+
+const testAgentID = "779cdd70-e9e2-58ca-b18a-bf3eb3f71244"
 
 type StatusGathererTestSuite struct {
 	suite.Suite
@@ -18,15 +19,8 @@ func TestStatusGathererTestSuite(t *testing.T) {
 	suite.Run(t, new(StatusGathererTestSuite))
 }
 
-func (suite *StatusGathererTestSuite) newFsWithMachineID(machineID string) afero.Fs {
-	fs := afero.NewMemMapFs()
-	_ = afero.WriteFile(fs, "/etc/machine-id", []byte(machineID+"\n"), 0644)
-	return fs
-}
-
 func (suite *StatusGathererTestSuite) TestStatusGathererSuccess() {
-	fs := suite.newFsWithMachineID("abc123")
-	g := gatherers.NewStatusGatherer(fs, "/etc/machine-id")
+	g := gatherers.NewStatusGatherer(testAgentID)
 
 	factRequests := []entities.FactRequest{
 		{
@@ -46,13 +40,12 @@ func (suite *StatusGathererTestSuite) TestStatusGathererSuccess() {
 	suite.Equal("check1", factResults[0].CheckID)
 	agentID, ok := resultMap.Value["agent_id"].(*entities.FactValueString)
 	suite.Require().True(ok)
-	suite.NotEmpty(agentID.Value)
+	suite.Equal(testAgentID, agentID.Value)
 	suite.IsType(&entities.FactValueString{}, resultMap.Value["version"])
 }
 
 func (suite *StatusGathererTestSuite) TestStatusGathererMultipleRequests() {
-	fs := suite.newFsWithMachineID("abc123")
-	g := gatherers.NewStatusGatherer(fs, "/etc/machine-id")
+	g := gatherers.NewStatusGatherer(testAgentID)
 
 	factRequests := []entities.FactRequest{
 		{Name: "status", Gatherer: "status@v1", CheckID: "check1"},
@@ -66,23 +59,8 @@ func (suite *StatusGathererTestSuite) TestStatusGathererMultipleRequests() {
 	suite.Equal(factResults[0].Value, factResults[1].Value)
 }
 
-func (suite *StatusGathererTestSuite) TestStatusGathererMachineIDNotFound() {
-	fs := afero.NewMemMapFs()
-	g := gatherers.NewStatusGatherer(fs, "/etc/machine-id")
-
-	factRequests := []entities.FactRequest{
-		{Name: "status", Gatherer: "status@v1"},
-	}
-
-	_, err := g.Gather(context.Background(), factRequests)
-
-	suite.EqualError(err, "fact gathering error: status-machine-id-error - error reading machine ID: "+
-		"open /etc/machine-id: file does not exist")
-}
-
 func (suite *StatusGathererTestSuite) TestStatusGathererContextCancelled() {
-	fs := suite.newFsWithMachineID("abc123")
-	g := gatherers.NewStatusGatherer(fs, "/etc/machine-id")
+	g := gatherers.NewStatusGatherer(testAgentID)
 
 	factsRequest := []entities.FactRequest{{
 		Name:     "status",

--- a/internal/identity/identity.go
+++ b/internal/identity/identity.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
 package identity
 
 import (

--- a/internal/identity/identity.go
+++ b/internal/identity/identity.go
@@ -1,0 +1,24 @@
+package identity
+
+import (
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/spf13/afero"
+)
+
+const MachineIDPath = "/etc/machine-id"
+
+var trentoNamespace = uuid.Must(uuid.Parse("fb92284e-aa5e-47f6-a883-bf9469e7a0dc")) //nolint:gochecknoglobals
+
+func GetAgentID(fileSystem afero.Fs) (string, error) {
+	machineIDBytes, err := afero.ReadFile(fileSystem, MachineIDPath)
+	if err != nil {
+		return "", err
+	}
+
+	machineID := strings.TrimSpace(string(machineIDBytes))
+	agentID := uuid.NewSHA1(trentoNamespace, []byte(machineID))
+
+	return agentID.String(), nil
+}

--- a/internal/identity/identity_test.go
+++ b/internal/identity/identity_test.go
@@ -1,0 +1,33 @@
+package identity_test
+
+import (
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/suite"
+	"github.com/trento-project/agent/internal/identity"
+	"github.com/trento-project/agent/test/helpers"
+)
+
+type IdentityTestSuite struct {
+	suite.Suite
+}
+
+func TestIdentityTestSuite(t *testing.T) {
+	suite.Run(t, new(IdentityTestSuite))
+}
+
+func (suite *IdentityTestSuite) TestGetAgentID() {
+	fileSystem := helpers.MockMachineIDFile()
+	agentID, err := identity.GetAgentID(fileSystem)
+
+	suite.NoError(err)
+	suite.Equal(helpers.DummyAgentID, agentID)
+}
+
+func (suite *IdentityTestSuite) TestGetAgentIDMachineIDNotFound() {
+	fileSystem := afero.NewMemMapFs()
+	_, err := identity.GetAgentID(fileSystem)
+
+	suite.EqualError(err, "open /etc/machine-id: file does not exist")
+}

--- a/internal/identity/identity_test.go
+++ b/internal/identity/identity_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
 package identity_test
 
 import (


### PR DESCRIPTION
A simple gatherer that is meant to signal that the agent is running and able to accept data gathering requests. It is meant for testing the checks infrastructure to ensure it is working properly.