### PR TITLE
Update `.tool-versions`

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -45,6 +45,7 @@ linters:
           - lll
           # ignore dupl in tests, as we prefer copy-paste over abstraction there
           - dupl
+          - goconst
         path: _test\.go
       - linters:
           - revive

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-golang 1.25.0
-golangci-lint 2.4.0
+golang 1.25.12
+golangci-lint 2.12.2
 bats 1.11.1


### PR DESCRIPTION
### Description

This pull request updates development tooling and linting configuration to improve code quality and ensure up-to-date dependencies. The main changes are:

* Upgraded `golang` to version 1.25.12 and `golangci-lint` to version 2.12.2 in `.tool-versions` for improved language features and linting capabilities.
* Enabled the `goconst` linter for test files in `.golangci.yaml` to help detect repeated string literals and encourage the use of constants.

Related [TRNT-4574](https://jira.suse.com/browse/TRNT-4574)

### How was this tested?

UT

### Documentation changes

No

### Additional information

N/A