### PR TITLE
Fix saptune parsing with output containing colors

### DIFF
--- a/internal/core/saptune/saptune.go
+++ b/internal/core/saptune/saptune.go
@@ -159,7 +159,21 @@ func (s *saptuneClient) runSaptune(ctx context.Context, args ...string) ([]byte,
 }
 
 func (s *saptuneClient) runSaptuneJSON(ctx context.Context, args ...string) ([]byte, error) {
+	slog.Info("Running saptune command with json format", "args", args)
+
 	prependedArgs := append([]string{"--format", "json"}, args...)
 
-	return s.runSaptune(ctx, prependedArgs...)
+	// Using OutputContext instead of CombinedOutputContext to avoid capturing stderr,
+	// which may contain non-JSON output (e.g., warnings) that would break JSON parsing.
+	output, err := s.executor.OutputContext(ctx, "saptune", prependedArgs...)
+	if err != nil {
+		slog.Error("error executing saptune command", "args", prependedArgs, "error", err)
+
+		return output, fmt.Errorf("error executing saptune command: %w", err)
+	}
+
+	slog.Debug("saptune output", "output", string(output))
+	slog.Info("Saptune command executed")
+
+	return output, nil
 }

--- a/internal/core/saptune/saptune.go
+++ b/internal/core/saptune/saptune.go
@@ -142,6 +142,7 @@ func (s *saptuneClient) VerifyNote(ctx context.Context) ([]byte, error) {
 	return s.runSaptuneJSON(ctx, "note", "verify")
 }
 
+//nolint:unparam
 func (s *saptuneClient) runSaptune(ctx context.Context, args ...string) ([]byte, error) {
 	slog.Info("Running saptune command", "args", args)
 

--- a/internal/core/saptune/saptune_test.go
+++ b/internal/core/saptune/saptune_test.go
@@ -159,7 +159,7 @@ func (suite *SaptuneClientTestSuite) TestGettingAppliedSolutionFailure() {
 	ctx := context.Background()
 
 	suite.mockExecutor.On(
-		"CombinedOutputContext",
+		"OutputContext",
 		ctx,
 		"saptune",
 		"--format",
@@ -185,7 +185,7 @@ func (suite *SaptuneClientTestSuite) TestGettingNoSolutionApplied() {
 	noSolutionApplied := helpers.ReadFixture("saptune/applied_no_solution.json")
 
 	suite.mockExecutor.On(
-		"CombinedOutputContext",
+		"OutputContext",
 		ctx,
 		"saptune",
 		"--format",
@@ -210,7 +210,7 @@ func (suite *SaptuneClientTestSuite) TestGettingAppliedSolution() {
 	hanaSolutionApplied := helpers.ReadFixture("saptune/applied_hana_solution.json")
 
 	suite.mockExecutor.On(
-		"CombinedOutputContext",
+		"OutputContext",
 		ctx,
 		"saptune",
 		"--format",
@@ -421,7 +421,7 @@ func (suite *SaptuneClientTestSuite) TestCheck() {
 	ctx := context.Background()
 
 	suite.mockExecutor.On(
-		"CombinedOutputContext",
+		"OutputContext",
 		ctx,
 		"saptune",
 		"--format",
@@ -440,7 +440,7 @@ func (suite *SaptuneClientTestSuite) TestCheckError() {
 	ctx := context.Background()
 
 	suite.mockExecutor.On(
-		"CombinedOutputContext",
+		"OutputContext",
 		ctx,
 		"saptune",
 		"--format",
@@ -459,7 +459,7 @@ func (suite *SaptuneClientTestSuite) TestListSolution() {
 	ctx := context.Background()
 
 	suite.mockExecutor.On(
-		"CombinedOutputContext",
+		"OutputContext",
 		ctx,
 		"saptune",
 		"--format",
@@ -479,7 +479,7 @@ func (suite *SaptuneClientTestSuite) TestListSolutionError() {
 	ctx := context.Background()
 
 	suite.mockExecutor.On(
-		"CombinedOutputContext",
+		"OutputContext",
 		ctx,
 		"saptune",
 		"--format",
@@ -499,7 +499,7 @@ func (suite *SaptuneClientTestSuite) TestVerifySolution() {
 	ctx := context.Background()
 
 	suite.mockExecutor.On(
-		"CombinedOutputContext",
+		"OutputContext",
 		ctx,
 		"saptune",
 		"--format",
@@ -519,7 +519,7 @@ func (suite *SaptuneClientTestSuite) TestVerifySolutionError() {
 	ctx := context.Background()
 
 	suite.mockExecutor.On(
-		"CombinedOutputContext",
+		"OutputContext",
 		ctx,
 		"saptune",
 		"--format",
@@ -539,7 +539,7 @@ func (suite *SaptuneClientTestSuite) TestListNote() {
 	ctx := context.Background()
 
 	suite.mockExecutor.On(
-		"CombinedOutputContext",
+		"OutputContext",
 		ctx,
 		"saptune",
 		"--format",
@@ -559,7 +559,7 @@ func (suite *SaptuneClientTestSuite) TestListNoteError() {
 	ctx := context.Background()
 
 	suite.mockExecutor.On(
-		"CombinedOutputContext",
+		"OutputContext",
 		ctx,
 		"saptune",
 		"--format",
@@ -579,7 +579,7 @@ func (suite *SaptuneClientTestSuite) TestVerifyNote() {
 	ctx := context.Background()
 
 	suite.mockExecutor.On(
-		"CombinedOutputContext",
+		"OutputContext",
 		ctx,
 		"saptune",
 		"--format",
@@ -599,7 +599,7 @@ func (suite *SaptuneClientTestSuite) TestVerifyNoteError() {
 	ctx := context.Background()
 
 	suite.mockExecutor.On(
-		"CombinedOutputContext",
+		"OutputContext",
 		ctx,
 		"saptune",
 		"--format",


### PR DESCRIPTION
### Description

This pull request refactors how the `saptune` command is executed to improve reliability when parsing JSON output and enhance logging for debugging. The main change is switching from capturing both stdout and stderr to capturing only stdout, which prevents non-JSON output (such as warnings on stderr) from breaking JSON parsing. All related tests are updated to reflect this change in the executor method.

* Updated `runSaptuneJSON` in `saptune.go` to use `OutputContext` instead of `CombinedOutputContext`, ensuring only stdout is captured for JSON parsing and adding more detailed logging for command execution and errors.
* Updated all test cases in `saptune_test.go` to expect `OutputContext` calls instead of `CombinedOutputContext`, keeping tests consistent with the new implementation. 

This is to fix this error:

```console
Jul 28 09:00:05 hana-s2-db1 trento-agent[2670]: 2026-07-28 09:00:05 ERROR fact gathering error: saptune-cmd-error - error executing saptune command: invalid character '\x1b' looking for beginning of value 
```

Fixes #[TRNT-4595](https://jira.suse.com/browse/TRNT-4595)

### How was this tested?

IRL

### Documentation changes

No

### Additional information

<!-- Add anything else relevant to this PR, such as screenshots or demos. -->