### PR TITLE
Use fine-grained `nolint` directives

### DIFF
--- a/cmd/facts.go
+++ b/cmd/facts.go
@@ -24,7 +24,7 @@ import (
 )
 
 func NewFactsCmd() *cobra.Command {
-	factsCmd := &cobra.Command{ //nolint
+	factsCmd := &cobra.Command{
 		Use:   "facts",
 		Short: "Run facts related operations",
 	}
@@ -36,7 +36,7 @@ func NewFactsCmd() *cobra.Command {
 }
 
 func NewFactsGatherCmd() *cobra.Command {
-	gatherCmd := &cobra.Command{ //nolint
+	gatherCmd := &cobra.Command{
 		Use:   "gather",
 		Short: "Gather the requested fact",
 		Run:   gather,
@@ -63,7 +63,7 @@ func NewFactsGatherCmd() *cobra.Command {
 }
 
 func NewFactsListCmd() *cobra.Command {
-	gatherCmd := &cobra.Command{ //nolint
+	gatherCmd := &cobra.Command{
 		Use:   "list",
 		Short: "List the available gatherers",
 		Run:   list,

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -18,7 +18,7 @@ import (
 )
 
 func NewGenerateCmd() *cobra.Command {
-	generateCmd := &cobra.Command{ //nolint
+	generateCmd := &cobra.Command{
 		Use:   "generate",
 		Short: "Generate configuration files",
 	}
@@ -29,7 +29,7 @@ func NewGenerateCmd() *cobra.Command {
 }
 
 func NewGenerateAlloyCmd() *cobra.Command {
-	alloyCmd := &cobra.Command{ //nolint
+	alloyCmd := &cobra.Command{
 		Use:   "alloy",
 		Short: "Generate Grafana Alloy configuration for Trento metrics",
 		Long: `Generate Grafana Alloy configuration for pushing system metrics to Prometheus.

--- a/cmd/id.go
+++ b/cmd/id.go
@@ -12,7 +12,7 @@ import (
 )
 
 func NewAgentIDCmd() *cobra.Command {
-	idCmd := &cobra.Command{ //nolint
+	idCmd := &cobra.Command{
 		Use:   "id",
 		Short: "Print the agent identifier",
 		RunE: func(_ *cobra.Command, _ []string) error {

--- a/cmd/operator.go
+++ b/cmd/operator.go
@@ -22,7 +22,7 @@ import (
 )
 
 func NewOperatorCmd() *cobra.Command {
-	operatorCmd := &cobra.Command{ //nolint
+	operatorCmd := &cobra.Command{
 		Use:    "operator",
 		Short:  "Run operator related commands",
 		Hidden: true,
@@ -35,7 +35,7 @@ func NewOperatorCmd() *cobra.Command {
 }
 
 func NewOperatorRunCmd() *cobra.Command {
-	runCmd := &cobra.Command{ //nolint
+	runCmd := &cobra.Command{
 		Use:   "run",
 		Short: "Run operator",
 		Run:   runOperator,
@@ -62,7 +62,7 @@ func NewOperatorRunCmd() *cobra.Command {
 }
 
 func NewOperatorListCmd() *cobra.Command {
-	listCmd := &cobra.Command{ //nolint
+	listCmd := &cobra.Command{
 		Use:   "list",
 		Short: "List the available operators",
 		Run:   listOperators,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,7 +21,7 @@ func Execute() {
 }
 
 func NewRootCmd() *cobra.Command {
-	var rootCmd = &cobra.Command{ //nolint
+	var rootCmd = &cobra.Command{
 		Use:   "trento-agent",
 		Short: "An open cloud-native web console improving on the life of SAP Applications administrators.",
 		Long: `Trento is a web-based graphical user interface

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -34,7 +34,7 @@ func NewStartCmd() *cobra.Command {
 
 	slog.SetDefault(logger)
 
-	startCmd := &cobra.Command{ //nolint
+	startCmd := &cobra.Command{
 		Use:   "start",
 		Short: "Start the agent",
 		Run:   start,

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -17,7 +17,8 @@ func NewVersionCmd() *cobra.Command {
 		Short: "Print the version number of Trento",
 		Long:  `All software has versions. This is Trento's`,
 		Run: func(_ *cobra.Command, _ []string) {
-			fmt.Printf("Trento installed from %s version %s\nbuilt with %s %s/%s\n", version.InstallationSource, version.Version, runtime.Version(), runtime.GOOS, runtime.GOARCH)
+			//nolint:forbidigo
+			fmt.Printf("Trento installed from %s version %s\nbuilt with %s %s/%s\n", version.InstallationSource, version.Version, runtime.Version(), runtime.GOOS, runtime.GOARCH) //nolint:lll
 		},
 	}
 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -12,12 +12,12 @@ import (
 )
 
 func NewVersionCmd() *cobra.Command {
-	versionCmd := &cobra.Command{ //nolint
+	versionCmd := &cobra.Command{
 		Use:   "version",
 		Short: "Print the version number of Trento",
 		Long:  `All software has versions. This is Trento's`,
 		Run: func(_ *cobra.Command, _ []string) {
-			fmt.Printf("Trento installed from %s version %s\nbuilt with %s %s/%s\n", version.InstallationSource, version.Version, runtime.Version(), runtime.GOOS, runtime.GOARCH) //nolint
+			fmt.Printf("Trento installed from %s version %s\nbuilt with %s %s/%s\n", version.InstallationSource, version.Version, runtime.Version(), runtime.GOOS, runtime.GOARCH)
 		},
 	}
 

--- a/internal/core/cloud/aws.go
+++ b/internal/core/cloud/aws.go
@@ -23,8 +23,8 @@ import (
 const (
 	awsMetadataURL                = "http://169.254.169.254/latest/"
 	awsMetadataResource           = "meta-data"
-	metadataTokenTTLHeader string = "X-aws-ec2-metadata-token-ttl-seconds"
-	metadataTokenHeader    string = "X-aws-ec2-metadata-token"
+	metadataTokenTTLHeader string = "X-aws-ec2-metadata-token-ttl-seconds" //nolint:gosec
+	metadataTokenHeader    string = "X-aws-ec2-metadata-token"             //nolint:gosec
 
 	// https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html
 	// (TTL) for the token, in seconds, up to a maximum of six hours (21,600 seconds).

--- a/internal/core/cloud/aws.go
+++ b/internal/core/cloud/aws.go
@@ -23,8 +23,8 @@ import (
 const (
 	awsMetadataURL                = "http://169.254.169.254/latest/"
 	awsMetadataResource           = "meta-data"
-	metadataTokenTTLHeader string = "X-aws-ec2-metadata-token-ttl-seconds" //nolint
-	metadataTokenHeader    string = "X-aws-ec2-metadata-token"             //nolint
+	metadataTokenTTLHeader string = "X-aws-ec2-metadata-token-ttl-seconds"
+	metadataTokenHeader    string = "X-aws-ec2-metadata-token"
 
 	// https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html
 	// (TTL) for the token, in seconds, up to a maximum of six hours (21,600 seconds).

--- a/internal/core/cluster/cib/data.go
+++ b/internal/core/cluster/cib/data.go
@@ -19,7 +19,7 @@ type Root struct {
 			ClusterProperties []Attribute `xml:"cluster_property_set>nvpair"`
 		} `xml:"crm_config"`
 		Nodes []struct {
-			ID                 string      `xml:"id,attr" json:"Id"` //nolint
+			ID                 string      `xml:"id,attr" json:"Id"`
 			Uname              string      `xml:"uname,attr"`
 			InstanceAttributes []Attribute `xml:"instance_attributes>nvpair"`
 		} `xml:"nodes>node"`
@@ -31,7 +31,7 @@ type Root struct {
 		} `xml:"resources"`
 		Constraints struct {
 			RscLocations []struct {
-				ID       string `xml:"id,attr" json:"Id"` //nolint
+				ID       string `xml:"id,attr" json:"Id"`
 				Node     string `xml:"node,attr"`
 				Resource string `xml:"rsc,attr"`
 				Role     string `xml:"role,attr"`
@@ -42,20 +42,20 @@ type Root struct {
 }
 
 type Attribute struct {
-	ID    string `xml:"id,attr" json:"Id"` //nolint
+	ID    string `xml:"id,attr" json:"Id"`
 	Name  string `xml:"name,attr"`
 	Value string `xml:"value,attr"`
 }
 
 type Primitive struct {
-	ID                 string      `xml:"id,attr" json:"Id"` //nolint
+	ID                 string      `xml:"id,attr" json:"Id"`
 	Class              string      `xml:"class,attr"`
 	Type               string      `xml:"type,attr"`
 	Provider           string      `xml:"provider,attr"`
 	InstanceAttributes []Attribute `xml:"instance_attributes>nvpair"`
 	MetaAttributes     []Attribute `xml:"meta_attributes>nvpair"`
 	Operations         []struct {
-		ID   string `xml:"id,attr" json:"Id"` //nolint
+		ID   string `xml:"id,attr" json:"Id"`
 		Name string `xml:"name,attr"`
 		Role string `xml:"role,attr"`
 		// todo: interval and timeout are time based vars. We should in future parse them correctly insteaf of string
@@ -65,12 +65,12 @@ type Primitive struct {
 }
 
 type Clone struct {
-	ID             string      `xml:"id,attr" json:"Id"` //nolint
+	ID             string      `xml:"id,attr" json:"Id"`
 	MetaAttributes []Attribute `xml:"meta_attributes>nvpair"`
 	Primitive      Primitive   `xml:"primitive"`
 }
 
 type Group struct {
-	ID         string      `xml:"id,attr" json:"Id"` //nolint
+	ID         string      `xml:"id,attr" json:"Id"`
 	Primitives []Primitive `xml:"primitive"`
 }

--- a/internal/core/cluster/cib/parser_test.go
+++ b/internal/core/cluster/cib/parser_test.go
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: SUSE LLC
 // SPDX-License-Identifier: Apache-2.0
 
-//nolint:lll
 package cib_test
 
 import (

--- a/internal/core/cluster/cluster.go
+++ b/internal/core/cluster/cluster.go
@@ -150,9 +150,9 @@ func makeOnlineHostPayload(
 	}
 
 	var cluster = &Cluster{
-		Cib:      cib.Root{},    //nolint
-		Crmmon:   crmmon.Root{}, //nolint
-		SBD:      SBD{},         //nolint
+		Cib:      cib.Root{},
+		Crmmon:   crmmon.Root{},
+		SBD:      SBD{},
 		ID:       detectedCluster.ID,
 		Name:     detectedCluster.Name,
 		DC:       false,

--- a/internal/core/cluster/cluster_test.go
+++ b/internal/core/cluster/cluster_test.go
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: SUSE LLC
 // SPDX-License-Identifier: Apache-2.0
 
-//nolint:exhaustruct
 package cluster_test
 
 import (

--- a/internal/core/cluster/sbd.go
+++ b/internal/core/cluster/sbd.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"errors"
+
 	"github.com/hashicorp/go-envparse"
 	"github.com/trento-project/agent/pkg/utils"
 )
@@ -108,7 +109,7 @@ func LoadSbdConfig(sbdConfigPath string) (map[string]string, error) {
 }
 
 func NewSBDDevice(executor utils.CommandExecutor, sbdPath, device string) SBDDevice {
-	return SBDDevice{ //nolint
+	return SBDDevice{
 		executor: executor,
 		sbdPath:  sbdPath,
 		Device:   device,

--- a/internal/core/cluster/sbd_test.go
+++ b/internal/core/cluster/sbd_test.go
@@ -330,7 +330,7 @@ func (suite *SbdTestSuite) TestNewSBDError() {
 	s, err := cluster.NewSBD(
 		mockCommand, "/bin/sbd", helpers.GetFixturePath("discovery/cluster/sbd/sbd_config_no_device"))
 
-	expectedSbd := cluster.SBD{ //nolint
+	expectedSbd := cluster.SBD{
 		Config: map[string]string{
 			"SBD_OPTS":                "",
 			"SBD_PACEMAKER":           "yes",

--- a/internal/core/sapsystem/sapcontrolapi/webservice.go
+++ b/internal/core/sapsystem/sapcontrolapi/webservice.go
@@ -14,9 +14,9 @@ import (
 )
 
 type WebService interface {
-	GetInstancePropertiesContext(ctx context.Context, request *GetInstanceProperties) (*GetInstancePropertiesResponse, error)
+	GetInstancePropertiesContext(ctx context.Context, request *GetInstanceProperties) (*GetInstancePropertiesResponse, error) //nolint:lll
 	GetProcessListContext(ctx context.Context, request *GetProcessList) (*GetProcessListResponse, error)
-	GetSystemInstanceListContext(ctx context.Context, request *GetSystemInstanceList) (*GetSystemInstanceListResponse, error)
+	GetSystemInstanceListContext(ctx context.Context, request *GetSystemInstanceList) (*GetSystemInstanceListResponse, error) //nolint:lll
 	GetVersionInfoContext(ctx context.Context, request *GetVersionInfo) (*GetVersionInfoResponse, error)
 	HACheckConfigContext(ctx context.Context, request *HACheckConfig) (*HACheckConfigResponse, error)
 	HAGetFailoverConfigContext(ctx context.Context, request *HAGetFailoverConfig) (*HAGetFailoverConfigResponse, error)
@@ -26,12 +26,13 @@ type WebService interface {
 	StopSystemContext(ctx context.Context, request *StopSystem) (*StopSystemResponse, error)
 }
 
-type STATECOLOR string
-type STATECOLOR_CODE int
+type STATECOLOR string   //nolint:revive
+type STATECOLOR_CODE int //nolint:revive
 type HAVerificationState string
 type HACheckCategory string
 type StartStopOption string
 
+//nolint:revive
 const (
 	STATECOLOR_GRAY   STATECOLOR = "SAPControl-GRAY"
 	STATECOLOR_GREEN  STATECOLOR = "SAPControl-GREEN"
@@ -59,6 +60,7 @@ const (
 	StartStopOptionSAPControlALLNOHDBINSTANCES StartStopOption = "SAPControl-ALLNOHDB-INSTANCES"
 
 	// NOTE: This was just copy-pasted from sap_host_exporter, not used right now
+	//nolint:lll
 	// see: https://github.com/SUSE/sap_host_exporter/blob/68bbf2f1b490ab0efaa2dd7b878b778f07fba2ab/lib/sapcontrol/webservice.go#L42
 	STATECOLOR_CODE_GRAY   STATECOLOR_CODE = 1
 	STATECOLOR_CODE_GREEN  STATECOLOR_CODE = 2
@@ -144,8 +146,8 @@ type InstanceProperty struct {
 type SAPInstance struct {
 	Hostname      string     `xml:"hostname,omitempty" json:"hostname,omitempty"`
 	InstanceNr    int32      `xml:"instanceNr,omitempty" json:"instanceNr"`
-	HttpPort      int32      `xml:"httpPort,omitempty" json:"httpPort,omitempty"`
-	HttpsPort     int32      `xml:"httpsPort,omitempty" json:"httpsPort,omitempty"`
+	HttpPort      int32      `xml:"httpPort,omitempty" json:"httpPort,omitempty"`   //nolint:revive
+	HttpsPort     int32      `xml:"httpsPort,omitempty" json:"httpsPort,omitempty"` //nolint:revive
 	StartPriority string     `xml:"startPriority,omitempty" json:"startPriority,omitempty"`
 	Features      string     `xml:"features,omitempty" json:"features,omitempty"`
 	Dispstatus    STATECOLOR `xml:"dispstatus,omitempty" json:"dispstatus,omitempty"`
@@ -329,6 +331,8 @@ func (s *webService) HAGetFailoverConfigContext(
 }
 
 // StartContext starts a SAP instance
+//
+//nolint:revive
 func (service *webService) StartContext(
 	ctx context.Context,
 	request *Start,
@@ -343,6 +347,8 @@ func (service *webService) StartContext(
 }
 
 // StopContext stops a SAP instance
+//
+//nolint:revive
 func (service *webService) StopContext(
 	ctx context.Context,
 	request *Stop,
@@ -357,6 +363,8 @@ func (service *webService) StopContext(
 }
 
 // StartSystemContext starts a SAP system
+//
+//nolint:revive
 func (service *webService) StartSystemContext(
 	ctx context.Context,
 	request *StartSystem,
@@ -371,6 +379,8 @@ func (service *webService) StartSystemContext(
 }
 
 // StopSystemContext stops a SAP system
+//
+//nolint:revive
 func (service *webService) StopSystemContext(
 	ctx context.Context,
 	request *StopSystem,

--- a/internal/core/sapsystem/sapcontrolapi/webservice.go
+++ b/internal/core/sapsystem/sapcontrolapi/webservice.go
@@ -1,5 +1,4 @@
 // generated
-// nolint
 package sapcontrolapi
 
 import (

--- a/internal/core/sapsystem/sapsystem_test.go
+++ b/internal/core/sapsystem/sapsystem_test.go
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: SUSE LLC
 // SPDX-License-Identifier: Apache-2.0
 
-//nolint:nosnakecase,dupl
 package sapsystem_test
 
 import (

--- a/internal/core/subscription/subscription_test.go
+++ b/internal/core/subscription/subscription_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"errors"
+
 	"github.com/stretchr/testify/suite"
 
 	"github.com/trento-project/agent/internal/core/subscription"
@@ -48,7 +49,7 @@ func (suite *SubscriptionTestSuite) TestNewSubscriptions() {
 			SubscriptionStatus: "ACTIVE",
 			Type:               "internal",
 		},
-		&subscription.Subscription{ //nolint
+		&subscription.Subscription{
 			Identifier: "sle-module-public-cloud",
 			Version:    "15.2",
 			Arch:       "x86_64",

--- a/internal/discovery/collector/publishing_test.go
+++ b/internal/discovery/collector/publishing_test.go
@@ -173,7 +173,7 @@ func (suite *PublishingTestSuite) runDiscoveryScenario(discoveryType string, pay
 
 		suite.Equal(req.URL.String(), "https://localhost/api/v1/collect")
 		suite.Equal(req.Header.Get("X-Trento-apiKey"), apiKey)
-		return &http.Response{ //nolint
+		return &http.Response{
 			StatusCode: 202,
 		}
 	})

--- a/internal/discovery/collector/publishing_test.go
+++ b/internal/discovery/collector/publishing_test.go
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: SUSE LLC
 // SPDX-License-Identifier: Apache-2.0
 
-//nolint:lll
 package collector_test
 
 import (

--- a/internal/discovery/mapper.go
+++ b/internal/discovery/mapper.go
@@ -7,11 +7,13 @@ import (
 	"github.com/trento-project/contracts/go/pkg/events"
 )
 
+//nolint:revive
 type DiscoveryRequested struct {
 	DiscoveryType string
 	Targets       []string
 }
 
+//nolint:revive
 func DiscoveryRequestedFromEvent(event []byte) (*DiscoveryRequested, error) {
 	var discoveryRequested events.DiscoveryRequested
 

--- a/internal/discovery/mapper.go
+++ b/internal/discovery/mapper.go
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: SUSE LLC
 // SPDX-License-Identifier: Apache-2.0
 
-// nolint:revive
 package discovery
 
 import (

--- a/internal/discovery/mocks/discovered_cloud_mock.go
+++ b/internal/discovery/mocks/discovered_cloud_mock.go
@@ -10,7 +10,7 @@ import (
 )
 
 func NewDiscoveredCloudMock() cloud.Instance {
-	metadata := &cloud.AzureMetadata{} //nolint
+	metadata := &cloud.AzureMetadata{}
 
 	jsonFile, err := os.Open(helpers.GetFixturePath("discovery/azure/azure_metadata.json"))
 	if err != nil {

--- a/internal/discovery/policy_integration_test.go
+++ b/internal/discovery/policy_integration_test.go
@@ -66,7 +66,6 @@ func (suite *PolicyIntegrationTestSuite) TearDownTest() {
 	}
 }
 
-// nolint:nosnakecase
 func (suite *PolicyIntegrationTestSuite) TestDiscoveryIntegration() {
 	agentID := "some-agent"
 	ctx, ctxCancel := context.WithCancel(context.Background())

--- a/internal/factsengine/factscache/cache.go
+++ b/internal/factsengine/factscache/cache.go
@@ -54,7 +54,7 @@ func GetOrUpdate(
 func (c *FactsCache) Entries() []string {
 	keys := []string{}
 	c.entries.Range(func(key, _ any) bool {
-		keys = append(keys, key.(string))
+		keys = append(keys, key.(string)) //nolint:forcetypeassert
 		return true
 	})
 	return keys
@@ -74,7 +74,7 @@ func (c *FactsCache) GetOrUpdate(
 	loadedEntry, hit := c.entries.Load(entry)
 	if hit {
 
-		cacheEntry := loadedEntry.(Entry)
+		cacheEntry := loadedEntry.(Entry) //nolint:forcetypeassert
 		slog.Debug("Value for entry already cached", "entry", entry)
 		return cacheEntry.content, cacheEntry.err
 	}

--- a/internal/factsengine/factscache/cache.go
+++ b/internal/factsengine/factscache/cache.go
@@ -54,7 +54,6 @@ func GetOrUpdate(
 func (c *FactsCache) Entries() []string {
 	keys := []string{}
 	c.entries.Range(func(key, _ any) bool {
-		// nolint:forcetypeassert
 		keys = append(keys, key.(string))
 		return true
 	})
@@ -74,7 +73,7 @@ func (c *FactsCache) GetOrUpdate(
 ) (interface{}, error) {
 	loadedEntry, hit := c.entries.Load(entry)
 	if hit {
-		// nolint:forcetypeassert
+
 		cacheEntry := loadedEntry.(Entry)
 		slog.Debug("Value for entry already cached", "entry", entry)
 		return cacheEntry.content, cacheEntry.err

--- a/internal/factsengine/factscache/cache_test.go
+++ b/internal/factsengine/factscache/cache_test.go
@@ -33,10 +33,10 @@ func (suite *FactsCacheTestSuite) SetupTest() {
 
 func (suite *FactsCacheTestSuite) TestEntries() {
 	cache := factscache.NewFactsCache()
-	cache.GetOrUpdate("entry1", func(_ ...interface{}) (interface{}, error) {
+	cache.GetOrUpdate("entry1", func(_ ...interface{}) (interface{}, error) { //nolint:errcheck
 		return "", nil
 	})
-	cache.GetOrUpdate("entry2", func(_ ...interface{}) (interface{}, error) {
+	cache.GetOrUpdate("entry2", func(_ ...interface{}) (interface{}, error) { //nolint:errcheck
 		return "", nil
 	})
 	entries := cache.Entries()
@@ -78,7 +78,7 @@ func (suite *FactsCacheTestSuite) TestGetOrUpdateCacheHit() {
 		return suite.returnValue, nil
 	}
 
-	cache.GetOrUpdate("entry", updateFunc)
+	cache.GetOrUpdate("entry", updateFunc) //nolint:errcheck
 	value, err := cache.GetOrUpdate("entry", updateFunc)
 
 	suite.Equal(suite.returnValue, value)
@@ -90,8 +90,8 @@ func (suite *FactsCacheTestSuite) TestGetOrUpdateWithArgs() {
 	cache := factscache.NewFactsCache()
 
 	updateFunc := func(args ...interface{}) (interface{}, error) {
-		arg1 := args[0].(int)
-		arg2 := args[1].(string)
+		arg1 := args[0].(int)    //nolint:forcetypeassert
+		arg2 := args[1].(string) //nolint:forcetypeassert
 		return fmt.Sprintf("%d_%s", arg1, arg2), nil
 	}
 
@@ -138,7 +138,7 @@ func (suite *FactsCacheTestSuite) TestGetOrUpdateCacheConcurrent() {
 		suite.Equal("initialValueEntry2", castedValue)
 		return nil
 	})
-	g.Wait()
+	g.Wait() //nolint:errcheck
 }
 
 func (suite *FactsCacheTestSuite) TestPureGetOrUpdate() {
@@ -162,7 +162,7 @@ func (suite *FactsCacheTestSuite) TestPureGetOrUpdateCacheHit() {
 		return suite.returnValue, nil
 	}
 
-	factscache.GetOrUpdate(cache, "entry1", updateFunc)
+	factscache.GetOrUpdate(cache, "entry1", updateFunc) //nolint:errcheck
 	value, err := factscache.GetOrUpdate(cache, "entry1", updateFunc)
 
 	suite.Equal(suite.returnValue, value)

--- a/internal/factsengine/factscache/cache_test.go
+++ b/internal/factsengine/factscache/cache_test.go
@@ -31,7 +31,6 @@ func (suite *FactsCacheTestSuite) SetupTest() {
 	suite.count = 0
 }
 
-// nolint:errcheck
 func (suite *FactsCacheTestSuite) TestEntries() {
 	cache := factscache.NewFactsCache()
 	cache.GetOrUpdate("entry1", func(_ ...interface{}) (interface{}, error) {
@@ -79,7 +78,6 @@ func (suite *FactsCacheTestSuite) TestGetOrUpdateCacheHit() {
 		return suite.returnValue, nil
 	}
 
-	// nolint:errcheck
 	cache.GetOrUpdate("entry", updateFunc)
 	value, err := cache.GetOrUpdate("entry", updateFunc)
 
@@ -91,7 +89,6 @@ func (suite *FactsCacheTestSuite) TestGetOrUpdateCacheHit() {
 func (suite *FactsCacheTestSuite) TestGetOrUpdateWithArgs() {
 	cache := factscache.NewFactsCache()
 
-	// nolint:forcetypeassert
 	updateFunc := func(args ...interface{}) (interface{}, error) {
 		arg1 := args[0].(int)
 		arg2 := args[1].(string)
@@ -104,7 +101,6 @@ func (suite *FactsCacheTestSuite) TestGetOrUpdateWithArgs() {
 	suite.NoError(err)
 }
 
-// nolint:errcheck
 func (suite *FactsCacheTestSuite) TestGetOrUpdateCacheConcurrent() {
 	cache := factscache.NewFactsCache()
 	g := errgroup.Group{}
@@ -166,7 +162,6 @@ func (suite *FactsCacheTestSuite) TestPureGetOrUpdateCacheHit() {
 		return suite.returnValue, nil
 	}
 
-	// nolint:errcheck
 	factscache.GetOrUpdate(cache, "entry1", updateFunc)
 	value, err := factscache.GetOrUpdate(cache, "entry1", updateFunc)
 

--- a/internal/factsengine/factsengine_integration_test.go
+++ b/internal/factsengine/factsengine_integration_test.go
@@ -88,7 +88,6 @@ func (s *FactsEngineIntegrationTestGatherer) Gather(_ context.Context, requests 
 	return facts, nil
 }
 
-// nolint:nosnakecase
 func (suite *FactsEngineIntegrationTestSuite) TestFactsEngineIntegration() {
 	agentID := "some-agent"
 

--- a/internal/factsengine/factsengine_test.go
+++ b/internal/factsengine/factsengine_test.go
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: SUSE LLC
 // SPDX-License-Identifier: Apache-2.0
 
-//nolint:lll
 package factsengine_test
 
 import (

--- a/internal/factsengine/gatherers/_todo/crmmon_test.go
+++ b/internal/factsengine/gatherers/_todo/crmmon_test.go
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: SUSE LLC
 // SPDX-License-Identifier: Apache-2.0
 
-package gatherers // nolint
+package gatherers
 
 import (
 	"context"

--- a/internal/factsengine/gatherers/ascsers_cluster.go
+++ b/internal/factsengine/gatherers/ascsers_cluster.go
@@ -26,6 +26,7 @@ const (
 	EnsaUnknown                = "unknown"
 )
 
+//nolint:gochecknoglobals
 var (
 	AscsErsClusterDecodingError = entities.FactGatheringError{
 		Type:    "ascsers-cluster-decoding-error",

--- a/internal/factsengine/gatherers/ascsers_cluster.go
+++ b/internal/factsengine/gatherers/ascsers_cluster.go
@@ -26,7 +26,6 @@ const (
 	EnsaUnknown                = "unknown"
 )
 
-// nolint:gochecknoglobals
 var (
 	AscsErsClusterDecodingError = entities.FactGatheringError{
 		Type:    "ascsers-cluster-decoding-error",

--- a/internal/factsengine/gatherers/ascsers_cluster_test.go
+++ b/internal/factsengine/gatherers/ascsers_cluster_test.go
@@ -202,7 +202,6 @@ func (suite *AscsErsClusterTestSuite) TestAscsErsClusterGather() {
 
 	results, err := p.Gather(context.Background(), factRequests)
 
-	// nolint:dupl
 	expectedFacts := []entities.Fact{
 		{
 			Name:    "ascsers",

--- a/internal/factsengine/gatherers/cibadmin.go
+++ b/internal/factsengine/gatherers/cibadmin.go
@@ -17,7 +17,6 @@ const (
 	CibAdminGathererCache = "cibadmin"
 )
 
-// nolint:gochecknoglobals
 var (
 	CibAdminCommandError = entities.FactGatheringError{
 		Type:    "cibadmin-command-error",

--- a/internal/factsengine/gatherers/cibadmin.go
+++ b/internal/factsengine/gatherers/cibadmin.go
@@ -17,6 +17,7 @@ const (
 	CibAdminGathererCache = "cibadmin"
 )
 
+//nolint:gochecknoglobals
 var (
 	CibAdminCommandError = entities.FactGatheringError{
 		Type:    "cibadmin-command-error",

--- a/internal/factsengine/gatherers/corosynccmapctl.go
+++ b/internal/factsengine/gatherers/corosynccmapctl.go
@@ -16,6 +16,7 @@ const (
 	CorosyncCmapCtlGathererName = "corosync-cmapctl"
 )
 
+//nolint:gochecknoglobals
 var (
 	CorosyncCmapCtlValueNotFound = entities.FactGatheringError{
 		Type:    "corosync-cmapctl-value-not-found",

--- a/internal/factsengine/gatherers/corosynccmapctl.go
+++ b/internal/factsengine/gatherers/corosynccmapctl.go
@@ -16,7 +16,6 @@ const (
 	CorosyncCmapCtlGathererName = "corosync-cmapctl"
 )
 
-// nolint:gochecknoglobals
 var (
 	CorosyncCmapCtlValueNotFound = entities.FactGatheringError{
 		Type:    "corosync-cmapctl-value-not-found",

--- a/internal/factsengine/gatherers/corosynccmapctl_test.go
+++ b/internal/factsengine/gatherers/corosynccmapctl_test.go
@@ -32,7 +32,6 @@ func (suite *CorosyncCmapctlTestSuite) SetupTest() {
 	suite.mockExecutor = new(utilsMocks.MockCommandExecutor)
 }
 
-// nolint:dupl
 func (suite *CorosyncCmapctlTestSuite) TestCorosyncCmapctlGathererNoArgumentProvided() {
 	mockOutputFile, _ := os.Open(helpers.GetFixturePath("gatherers/corosynccmap-ctl.output"))
 	mockOutput, _ := io.ReadAll(mockOutputFile)

--- a/internal/factsengine/gatherers/corosyncconf.go
+++ b/internal/factsengine/gatherers/corosyncconf.go
@@ -25,7 +25,6 @@ var (
 	valuePatternCompiled        = regexp.MustCompile(`^\s*(\w+)\s*:\s*(\S+).*`)
 )
 
-// nolint:gochecknoglobals
 var (
 	CorosyncConfFileError = entities.FactGatheringError{
 		Type:    "corosync-conf-file-error",

--- a/internal/factsengine/gatherers/corosyncconf.go
+++ b/internal/factsengine/gatherers/corosyncconf.go
@@ -25,6 +25,7 @@ var (
 	valuePatternCompiled        = regexp.MustCompile(`^\s*(\w+)\s*:\s*(\S+).*`)
 )
 
+//nolint:gochecknoglobals
 var (
 	CorosyncConfFileError = entities.FactGatheringError{
 		Type:    "corosync-conf-file-error",

--- a/internal/factsengine/gatherers/dir_scan.go
+++ b/internal/factsengine/gatherers/dir_scan.go
@@ -21,6 +21,7 @@ const (
 	DirScanGathererName = "dir_scan"
 )
 
+//nolint:gochecknoglobals
 var (
 	DirScanMissingArgumentError = entities.FactGatheringError{
 		Type:    "dir-scan-missing-argument",

--- a/internal/factsengine/gatherers/dir_scan.go
+++ b/internal/factsengine/gatherers/dir_scan.go
@@ -21,7 +21,6 @@ const (
 	DirScanGathererName = "dir_scan"
 )
 
-// nolint:gochecknoglobals
 var (
 	DirScanMissingArgumentError = entities.FactGatheringError{
 		Type:    "dir-scan-missing-argument",
@@ -136,7 +135,7 @@ func (d *DirScanGatherer) getDirScanDetailsForPath(path string) (*DirScanDetails
 		return nil, err
 	}
 
-	stat, ok := fi.Sys().(*syscall.Stat_t) //nolint
+	stat, ok := fi.Sys().(*syscall.Stat_t)
 	if !ok {
 		return nil, fmt.Errorf("could not extract stat infos for file %s", path)
 	}

--- a/internal/factsengine/gatherers/dispwork.go
+++ b/internal/factsengine/gatherers/dispwork.go
@@ -22,7 +22,6 @@ const (
 	DispWorkGathererName = "disp+work"
 )
 
-// nolint:gochecknoglobals
 var (
 	DispWorkFileSystemError = entities.FactGatheringError{
 		Type:    "dispwork-file-system-error",

--- a/internal/factsengine/gatherers/dispwork.go
+++ b/internal/factsengine/gatherers/dispwork.go
@@ -22,6 +22,7 @@ const (
 	DispWorkGathererName = "disp+work"
 )
 
+//nolint:gochecknoglobals
 var (
 	DispWorkFileSystemError = entities.FactGatheringError{
 		Type:    "dispwork-file-system-error",

--- a/internal/factsengine/gatherers/fs_usage.go
+++ b/internal/factsengine/gatherers/fs_usage.go
@@ -20,7 +20,6 @@ const (
 	FSUsageGathererName = "fs_usage"
 )
 
-// nolint:gochecknoglobals
 var (
 	FSUsageInvalidFormatError = entities.FactGatheringError{
 		Type:    "fs-usage-invalid-format-error",
@@ -180,7 +179,6 @@ func (f *FSUsageGatherer) gatherAll(ctx context.Context) ([]FSUsageEntry, *entit
 	return entries, nil
 }
 
-// nolint:lll
 func (f *FSUsageGatherer) gatherSingle(ctx context.Context, file string) ([]FSUsageEntry, *entities.FactGatheringError) {
 	// Output in 1024 Blocks
 	content, err := f.executor.OutputContext(ctx, "/usr/bin/df", "-k", "-P", "--", file)

--- a/internal/factsengine/gatherers/fs_usage.go
+++ b/internal/factsengine/gatherers/fs_usage.go
@@ -20,6 +20,7 @@ const (
 	FSUsageGathererName = "fs_usage"
 )
 
+//nolint:gochecknoglobals
 var (
 	FSUsageInvalidFormatError = entities.FactGatheringError{
 		Type:    "fs-usage-invalid-format-error",
@@ -179,7 +180,7 @@ func (f *FSUsageGatherer) gatherAll(ctx context.Context) ([]FSUsageEntry, *entit
 	return entries, nil
 }
 
-func (f *FSUsageGatherer) gatherSingle(ctx context.Context, file string) ([]FSUsageEntry, *entities.FactGatheringError) {
+func (f *FSUsageGatherer) gatherSingle(ctx context.Context, file string) ([]FSUsageEntry, *entities.FactGatheringError) { //nolint:lll
 	// Output in 1024 Blocks
 	content, err := f.executor.OutputContext(ctx, "/usr/bin/df", "-k", "-P", "--", file)
 	if err != nil {

--- a/internal/factsengine/gatherers/fstab.go
+++ b/internal/factsengine/gatherers/fstab.go
@@ -20,6 +20,7 @@ const (
 	FstabFilePath     = "/etc/fstab"
 )
 
+//nolint:gochecknoglobals
 var (
 	FstabFileError = entities.FactGatheringError{
 		Type:    "fstab-file-error",

--- a/internal/factsengine/gatherers/fstab.go
+++ b/internal/factsengine/gatherers/fstab.go
@@ -20,7 +20,6 @@ const (
 	FstabFilePath     = "/etc/fstab"
 )
 
-// nolint:gochecknoglobals
 var (
 	FstabFileError = entities.FactGatheringError{
 		Type:    "fstab-file-error",

--- a/internal/factsengine/gatherers/gatherer.go
+++ b/internal/factsengine/gatherers/gatherer.go
@@ -10,7 +10,7 @@ import (
 	"github.com/trento-project/agent/pkg/factsengine/entities"
 )
 
-// nolint:gochecknoglobals
+
 var ImplementationError = entities.FactGatheringError{
 	Type:    "implemetation-error",
 	Message: "implementation error",

--- a/internal/factsengine/gatherers/gatherer.go
+++ b/internal/factsengine/gatherers/gatherer.go
@@ -10,7 +10,7 @@ import (
 	"github.com/trento-project/agent/pkg/factsengine/entities"
 )
 
-
+//nolint:gochecknoglobals
 var ImplementationError = entities.FactGatheringError{
 	Type:    "implemetation-error",
 	Message: "implementation error",

--- a/internal/factsengine/gatherers/groups.go
+++ b/internal/factsengine/gatherers/groups.go
@@ -22,6 +22,7 @@ const (
 	GroupsFilePath     = "/etc/group"
 )
 
+//nolint:gochecknoglobals
 var (
 	GroupsFileError = entities.FactGatheringError{
 		Type:    "groups-file-error",

--- a/internal/factsengine/gatherers/groups.go
+++ b/internal/factsengine/gatherers/groups.go
@@ -22,7 +22,6 @@ const (
 	GroupsFilePath     = "/etc/group"
 )
 
-// nolint:gochecknoglobals
 var (
 	GroupsFileError = entities.FactGatheringError{
 		Type:    "groups-file-error",

--- a/internal/factsengine/gatherers/hostsfile.go
+++ b/internal/factsengine/gatherers/hostsfile.go
@@ -27,7 +27,6 @@ var (
 	hostsEntryCompiled = regexp.MustCompile(hostsParsingRegexp)
 )
 
-// nolint:gochecknoglobals
 var (
 	HostsFileError = entities.FactGatheringError{
 		Type:    "hosts-file-error",

--- a/internal/factsengine/gatherers/hostsfile.go
+++ b/internal/factsengine/gatherers/hostsfile.go
@@ -27,6 +27,7 @@ var (
 	hostsEntryCompiled = regexp.MustCompile(hostsParsingRegexp)
 )
 
+//nolint:gochecknoglobals
 var (
 	HostsFileError = entities.FactGatheringError{
 		Type:    "hosts-file-error",

--- a/internal/factsengine/gatherers/ini_files.go
+++ b/internal/factsengine/gatherers/ini_files.go
@@ -20,6 +20,7 @@ const (
 	IniFilesGathererName = "ini_files"
 )
 
+//nolint:gochecknoglobals
 var (
 	IniFilesError = entities.FactGatheringError{
 		Type:    "ini-files-error",

--- a/internal/factsengine/gatherers/ini_files.go
+++ b/internal/factsengine/gatherers/ini_files.go
@@ -20,7 +20,6 @@ const (
 	IniFilesGathererName = "ini_files"
 )
 
-// nolint:gochecknoglobals
 var (
 	IniFilesError = entities.FactGatheringError{
 		Type:    "ini-files-error",

--- a/internal/factsengine/gatherers/mountinfo.go
+++ b/internal/factsengine/gatherers/mountinfo.go
@@ -19,7 +19,6 @@ const (
 	MountInfoGathererName = "mount_info"
 )
 
-// nolint:gochecknoglobals
 var (
 	MountInfoParsingError = entities.FactGatheringError{
 		Type:    "mount-info-parsing-error",

--- a/internal/factsengine/gatherers/mountinfo.go
+++ b/internal/factsengine/gatherers/mountinfo.go
@@ -19,6 +19,7 @@ const (
 	MountInfoGathererName = "mount_info"
 )
 
+//nolint:gochecknoglobals
 var (
 	MountInfoParsingError = entities.FactGatheringError{
 		Type:    "mount-info-parsing-error",

--- a/internal/factsengine/gatherers/osrelease.go
+++ b/internal/factsengine/gatherers/osrelease.go
@@ -18,7 +18,6 @@ const (
 	OSReleaseFilePath     = "/etc/os-release"
 )
 
-// nolint:gochecknoglobals
 var (
 	OSReleaseFileError = entities.FactGatheringError{
 		Type:    "os-release-file-error",

--- a/internal/factsengine/gatherers/osrelease.go
+++ b/internal/factsengine/gatherers/osrelease.go
@@ -18,6 +18,7 @@ const (
 	OSReleaseFilePath     = "/etc/os-release"
 )
 
+//nolint:gochecknoglobals
 var (
 	OSReleaseFileError = entities.FactGatheringError{
 		Type:    "os-release-file-error",

--- a/internal/factsengine/gatherers/packageversion.go
+++ b/internal/factsengine/gatherers/packageversion.go
@@ -25,6 +25,7 @@ const (
 	packageVersionQueryFormat  = "VERSION=%{VERSION}\nINSTALLTIME=%{INSTALLTIME}\n---\n"
 )
 
+//nolint:gochecknoglobals
 var (
 	PackageVersionRpmCommandError = entities.FactGatheringError{
 		Type:    "package-version-rpm-cmd-error",

--- a/internal/factsengine/gatherers/packageversion.go
+++ b/internal/factsengine/gatherers/packageversion.go
@@ -25,7 +25,6 @@ const (
 	packageVersionQueryFormat  = "VERSION=%{VERSION}\nINSTALLTIME=%{INSTALLTIME}\n---\n"
 )
 
-// nolint:gochecknoglobals
 var (
 	PackageVersionRpmCommandError = entities.FactGatheringError{
 		Type:    "package-version-rpm-cmd-error",

--- a/internal/factsengine/gatherers/passwd.go
+++ b/internal/factsengine/gatherers/passwd.go
@@ -20,7 +20,6 @@ const (
 	PasswdFilePath     = "/etc/passwd"
 )
 
-// nolint:gochecknoglobals
 var (
 	PasswdFileError = entities.FactGatheringError{
 		Type:    "passwd-file-error",

--- a/internal/factsengine/gatherers/passwd.go
+++ b/internal/factsengine/gatherers/passwd.go
@@ -20,6 +20,7 @@ const (
 	PasswdFilePath     = "/etc/passwd"
 )
 
+//nolint:gochecknoglobals
 var (
 	PasswdFileError = entities.FactGatheringError{
 		Type:    "passwd-file-error",

--- a/internal/factsengine/gatherers/products.go
+++ b/internal/factsengine/gatherers/products.go
@@ -18,7 +18,6 @@ const (
 	productsDefaultPath  = "/etc/products.d/"
 )
 
-// nolint:gochecknoglobals
 var (
 	ProductsFolderMissingError = entities.FactGatheringError{
 		Type:    "products-folder-missing-error",

--- a/internal/factsengine/gatherers/products.go
+++ b/internal/factsengine/gatherers/products.go
@@ -18,6 +18,7 @@ const (
 	productsDefaultPath  = "/etc/products.d/"
 )
 
+//nolint:gochecknoglobals
 var (
 	ProductsFolderMissingError = entities.FactGatheringError{
 		Type:    "products-folder-missing-error",

--- a/internal/factsengine/gatherers/rpc_plugin.go
+++ b/internal/factsengine/gatherers/rpc_plugin.go
@@ -27,7 +27,7 @@ func (l *RPCPluginLoader) Load(pluginPath string) (FactGatherer, error) {
 		MagicCookieValue: "gatherer",
 	}
 
-	client := goplugin.NewClient(&goplugin.ClientConfig{ // nolint
+	client := goplugin.NewClient(&goplugin.ClientConfig{
 		HandshakeConfig: handshakeConfig,
 		Plugins:         pluginMap,
 		Cmd:             exec.Command(pluginPath),

--- a/internal/factsengine/gatherers/sapcontrol.go
+++ b/internal/factsengine/gatherers/sapcontrol.go
@@ -24,6 +24,7 @@ const (
 	SapControlGathererCache = "sapcontrol"
 )
 
+//nolint:gochecknoglobals
 var whitelistedSapControlArguments = map[string]func(context.Context, sapcontrolapi.WebService) (interface{}, error){
 	"GetProcessList":        mapGetProcessList,
 	"GetSystemInstanceList": mapGetSystemInstanceList,
@@ -32,6 +33,7 @@ var whitelistedSapControlArguments = map[string]func(context.Context, sapcontrol
 	"HAGetFailoverConfig":   mapHAGetFailoverConfig,
 }
 
+//nolint:gochecknoglobals
 var (
 	SapcontrolFileSystemError = entities.FactGatheringError{
 		Type:    "sapcontrol-file-system-error",

--- a/internal/factsengine/gatherers/sapcontrol.go
+++ b/internal/factsengine/gatherers/sapcontrol.go
@@ -24,7 +24,6 @@ const (
 	SapControlGathererCache = "sapcontrol"
 )
 
-// nolint:gochecknoglobals
 var whitelistedSapControlArguments = map[string]func(context.Context, sapcontrolapi.WebService) (interface{}, error){
 	"GetProcessList":        mapGetProcessList,
 	"GetSystemInstanceList": mapGetSystemInstanceList,
@@ -33,7 +32,6 @@ var whitelistedSapControlArguments = map[string]func(context.Context, sapcontrol
 	"HAGetFailoverConfig":   mapHAGetFailoverConfig,
 }
 
-// nolint:gochecknoglobals
 var (
 	SapcontrolFileSystemError = entities.FactGatheringError{
 		Type:    "sapcontrol-file-system-error",

--- a/internal/factsengine/gatherers/saphostctrl.go
+++ b/internal/factsengine/gatherers/saphostctrl.go
@@ -24,11 +24,13 @@ var (
 	saphostCtrlPingParsingRegexp = regexp.MustCompile(`(SUCCESS|FAILED) \( *(\d+) usec\)`)
 )
 
+//nolint:gochecknoglobals
 var whitelistedWebmethods = map[string]func(string) (entities.FactValue, *entities.FactGatheringError){
 	"Ping":          parsePing,
 	"ListInstances": parseInstances,
 }
 
+//nolint:gochecknoglobals
 var (
 	SapHostCtrlCommandError = entities.FactGatheringError{
 		Type:    "saphostctrl-cmd-error",

--- a/internal/factsengine/gatherers/saphostctrl.go
+++ b/internal/factsengine/gatherers/saphostctrl.go
@@ -17,7 +17,6 @@ const (
 	SapHostCtrlGathererName = "saphostctrl"
 )
 
-// nolint:gochecknoglobals
 var (
 	saphostCtrlListInstancesParsingRegexp = regexp.MustCompile(`^\s+Inst Info\s*` +
 		`:\s*([^-]+?)\s*-\s*(\d+)\s*-\s*([^,]+?)` +
@@ -25,13 +24,11 @@ var (
 	saphostCtrlPingParsingRegexp = regexp.MustCompile(`(SUCCESS|FAILED) \( *(\d+) usec\)`)
 )
 
-// nolint:gochecknoglobals
 var whitelistedWebmethods = map[string]func(string) (entities.FactValue, *entities.FactGatheringError){
 	"Ping":          parsePing,
 	"ListInstances": parseInstances,
 }
 
-// nolint:gochecknoglobals
 var (
 	SapHostCtrlCommandError = entities.FactGatheringError{
 		Type:    "saphostctrl-cmd-error",

--- a/internal/factsengine/gatherers/sapinstancehostnameresolver.go
+++ b/internal/factsengine/gatherers/sapinstancehostnameresolver.go
@@ -22,7 +22,6 @@ const (
 	SapInstanceHostnameResolverGathererName = "sapinstance_hostname_resolver"
 )
 
-// nolint:gochecknoglobals
 var (
 	hostnameRegexCompiled                   = regexp.MustCompile(`(.+)_(.+)_(.+)`) // <SID>_<InstanceNumber>_<Hostname>
 	regexSubgroupsCount                     = 4

--- a/internal/factsengine/gatherers/sapinstancehostnameresolver.go
+++ b/internal/factsengine/gatherers/sapinstancehostnameresolver.go
@@ -22,6 +22,7 @@ const (
 	SapInstanceHostnameResolverGathererName = "sapinstance_hostname_resolver"
 )
 
+//nolint:gochecknoglobals
 var (
 	hostnameRegexCompiled                   = regexp.MustCompile(`(.+)_(.+)_(.+)`) // <SID>_<InstanceNumber>_<Hostname>
 	regexSubgroupsCount                     = 4

--- a/internal/factsengine/gatherers/sapprofiles.go
+++ b/internal/factsengine/gatherers/sapprofiles.go
@@ -20,6 +20,7 @@ const (
 	sapMntPath              = "/sapmnt"
 )
 
+//nolint:gochecknoglobals
 var (
 	SapProfilesFileSystemError = entities.FactGatheringError{
 		Type:    "sap-profiles-file-system-error",

--- a/internal/factsengine/gatherers/sapprofiles.go
+++ b/internal/factsengine/gatherers/sapprofiles.go
@@ -20,7 +20,6 @@ const (
 	sapMntPath              = "/sapmnt"
 )
 
-// nolint:gochecknoglobals
 var (
 	SapProfilesFileSystemError = entities.FactGatheringError{
 		Type:    "sap-profiles-file-system-error",

--- a/internal/factsengine/gatherers/sapservices.go
+++ b/internal/factsengine/gatherers/sapservices.go
@@ -26,6 +26,7 @@ const (
 	SapServicesGathererName                           = "sapservices"
 )
 
+//nolint:gochecknoglobals
 var (
 	SapServicesParsingError = entities.FactGatheringError{
 		Type:    "sap-services-parsing-error",

--- a/internal/factsengine/gatherers/sapservices.go
+++ b/internal/factsengine/gatherers/sapservices.go
@@ -26,7 +26,6 @@ const (
 	SapServicesGathererName                           = "sapservices"
 )
 
-// nolint:gochecknoglobals
 var (
 	SapServicesParsingError = entities.FactGatheringError{
 		Type:    "sap-services-parsing-error",

--- a/internal/factsengine/gatherers/saptune.go
+++ b/internal/factsengine/gatherers/saptune.go
@@ -27,7 +27,6 @@ const (
 	saptuneCheckArg          validSaptuneArgument = "check"
 )
 
-// nolint:gochecknoglobals
 var whitelistedArguments = map[validSaptuneArgument]struct{}{
 	saptuneStatusArg:         {},
 	saptuneSolutionVerifyArg: {},
@@ -39,12 +38,11 @@ var whitelistedArguments = map[validSaptuneArgument]struct{}{
 
 // Map to store supported saptune versions for specific commands.
 // Arguments not present in this map use the global supported version
-// nolint:gochecknoglobals
+
 var argumentSupportedVersions = map[validSaptuneArgument]string{
 	saptuneCheckArg: "3.2.0",
 }
 
-// nolint:gochecknoglobals
 var (
 	SaptuneNotInstalled = entities.FactGatheringError{
 		Type:    "saptune-not-installed",

--- a/internal/factsengine/gatherers/saptune.go
+++ b/internal/factsengine/gatherers/saptune.go
@@ -27,6 +27,7 @@ const (
 	saptuneCheckArg          validSaptuneArgument = "check"
 )
 
+//nolint:gochecknoglobals
 var whitelistedArguments = map[validSaptuneArgument]struct{}{
 	saptuneStatusArg:         {},
 	saptuneSolutionVerifyArg: {},
@@ -38,11 +39,13 @@ var whitelistedArguments = map[validSaptuneArgument]struct{}{
 
 // Map to store supported saptune versions for specific commands.
 // Arguments not present in this map use the global supported version
-
+//
+//nolint:gochecknoglobals
 var argumentSupportedVersions = map[validSaptuneArgument]string{
 	saptuneCheckArg: "3.2.0",
 }
 
+//nolint:gochecknoglobals
 var (
 	SaptuneNotInstalled = entities.FactGatheringError{
 		Type:    "saptune-not-installed",

--- a/internal/factsengine/gatherers/saptune_test.go
+++ b/internal/factsengine/gatherers/saptune_test.go
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: SUSE LLC
 // SPDX-License-Identifier: Apache-2.0
 
-//nolint:dupl
 package gatherers_test
 
 import (

--- a/internal/factsengine/gatherers/sbd.go
+++ b/internal/factsengine/gatherers/sbd.go
@@ -15,6 +15,7 @@ const (
 	SBDConfigGathererName = "sbd_config"
 )
 
+//nolint:gochecknoglobals
 var (
 	SBDConfigFileError = entities.FactGatheringError{
 		Type:    "sbd-config-file-error",

--- a/internal/factsengine/gatherers/sbd.go
+++ b/internal/factsengine/gatherers/sbd.go
@@ -15,7 +15,6 @@ const (
 	SBDConfigGathererName = "sbd_config"
 )
 
-// nolint:gochecknoglobals
 var (
 	SBDConfigFileError = entities.FactGatheringError{
 		Type:    "sbd-config-file-error",

--- a/internal/factsengine/gatherers/sbddump.go
+++ b/internal/factsengine/gatherers/sbddump.go
@@ -23,6 +23,7 @@ const (
 
 var undesiredParenthesesRegexp = regexp.MustCompile(`[()]`)
 
+//nolint:gochecknoglobals
 var (
 	SBDDevicesLoadingError = entities.FactGatheringError{
 		Type:    "sbd-devices-loading-error",

--- a/internal/factsengine/gatherers/sbddump.go
+++ b/internal/factsengine/gatherers/sbddump.go
@@ -23,7 +23,6 @@ const (
 
 var undesiredParenthesesRegexp = regexp.MustCompile(`[()]`)
 
-// nolint:gochecknoglobals
 var (
 	SBDDevicesLoadingError = entities.FactGatheringError{
 		Type:    "sbd-devices-loading-error",

--- a/internal/factsengine/gatherers/sudoers.go
+++ b/internal/factsengine/gatherers/sudoers.go
@@ -24,6 +24,7 @@ const (
 	SudoersGathererName = "sudoers"
 )
 
+//nolint:gochecknoglobals
 var (
 	SudoersReadError = entities.FactGatheringError{
 		Type:    "sudoers-read-error",

--- a/internal/factsengine/gatherers/sudoers.go
+++ b/internal/factsengine/gatherers/sudoers.go
@@ -24,7 +24,6 @@ const (
 	SudoersGathererName = "sudoers"
 )
 
-// nolint:gochecknoglobals
 var (
 	SudoersReadError = entities.FactGatheringError{
 		Type:    "sudoers-read-error",

--- a/internal/factsengine/gatherers/sysctl.go
+++ b/internal/factsengine/gatherers/sysctl.go
@@ -17,7 +17,6 @@ const (
 	SysctlGathererName = "sysctl"
 )
 
-// nolint:gochecknoglobals
 var (
 	SysctlValueNotFound = entities.FactGatheringError{
 		Type:    "sysctl-value-not-found",

--- a/internal/factsengine/gatherers/sysctl.go
+++ b/internal/factsengine/gatherers/sysctl.go
@@ -17,6 +17,7 @@ const (
 	SysctlGathererName = "sysctl"
 )
 
+//nolint:gochecknoglobals
 var (
 	SysctlValueNotFound = entities.FactGatheringError{
 		Type:    "sysctl-value-not-found",

--- a/internal/factsengine/gatherers/sysctl_test.go
+++ b/internal/factsengine/gatherers/sysctl_test.go
@@ -32,7 +32,6 @@ func (suite *SysctlTestSuite) SetupTest() {
 	suite.mockExecutor = new(utilsMocks.MockCommandExecutor)
 }
 
-// nolint:dupl
 func (suite *SysctlTestSuite) TestSysctlGathererNoArgumentProvided() {
 	mockOutputFile, _ := os.Open(helpers.GetFixturePath("gatherers/sysctl.output"))
 	mockOutput, _ := io.ReadAll(mockOutputFile)

--- a/internal/factsengine/gatherers/systemd.go
+++ b/internal/factsengine/gatherers/systemd.go
@@ -16,7 +16,6 @@ const (
 	SystemDGathererName = "systemd"
 )
 
-// nolint:gochecknoglobals
 var (
 	SystemDNotInitializedError = entities.FactGatheringError{
 		Type:    "systemd-dbus-not-initialized",

--- a/internal/factsengine/gatherers/systemd.go
+++ b/internal/factsengine/gatherers/systemd.go
@@ -16,6 +16,7 @@ const (
 	SystemDGathererName = "systemd"
 )
 
+//nolint:gochecknoglobals
 var (
 	SystemDNotInitializedError = entities.FactGatheringError{
 		Type:    "systemd-dbus-not-initialized",

--- a/internal/factsengine/gatherers/systemd_v2.go
+++ b/internal/factsengine/gatherers/systemd_v2.go
@@ -13,7 +13,6 @@ import (
 	"github.com/trento-project/agent/pkg/factsengine/entities"
 )
 
-// nolint:gochecknoglobals
 var (
 	SystemDUnitError = entities.FactGatheringError{
 		Type:    "systemd-unit-error",

--- a/internal/factsengine/gatherers/systemd_v2.go
+++ b/internal/factsengine/gatherers/systemd_v2.go
@@ -13,6 +13,7 @@ import (
 	"github.com/trento-project/agent/pkg/factsengine/entities"
 )
 
+//nolint:gochecknoglobals
 var (
 	SystemDUnitError = entities.FactGatheringError{
 		Type:    "systemd-unit-error",

--- a/internal/factsengine/gatherers/verifypassword.go
+++ b/internal/factsengine/gatherers/verifypassword.go
@@ -20,12 +20,14 @@ const (
 	VerifyPasswordGathererName = "verify_password"
 )
 
+//nolint:gochecknoglobals
 var (
 	checkableUsernames   = []string{"hacluster"}
 	unsafePasswords      = []string{"linux"}
 	passwordNotSetValues = "!*:;\\" // Get more info with "man 3 crypt"
 )
 
+//nolint:gochecknoglobals
 var (
 	VerifyPasswordInvalidUsername = entities.FactGatheringError{
 		Type:    "verify-password-invalid-username",

--- a/internal/factsengine/gatherers/verifypassword.go
+++ b/internal/factsengine/gatherers/verifypassword.go
@@ -20,14 +20,12 @@ const (
 	VerifyPasswordGathererName = "verify_password"
 )
 
-// nolint:gochecknoglobals
 var (
 	checkableUsernames   = []string{"hacluster"}
 	unsafePasswords      = []string{"linux"}
 	passwordNotSetValues = "!*:;\\" // Get more info with "man 3 crypt"
 )
 
-// nolint:gochecknoglobals
 var (
 	VerifyPasswordInvalidUsername = entities.FactGatheringError{
 		Type:    "verify-password-invalid-username",

--- a/internal/factsengine/gathering_internal_test.go
+++ b/internal/factsengine/gathering_internal_test.go
@@ -291,7 +291,6 @@ func (suite *GatheringTestSuite) TestGatherIsCancelledWhenParentContextIsCancell
 	dummyGathererOne.
 		On("Gather", mock.Anything, mock.Anything).
 		Run(func(args mock.Arguments) {
-			// nolint:forcetypeassert
 			innerCtx := args.Get(0).(context.Context)
 			select {
 			case <-innerCtx.Done():

--- a/internal/factsengine/gathering_internal_test.go
+++ b/internal/factsengine/gathering_internal_test.go
@@ -291,7 +291,7 @@ func (suite *GatheringTestSuite) TestGatherIsCancelledWhenParentContextIsCancell
 	dummyGathererOne.
 		On("Gather", mock.Anything, mock.Anything).
 		Run(func(args mock.Arguments) {
-			innerCtx := args.Get(0).(context.Context)
+			innerCtx := args.Get(0).(context.Context) //nolint:forcetypeassert
 			select {
 			case <-innerCtx.Done():
 				suite.T().Log("Gather receives context cancellation")

--- a/internal/factsengine/mapper.go
+++ b/internal/factsengine/mapper.go
@@ -1,11 +1,11 @@
 // SPDX-FileCopyrightText: SUSE LLC
 // SPDX-License-Identifier: Apache-2.0
 
-// nolint:nosnakecase
 package factsengine
 
 import (
 	"fmt"
+
 	"github.com/google/uuid"
 	"github.com/trento-project/agent/pkg/factsengine/entities"
 	"github.com/trento-project/contracts/go/pkg/events"

--- a/internal/factsengine/mapper_test.go
+++ b/internal/factsengine/mapper_test.go
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: SUSE LLC
 // SPDX-License-Identifier: Apache-2.0
 
-// nolint:nosnakecase
 package factsengine_test
 
 import (

--- a/internal/factsengine/policy_test.go
+++ b/internal/factsengine/policy_test.go
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: SUSE LLC
 // SPDX-License-Identifier: Apache-2.0
 
-// nolint:nosnakecase
 package factsengine_test
 
 import (
@@ -39,7 +38,7 @@ func (suite *PolicyTestSuite) SetupTest() {
 	suite.executionID = uuid.New().String()
 	suite.agentID = uuid.New().String()
 	suite.groupID = uuid.New().String()
-	suite.mockAdapter = mocks.MockAdapter{} // nolint
+	suite.mockAdapter = mocks.MockAdapter{}
 	suite.mockGatherer = gathererMocks.MockFactGatherer{}
 	suite.testRegistry = gatherers.NewRegistry(gatherers.FactGatherersTree{
 		"test": map[string]gatherers.FactGatherer{
@@ -61,7 +60,7 @@ func (suite *PolicyTestSuite) TestPolicyHandleEventWrongMessage() {
 
 func (suite *PolicyTestSuite) TestPolicyHandleEventInvalideEvent() {
 	event, err := events.ToEvent(
-		&events.FactsGathered{}, // nolint
+		&events.FactsGathered{},
 		events.WithSource(""),
 		events.WithID(""),
 	)
@@ -78,7 +77,7 @@ func (suite *PolicyTestSuite) TestPolicyHandleEventInvalideEvent() {
 }
 
 func (suite *PolicyTestSuite) TestPolicyHandleEventDiscardAgent() {
-	factsGatheringRequestsEvent := &events.FactsGatheringRequested{ // nolint
+	factsGatheringRequestsEvent := &events.FactsGatheringRequested{
 		Targets: []*events.FactsGatheringRequestedTarget{
 			{
 				AgentId: "other-agent",
@@ -92,7 +91,7 @@ func (suite *PolicyTestSuite) TestPolicyHandleEventDiscardAgent() {
 		factsGatheringRequestsEvent,
 		events.WithSource(""),
 		events.WithID(""),
-	) // nolint
+	)
 	suite.NoError(err)
 
 	err = factsengine.HandleEvent(
@@ -107,7 +106,7 @@ func (suite *PolicyTestSuite) TestPolicyHandleEventDiscardAgent() {
 }
 
 func (suite *PolicyTestSuite) TestPolicyHandleEvent() {
-	factsGatheringRequestsEvent := &events.FactsGatheringRequested{ // nolint
+	factsGatheringRequestsEvent := &events.FactsGatheringRequested{
 		Targets: []*events.FactsGatheringRequestedTarget{
 			{
 				AgentId: suite.agentID,
@@ -118,7 +117,7 @@ func (suite *PolicyTestSuite) TestPolicyHandleEvent() {
 		},
 	}
 	event, err := events.ToEvent(factsGatheringRequestsEvent, events.WithSource(""),
-		events.WithID("")) // nolint
+		events.WithID(""))
 	suite.NoError(err)
 
 	suite.mockAdapter.On(
@@ -141,7 +140,7 @@ func (suite *PolicyTestSuite) TestPolicyHandleEvent() {
 
 func (suite *PolicyTestSuite) TestPolicyPublishFacts() {
 	ctx := context.Background()
-	factsGatheringRequestsEvent := &events.FactsGatheringRequested{ // nolint
+	factsGatheringRequestsEvent := &events.FactsGatheringRequested{
 		ExecutionId: suite.executionID,
 		GroupId:     suite.groupID,
 		Targets: []*events.FactsGatheringRequestedTarget{
@@ -156,7 +155,7 @@ func (suite *PolicyTestSuite) TestPolicyPublishFacts() {
 		},
 	}
 	event, err := events.ToEvent(factsGatheringRequestsEvent, events.WithSource(""),
-		events.WithID("")) // nolint
+		events.WithID(""))
 	suite.NoError(err)
 
 	suite.mockAdapter.On(

--- a/internal/operations/engine_integration_test.go
+++ b/internal/operations/engine_integration_test.go
@@ -68,7 +68,6 @@ func (suite *OperationsIntegrationTestSuite) TearDownTest() {
 	}
 }
 
-// nolint:nosnakecase
 func (suite *OperationsIntegrationTestSuite) TestFactsEngineIntegration() {
 	agentID := "some-agent"
 

--- a/internal/operations/operator/clustermaintenancechange_v1.go
+++ b/internal/operations/operator/clustermaintenancechange_v1.go
@@ -54,6 +54,7 @@ type diffOutput struct {
 //
 // Find some helpful references about maintenance transitions and used commands:
 // - https://www.suse.com/c/sles-for-sap-hana-maintenance-procedures-part-1-pre-maintenance-checks/
+//nolint:lll
 // - https://www.suse.com/c/sles-for-sap-hana-maintenance-procedures-part-2-manual-administrative-tasks-os-reboots-and-updation-of-os-and-hana/
 // - https://crmsh.github.io/man-4.6/
 // - https://crmsh.github.io/man-4.6/#cmdhelp_root_status
@@ -229,6 +230,7 @@ func (c *ClusterMaintenanceChange) rollback(ctx context.Context) error {
 	return nil
 }
 
+//nolint:dupl
 func (c *ClusterMaintenanceChange) operationDiff(_ context.Context) map[string]any {
 	diff := make(map[string]any)
 

--- a/internal/operations/operator/clustermaintenancechange_v1.go
+++ b/internal/operations/operator/clustermaintenancechange_v1.go
@@ -54,7 +54,6 @@ type diffOutput struct {
 //
 // Find some helpful references about maintenance transitions and used commands:
 // - https://www.suse.com/c/sles-for-sap-hana-maintenance-procedures-part-1-pre-maintenance-checks/
-// nolint:lll
 // - https://www.suse.com/c/sles-for-sap-hana-maintenance-procedures-part-2-manual-administrative-tasks-os-reboots-and-updation-of-os-and-hana/
 // - https://crmsh.github.io/man-4.6/
 // - https://crmsh.github.io/man-4.6/#cmdhelp_root_status
@@ -230,7 +229,6 @@ func (c *ClusterMaintenanceChange) rollback(ctx context.Context) error {
 	return nil
 }
 
-// nolint: dupl
 func (c *ClusterMaintenanceChange) operationDiff(_ context.Context) map[string]any {
 	diff := make(map[string]any)
 

--- a/internal/operations/operator/clusterresourcerefresh_v1.go
+++ b/internal/operations/operator/clusterresourcerefresh_v1.go
@@ -137,6 +137,7 @@ func (c *ClusterResourceRefresh) rollback(_ context.Context) error {
 	return nil
 }
 
+//nolint:dupl
 func (c *ClusterResourceRefresh) operationDiff(_ context.Context) map[string]any {
 	diff := make(map[string]any)
 

--- a/internal/operations/operator/clusterresourcerefresh_v1.go
+++ b/internal/operations/operator/clusterresourcerefresh_v1.go
@@ -137,7 +137,6 @@ func (c *ClusterResourceRefresh) rollback(_ context.Context) error {
 	return nil
 }
 
-// nolint: dupl
 func (c *ClusterResourceRefresh) operationDiff(_ context.Context) map[string]any {
 	diff := make(map[string]any)
 

--- a/internal/operations/operator/crmclusterstart_v1.go
+++ b/internal/operations/operator/crmclusterstart_v1.go
@@ -159,9 +159,9 @@ func (c *CrmClusterStart) verify(ctx context.Context) error {
 	return nil
 }
 
-//	operationDiff needs to be refactored, ignoring duplication issues for now
+// operationDiff needs to be refactored, ignoring duplication issues for now
 //
-
+//nolint:dupl
 func (c *CrmClusterStart) operationDiff(_ context.Context) map[string]any {
 	diff := make(map[string]any)
 

--- a/internal/operations/operator/crmclusterstart_v1.go
+++ b/internal/operations/operator/crmclusterstart_v1.go
@@ -161,7 +161,7 @@ func (c *CrmClusterStart) verify(ctx context.Context) error {
 
 //	operationDiff needs to be refactored, ignoring duplication issues for now
 //
-// nolint: dupl
+
 func (c *CrmClusterStart) operationDiff(_ context.Context) map[string]any {
 	diff := make(map[string]any)
 

--- a/internal/operations/operator/crmclusterstop_v1.go
+++ b/internal/operations/operator/crmclusterstop_v1.go
@@ -156,9 +156,9 @@ func (c *CrmClusterStop) verify(ctx context.Context) error {
 	return nil
 }
 
-//	operationDiff needs to be refactored, ignoring duplication issues for now
+// operationDiff needs to be refactored, ignoring duplication issues for now
 //
-
+//nolint:dupl
 func (c *CrmClusterStop) operationDiff(_ context.Context) map[string]any {
 	diff := make(map[string]any)
 

--- a/internal/operations/operator/crmclusterstop_v1.go
+++ b/internal/operations/operator/crmclusterstop_v1.go
@@ -158,7 +158,7 @@ func (c *CrmClusterStop) verify(ctx context.Context) error {
 
 //	operationDiff needs to be refactored, ignoring duplication issues for now
 //
-// nolint: dupl
+
 func (c *CrmClusterStop) operationDiff(_ context.Context) map[string]any {
 	diff := make(map[string]any)
 

--- a/internal/operations/operator/sapinstancestart_v1.go
+++ b/internal/operations/operator/sapinstancestart_v1.go
@@ -171,7 +171,7 @@ func (s *SAPInstanceStart) rollback(ctx context.Context) error {
 
 //	operationDiff needs to be refactored, ignoring duplication issues for now
 //
-// nolint: dupl
+
 func (s *SAPInstanceStart) operationDiff(_ context.Context) map[string]any {
 	diff := make(map[string]any)
 

--- a/internal/operations/operator/sapinstancestart_v1.go
+++ b/internal/operations/operator/sapinstancestart_v1.go
@@ -169,9 +169,9 @@ func (s *SAPInstanceStart) rollback(ctx context.Context) error {
 	return nil
 }
 
-//	operationDiff needs to be refactored, ignoring duplication issues for now
+// operationDiff needs to be refactored, ignoring duplication issues for now
 //
-
+//nolint:dupl
 func (s *SAPInstanceStart) operationDiff(_ context.Context) map[string]any {
 	diff := make(map[string]any)
 

--- a/internal/operations/operator/sapinstancestop_v1.go
+++ b/internal/operations/operator/sapinstancestop_v1.go
@@ -162,9 +162,9 @@ func (s *SAPInstanceStop) rollback(ctx context.Context) error {
 	return nil
 }
 
-//	operationDiff needs to be refactored, ignoring duplication issues for now
+// operationDiff needs to be refactored, ignoring duplication issues for now
 //
-
+//nolint:dupl
 func (s *SAPInstanceStop) operationDiff(_ context.Context) map[string]any {
 	diff := make(map[string]any)
 

--- a/internal/operations/operator/sapinstancestop_v1.go
+++ b/internal/operations/operator/sapinstancestop_v1.go
@@ -164,7 +164,7 @@ func (s *SAPInstanceStop) rollback(ctx context.Context) error {
 
 //	operationDiff needs to be refactored, ignoring duplication issues for now
 //
-// nolint: dupl
+
 func (s *SAPInstanceStop) operationDiff(_ context.Context) map[string]any {
 	diff := make(map[string]any)
 

--- a/internal/operations/operator/sapsystemstart_v1.go
+++ b/internal/operations/operator/sapsystemstart_v1.go
@@ -193,9 +193,9 @@ func (s *SAPSystemStart) rollback(ctx context.Context) error {
 	return nil
 }
 
-//	operationDiff needs to be refactored, ignoring duplication issues for now
+// operationDiff needs to be refactored, ignoring duplication issues for now
 //
-
+//nolint:dupl
 func (s *SAPSystemStart) operationDiff(_ context.Context) map[string]any {
 	diff := make(map[string]any)
 

--- a/internal/operations/operator/sapsystemstart_v1.go
+++ b/internal/operations/operator/sapsystemstart_v1.go
@@ -195,7 +195,7 @@ func (s *SAPSystemStart) rollback(ctx context.Context) error {
 
 //	operationDiff needs to be refactored, ignoring duplication issues for now
 //
-// nolint: dupl
+
 func (s *SAPSystemStart) operationDiff(_ context.Context) map[string]any {
 	diff := make(map[string]any)
 

--- a/internal/operations/operator/sapsystemstop_v1.go
+++ b/internal/operations/operator/sapsystemstop_v1.go
@@ -176,7 +176,7 @@ func (s *SAPSystemStop) rollback(ctx context.Context) error {
 
 //	operationDiff needs to be refactored, ignoring duplication issues for now
 //
-// nolint: dupl
+
 func (s *SAPSystemStop) operationDiff(_ context.Context) map[string]any {
 	diff := make(map[string]any)
 

--- a/internal/operations/operator/sapsystemstop_v1.go
+++ b/internal/operations/operator/sapsystemstop_v1.go
@@ -174,9 +174,9 @@ func (s *SAPSystemStop) rollback(ctx context.Context) error {
 	return nil
 }
 
-//	operationDiff needs to be refactored, ignoring duplication issues for now
+// operationDiff needs to be refactored, ignoring duplication issues for now
 //
-
+//nolint:dupl
 func (s *SAPSystemStop) operationDiff(_ context.Context) map[string]any {
 	diff := make(map[string]any)
 

--- a/internal/operations/operator/saptuneapplysolution_v1.go
+++ b/internal/operations/operator/saptuneapplysolution_v1.go
@@ -186,9 +186,9 @@ func (sa *SaptuneApplySolution) rollback(ctx context.Context) error {
 	return sa.saptune.RevertSolution(ctx, sa.parsedArguments.solution)
 }
 
-//	operationDiff needs to be refactored, ignoring duplication issues for now
+// operationDiff needs to be refactored, ignoring duplication issues for now
 //
-
+//nolint:dupl
 func (sa *SaptuneApplySolution) operationDiff(_ context.Context) map[string]any {
 	diff := make(map[string]any)
 

--- a/internal/operations/operator/saptuneapplysolution_v1.go
+++ b/internal/operations/operator/saptuneapplysolution_v1.go
@@ -188,7 +188,7 @@ func (sa *SaptuneApplySolution) rollback(ctx context.Context) error {
 
 //	operationDiff needs to be refactored, ignoring duplication issues for now
 //
-// nolint: dupl
+
 func (sa *SaptuneApplySolution) operationDiff(_ context.Context) map[string]any {
 	diff := make(map[string]any)
 

--- a/internal/operations/operator/saptunechangesolution_v1.go
+++ b/internal/operations/operator/saptunechangesolution_v1.go
@@ -159,9 +159,9 @@ func (sc *SaptuneChangeSolution) rollback(ctx context.Context) error {
 	return sc.saptune.ChangeSolution(ctx, initiallyAppliedSolution)
 }
 
-//	operationDiff needs to be refactored, ignoring duplication issues for now
+// operationDiff needs to be refactored, ignoring duplication issues for now
 //
-
+//nolint:dupl
 func (sc *SaptuneChangeSolution) operationDiff(_ context.Context) map[string]any {
 	diff := make(map[string]any)
 

--- a/internal/operations/operator/saptunechangesolution_v1.go
+++ b/internal/operations/operator/saptunechangesolution_v1.go
@@ -161,7 +161,7 @@ func (sc *SaptuneChangeSolution) rollback(ctx context.Context) error {
 
 //	operationDiff needs to be refactored, ignoring duplication issues for now
 //
-// nolint: dupl
+
 func (sc *SaptuneChangeSolution) operationDiff(_ context.Context) map[string]any {
 	diff := make(map[string]any)
 

--- a/internal/operations/policy_test.go
+++ b/internal/operations/policy_test.go
@@ -35,7 +35,7 @@ func TestPolicyTestSuite(t *testing.T) {
 
 func (suite *PolicyTestSuite) SetupTest() {
 	suite.agentID = uuid.New().String()
-	suite.mockAdapter = mocks.MockAdapter{} // nolint
+	suite.mockAdapter = mocks.MockAdapter{}
 	suite.mockOperator = operatorMocks.NewMockOperator(suite.T())
 	suite.testRegistry = operator.NewRegistry(operator.BuildersTree{
 		"test": map[string]operator.Builder{
@@ -59,7 +59,7 @@ func (suite *PolicyTestSuite) TestPolicyHandleEventWrongMessage() {
 
 func (suite *PolicyTestSuite) TestPolicyHandleEventInvalidEvent() {
 	event, err := events.ToEvent(
-		&events.OperatorExecutionCompleted{}, // nolint
+		&events.OperatorExecutionCompleted{},
 		events.WithSource(""),
 		events.WithID(""),
 	)
@@ -76,7 +76,7 @@ func (suite *PolicyTestSuite) TestPolicyHandleEventInvalidEvent() {
 }
 
 func (suite *PolicyTestSuite) TestPolicyHandleEventDiscardAgent() {
-	operatorRequestsEvent := &events.OperatorExecutionRequested{ // nolint
+	operatorRequestsEvent := &events.OperatorExecutionRequested{
 		Targets: []*events.OperatorExecutionRequestedTarget{
 			{
 				AgentId: "other-agent",
@@ -90,7 +90,7 @@ func (suite *PolicyTestSuite) TestPolicyHandleEventDiscardAgent() {
 		operatorRequestsEvent,
 		events.WithSource(""),
 		events.WithID(""),
-	) // nolint
+	)
 	suite.NoError(err)
 
 	err = operations.HandleEvent(
@@ -107,7 +107,7 @@ func (suite *PolicyTestSuite) TestPolicyHandleEventDiscardAgent() {
 func (suite *PolicyTestSuite) TestPolicyHandleEventOperatorNotFound() {
 	ctx := context.Background()
 
-	operatorRequestsEvent := &events.OperatorExecutionRequested{ // nolint
+	operatorRequestsEvent := &events.OperatorExecutionRequested{
 		Operator: "foo",
 		Targets: []*events.OperatorExecutionRequestedTarget{
 			{
@@ -117,7 +117,7 @@ func (suite *PolicyTestSuite) TestPolicyHandleEventOperatorNotFound() {
 	}
 	event, err := events.ToEvent(operatorRequestsEvent,
 		events.WithSource(""),
-		events.WithID("")) // nolint
+		events.WithID(""))
 	suite.NoError(err)
 
 	err = operations.HandleEvent(
@@ -135,7 +135,7 @@ func (suite *PolicyTestSuite) TestPolicyHandleEventOperatorNotFound() {
 func (suite *PolicyTestSuite) TestPolicyHandleEventErrorDecoding() {
 	ctx := context.Background()
 
-	operatorRequestsEvent := &events.OperatorExecutionRequested{} // nolint
+	operatorRequestsEvent := &events.OperatorExecutionRequested{}
 
 	now := time.Now()
 	expiration := now.Add(-60 * time.Minute)
@@ -143,7 +143,7 @@ func (suite *PolicyTestSuite) TestPolicyHandleEventErrorDecoding() {
 		events.WithTime(now),
 		events.WithExpiration(expiration),
 		events.WithSource(""),
-		events.WithID("")) // nolint
+		events.WithID(""))
 	suite.NoError(err)
 
 	err = operations.HandleEvent(
@@ -163,7 +163,7 @@ func (suite *PolicyTestSuite) TestPolicyHandleEventErrorDecoding() {
 func (suite *PolicyTestSuite) TestPolicyHandleEventErrorEncoding() {
 	ctx := context.Background()
 
-	operatorRequestsEvent := &events.OperatorExecutionRequested{ // nolint
+	operatorRequestsEvent := &events.OperatorExecutionRequested{
 		OperationId: uuid.New().String(),
 		Operator:    "test@v1",
 		Targets: []*events.OperatorExecutionRequestedTarget{
@@ -175,7 +175,7 @@ func (suite *PolicyTestSuite) TestPolicyHandleEventErrorEncoding() {
 	}
 	event, err := events.ToEvent(operatorRequestsEvent,
 		events.WithSource(""),
-		events.WithID("")) // nolint
+		events.WithID(""))
 	suite.NoError(err)
 
 	suite.mockOperator.On(
@@ -207,7 +207,7 @@ func (suite *PolicyTestSuite) TestPolicyHandleEventErrorEncoding() {
 func (suite *PolicyTestSuite) TestPolicyHandleEventErrorPublishing() {
 	ctx := context.Background()
 
-	operatorRequestsEvent := &events.OperatorExecutionRequested{ // nolint
+	operatorRequestsEvent := &events.OperatorExecutionRequested{
 		OperationId: uuid.New().String(),
 		Operator:    "test@v1",
 		Targets: []*events.OperatorExecutionRequestedTarget{
@@ -219,7 +219,7 @@ func (suite *PolicyTestSuite) TestPolicyHandleEventErrorPublishing() {
 	}
 	event, err := events.ToEvent(operatorRequestsEvent,
 		events.WithSource(""),
-		events.WithID("")) // nolint
+		events.WithID(""))
 	suite.NoError(err)
 
 	suite.mockOperator.On(
@@ -259,7 +259,7 @@ func (suite *PolicyTestSuite) TestPolicyHandleEventErrorPublishing() {
 func (suite *PolicyTestSuite) TestPolicyHandleEvent() {
 	ctx := context.Background()
 
-	operatorRequestsEvent := &events.OperatorExecutionRequested{ // nolint
+	operatorRequestsEvent := &events.OperatorExecutionRequested{
 		OperationId: uuid.New().String(),
 		Operator:    "test@v1",
 		Targets: []*events.OperatorExecutionRequestedTarget{
@@ -275,7 +275,7 @@ func (suite *PolicyTestSuite) TestPolicyHandleEvent() {
 	}
 	event, err := events.ToEvent(operatorRequestsEvent,
 		events.WithSource(""),
-		events.WithID("")) // nolint
+		events.WithID(""))
 	suite.NoError(err)
 
 	suite.mockOperator.On(

--- a/pkg/factsengine/entities/fact_value.go
+++ b/pkg/factsengine/entities/fact_value.go
@@ -16,6 +16,8 @@ import (
 
 // ValueNotFoundError is an error returned when the wanted value in GetValue
 // function is not found
+//
+//nolint:gochecknoglobals
 var ValueNotFoundError = FactGatheringError{
 	Type:    "value-not-found",
 	Message: "error getting value",

--- a/pkg/factsengine/entities/fact_value.go
+++ b/pkg/factsengine/entities/fact_value.go
@@ -14,7 +14,6 @@ import (
 	"github.com/iancoleman/strcase"
 )
 
-// nolint:gochecknoglobals
 // ValueNotFoundError is an error returned when the wanted value in GetValue
 // function is not found
 var ValueNotFoundError = FactGatheringError{

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -20,13 +20,13 @@ func FindMatches(pattern string, text []byte) map[string]interface{} {
 	r := regexp.MustCompile(pattern)
 	values := r.FindAllStringSubmatch(string(text), -1)
 	for _, match := range values {
-		key := strings.Replace(match[1], " ", "_", -1) //nolint
+		key := strings.Replace(match[1], " ", "_", -1)
 		if _, ok := configMap[key]; ok {
-			switch configMap[key].(type) { //nolint
+			switch configMap[key].(type) {
 			case string:
 				configMap[key] = []interface{}{configMap[key]}
 			}
-			configMap[key] = append(configMap[key].([]interface{}), match[2]) //nolint
+			configMap[key] = append(configMap[key].([]interface{}), match[2])
 		} else {
 			configMap[key] = match[2]
 		}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -20,13 +20,13 @@ func FindMatches(pattern string, text []byte) map[string]interface{} {
 	r := regexp.MustCompile(pattern)
 	values := r.FindAllStringSubmatch(string(text), -1)
 	for _, match := range values {
-		key := strings.Replace(match[1], " ", "_", -1)
+		key := strings.Replace(match[1], " ", "_", -1) //nolint:gocritic
 		if _, ok := configMap[key]; ok {
-			switch configMap[key].(type) {
+			switch configMap[key].(type) { //nolint:gocritic
 			case string:
 				configMap[key] = []interface{}{configMap[key]}
 			}
-			configMap[key] = append(configMap[key].([]interface{}), match[2])
+			configMap[key] = append(configMap[key].([]interface{}), match[2]) //nolint:forcetypeassert
 		} else {
 			configMap[key] = match[2]
 		}

--- a/plugin_examples/dummy/dummy.go
+++ b/plugin_examples/dummy/dummy.go
@@ -24,7 +24,7 @@ func (s dummyGatherer) Gather(_ context.Context, factsRequests []entities.FactRe
 	slog.Info("Starting dummy plugin facts gathering process")
 
 	for _, factReq := range factsRequests {
-		value := rand.Int() // nolint
+		value := rand.Int()
 		fact := entities.NewFactGatheredWithRequest(factReq, &entities.FactValueString{Value: fmt.Sprint(value)})
 		facts = append(facts, fact)
 	}
@@ -46,7 +46,7 @@ func main() {
 		"gatherer": &plugininterface.GathererPlugin{Impl: d},
 	}
 
-	plugin.Serve(&plugin.ServeConfig{ // nolint
+	plugin.Serve(&plugin.ServeConfig{
 		HandshakeConfig: handshakeConfig,
 		Plugins:         pluginMap,
 	})

--- a/plugin_examples/dummy/dummy.go
+++ b/plugin_examples/dummy/dummy.go
@@ -24,7 +24,7 @@ func (s dummyGatherer) Gather(_ context.Context, factsRequests []entities.FactRe
 	slog.Info("Starting dummy plugin facts gathering process")
 
 	for _, factReq := range factsRequests {
-		value := rand.Int()
+		value := rand.Int() //nolint:gosec
 		fact := entities.NewFactGatheredWithRequest(factReq, &entities.FactValueString{Value: fmt.Sprint(value)})
 		facts = append(facts, fact)
 	}

--- a/plugin_examples/sleep/sleep.go
+++ b/plugin_examples/sleep/sleep.go
@@ -65,7 +65,7 @@ func main() {
 		"gatherer": &plugininterface.GathererPlugin{Impl: d},
 	}
 
-	plugin.Serve(&plugin.ServeConfig{ // nolint
+	plugin.Serve(&plugin.ServeConfig{
 		HandshakeConfig: handshakeConfig,
 		Plugins:         pluginMap,
 	})

--- a/version/version.go
+++ b/version/version.go
@@ -6,5 +6,9 @@ package version
 // We exclude that variables from linting
 // because we explicitly use that
 // in the ldflags at build time
-var Version string            //nolint
-var InstallationSource string //nolint
+//
+//nolint:gochecknoglobals
+var (
+	Version            string
+	InstallationSource string
+)


### PR DESCRIPTION
### Description

This pull request primarily removes unnecessary `//nolint` and related linter suppression comments throughout the codebase, leading to cleaner and more maintainable code. In a few cases, specific linter directives are updated to target the appropriate linter or line length, and some minor formatting improvements are included.

The most important changes are:

* Removed generic `//nolint` comments from command constructors and struct field tags in multiple files, such as `cmd/facts.go`, `cmd/generate.go`, `cmd/id.go`, `cmd/operator.go`, `cmd/root.go`, `cmd/start.go`, and `cmd/version.go`.
* Where necessary, updated to more specific linter suppressions (e.g., `//nolint:lll`, `//nolint:gosec`, `//nolint:revive`).
* Updated or added line-length (`//nolint:lll`) and security (`//nolint:gosec`) suppressions where appropriate, and replaced blanket disables with targeted ones (e.g., `//nolint:revive` .

These changes help ensure the codebase adheres more closely to linting standards, reduces noise from unnecessary suppressions, and improves readability and maintainability.

Related [TRNT-4574](https://jira.suse.com/browse/TRNT-4574)

### How was this tested?

UT

### Documentation changes

No

### Additional information

N/A