### PR TITLE
Bump contracts ref

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ trento-agent
 /build
 
 covprofile
+
+.DS_Store

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
 	github.com/tklauser/go-sysconf v0.3.10 // indirect
-	github.com/trento-project/contracts/go v0.2.1-0.20250908123711-67fe0387f4f6
+	github.com/trento-project/contracts/go v0.2.1-0.20260603071654-69a5241e3065
 	github.com/vektra/mockery/v2 v2.53.5 // indirect
 	github.com/wagslane/go-rabbitmq v0.15.0
 	golang.org/x/sync v0.20.0

--- a/go.sum
+++ b/go.sum
@@ -149,8 +149,8 @@ github.com/tklauser/numcpus v0.4.0 h1:E53Dm1HjH1/R2/aoCtXtPgzmElmn51aOkhCFSuZq//
 github.com/tklauser/numcpus v0.4.0/go.mod h1:1+UI3pD8NW14VMwdgJNJ1ESk2UnwhAnz5hMwiKKqXCQ=
 github.com/tredoe/osutil v1.5.0 h1:UGVxbbHRoZi8xXVmbNZ2vgG6XoJ15ndE4LniiQ3rJKg=
 github.com/tredoe/osutil v1.5.0/go.mod h1:TEzphzUUunysbdDRfdOgqkg10POQbnfIPV50ynqOfIg=
-github.com/trento-project/contracts/go v0.2.1-0.20250908123711-67fe0387f4f6 h1:KzUUyayntTo/B89v5QpyB3YvFcAnwKiI+Hp1NmGMNR0=
-github.com/trento-project/contracts/go v0.2.1-0.20250908123711-67fe0387f4f6/go.mod h1:uehfl2C2QiinLJozft+hZnWmrSehnpyyWLs9Q1j3Qpw=
+github.com/trento-project/contracts/go v0.2.1-0.20260603071654-69a5241e3065 h1:7bp1/QnrVOdhBnyx9RsxNY7dHD0Xt5Niryl5XAtJMGk=
+github.com/trento-project/contracts/go v0.2.1-0.20260603071654-69a5241e3065/go.mod h1:ZMOZd9r5fxXPR3I+IopaG6nX+7bBr7fThn1ikYutC64=
 github.com/vektra/mockery/v2 v2.53.5 h1:iktAY68pNiMvLoHxKqlSNSv/1py0QF/17UGrrAMYDI8=
 github.com/vektra/mockery/v2 v2.53.5/go.mod h1:hIFFb3CvzPdDJJiU7J4zLRblUMv7OuezWsHPmswriwo=
 github.com/wagslane/go-rabbitmq v0.15.0 h1:KibShYLLeDYc3C5fnx+BjiHJLJdL6D5/BysgcRJknRE=


### PR DESCRIPTION
# Description

Bumping to latest commit in https://github.com/trento-project/contracts.

Not strictly necessary because go code is unchanged, but just for consistency.