### PR TITLE
Update go version to 1.26

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-golang 1.25.12
+golang 1.26.5
 golangci-lint 2.12.2
 bats 1.11.1

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@
 
 module github.com/trento-project/agent/v3
 
-go 1.25.0
+go 1.26
 
 require (
 	github.com/Showmax/go-fqdn v1.0.0

--- a/packaging/suse/trento-agent.spec
+++ b/packaging/suse/trento-agent.spec
@@ -28,7 +28,7 @@ Source:         %{name}-%{version}.tar.gz
 Source1:        vendor.tar.gz
 ExclusiveArch:  x86_64 ppc64le s390x
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
-BuildRequires:  golang(API) = 1.25
+BuildRequires:  golang(API) = 1.26
 %if 0%{?suse_version} >= 1600
 Recommends:     alloy
 %else


### PR DESCRIPTION
### Description

This PR bumps the current Go version from 1.25 to 1.26

### How was this tested?

CI

### Documentation changes

No

### Additional information

It worked in other Go projects; see https://github.com/trento-project/mcp-server/pull/142
