### PR TITLE
Fix additional linter issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,9 +43,9 @@ $(ARCHS):
 bundle:
 	set -x
 	find $(BUILD_DIR) -maxdepth 1 -mindepth 1 -type d -exec sh -c 'tar -zcf build/trento-agent-$$(basename {}).tgz -C {} trento-agent -C $$(pwd)/packaging/systemd trento-agent.service' \;
-	
+
 .PHONY: clean
-clean: clean-binary 
+clean: clean-binary
 
 .PHONY: clean-binary
 clean-binary:

--- a/cmd/facts.go
+++ b/cmd/facts.go
@@ -15,7 +15,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
-
 	"github.com/trento-project/agent/v3/internal/agent"
 	"github.com/trento-project/agent/v3/internal/factsengine/gatherers"
 	"github.com/trento-project/agent/v3/internal/identity"
@@ -139,7 +138,9 @@ func gather(cmd *cobra.Command, _ []string) {
 	ctx, cancel := context.WithCancel(cmd.Context())
 
 	signals := make(chan os.Signal, 1)
+
 	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM)
+
 	go func() {
 		<-signals
 		slog.Info("Caught signal!")

--- a/cmd/operator.go
+++ b/cmd/operator.go
@@ -15,7 +15,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
-
 	"github.com/trento-project/agent/v3/internal/agent"
 	"github.com/trento-project/agent/v3/internal/operations/operator"
 	"github.com/trento-project/agent/v3/pkg/utils"
@@ -113,7 +112,9 @@ func runOperator(cmd *cobra.Command, _ []string) {
 	ctx, cancel := context.WithCancel(cmd.Context())
 
 	signals := make(chan os.Signal, 1)
+
 	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM)
+
 	go func() {
 		<-signals
 		slog.Info("Caught signal!")
@@ -147,7 +148,7 @@ func runOperator(cmd *cobra.Command, _ []string) {
 }
 
 func listOperators(*cobra.Command, []string) {
-	var logger = utils.NewDefaultLogger(
+	logger := utils.NewDefaultLogger(
 		viper.GetString("log-level"),
 	)
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,7 +21,7 @@ func Execute() {
 }
 
 func NewRootCmd() *cobra.Command {
-	var rootCmd = &cobra.Command{
+	rootCmd := &cobra.Command{
 		Use:   "trento-agent",
 		Short: "An open cloud-native web console improving on the life of SAP Applications administrators.",
 		Long: `Trento is a web-based graphical user interface

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -30,6 +30,7 @@ func NewStartCmd() *cobra.Command {
 		saptuneDiscoveryPeriod      time.Duration
 		heartbeatInterval           time.Duration
 	)
+
 	startCmd := &cobra.Command{
 		Use:   "start",
 		Short: "Start the agent",
@@ -45,12 +46,14 @@ func NewStartCmd() *cobra.Command {
 			// Set the default logger to the log-level provided by the user in the command line flags, if any
 			slog.SetDefault(utils.NewDefaultLogger(viper.GetString("log-level")))
 
-			if err := agent.InitConfig("agent"); err != nil {
+			err := agent.InitConfig("agent")
+			if err != nil {
 				return err
 			}
 
 			// Re-initialize in case the config file overrides log-level
 			slog.SetDefault(utils.NewDefaultLogger(viper.GetString("log-level")))
+
 			return nil
 		},
 	}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -18,7 +18,14 @@ func NewVersionCmd() *cobra.Command {
 		Long:  `All software has versions. This is Trento's`,
 		Run: func(_ *cobra.Command, _ []string) {
 			//nolint:forbidigo
-			fmt.Printf("Trento installed from %s version %s\nbuilt with %s %s/%s\n", version.InstallationSource(), version.Version(), runtime.Version(), runtime.GOOS, runtime.GOARCH) //nolint:lll
+			fmt.Printf(
+				"Trento installed from %s version %s\nbuilt with %s %s/%s\n",
+				version.InstallationSource(),
+				version.Version(),
+				runtime.Version(),
+				runtime.GOOS,
+				runtime.GOARCH,
+			)
 		},
 	}
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -6,13 +6,10 @@ package agent
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"os"
 	"time"
-
-	"log/slog"
-
-	"golang.org/x/sync/errgroup"
 
 	"github.com/trento-project/agent/v3/internal/discovery"
 	"github.com/trento-project/agent/v3/internal/discovery/collector"
@@ -20,6 +17,7 @@ import (
 	"github.com/trento-project/agent/v3/internal/factsengine/gatherers"
 	"github.com/trento-project/agent/v3/internal/operations"
 	"github.com/trento-project/agent/v3/internal/operations/operator"
+	"golang.org/x/sync/errgroup"
 )
 
 type Agent struct {
@@ -67,6 +65,7 @@ func NewAgent(config *Config) (*Agent, error) {
 // Start the Agent. This will start the discovery ticker and the heartbeat ticker.
 func (a *Agent) Start(ctx context.Context) error {
 	gathererRegistry := gatherers.NewRegistry(
+		//nolint:contextcheck
 		gatherers.StandardGatherers(
 			gatherers.Config{AgentID: a.config.AgentID},
 		),

--- a/internal/core/cloud/azure.go
+++ b/internal/core/cloud/azure.go
@@ -14,10 +14,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"path"
-
-	"log/slog"
 )
 
 const (

--- a/internal/core/cloud/azure_test.go
+++ b/internal/core/cloud/azure_test.go
@@ -221,5 +221,8 @@ func (suite *AzureMetadataTestSuite) TestGetResourceGroupUrl() {
 		},
 	}
 
-	suite.Equal("https:/portal.azure.com/#@SUSERDBillingsuse.onmicrosoft.com/resource/subscriptions/xxx/resourceGroups/myresourcegroupname/overview", meta.GetResourceGroupURL())
+	suite.Equal(
+		"https:/portal.azure.com/#@SUSERDBillingsuse.onmicrosoft.com/resource/subscriptions/xxx/resourceGroups/myresourcegroupname/overview",
+		meta.GetResourceGroupURL(),
+	)
 }

--- a/internal/core/cloud/gcp.go
+++ b/internal/core/cloud/gcp.go
@@ -14,9 +14,8 @@ import (
 	"context"
 	"encoding/json"
 	"io"
-	"net/http"
-
 	"log/slog"
+	"net/http"
 )
 
 const (

--- a/internal/core/cloud/metadata.go
+++ b/internal/core/cloud/metadata.go
@@ -5,10 +5,9 @@ package cloud
 
 import (
 	"context"
+	"log/slog"
 	"regexp"
 	"strings"
-
-	"log/slog"
 
 	"github.com/trento-project/agent/v3/pkg/utils"
 )

--- a/internal/core/cloud/metadata_test.go
+++ b/internal/core/cloud/metadata_test.go
@@ -6,11 +6,11 @@ package cloud_test
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"testing"
 
-	"errors"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 	"github.com/trento-project/agent/v3/internal/core/cloud"

--- a/internal/core/cluster/cib/data.go
+++ b/internal/core/cluster/cib/data.go
@@ -27,7 +27,7 @@ type Root struct {
 		} `xml:"crm_config"`
 		// Schema: https://github.com/ClusterLabs/pacemaker/blob/main/xml/nodes-3.9.rng
 		Nodes []struct {
-			ID                 string      `xml:"id,attr" json:"Id"`
+			ID                 string      `json:"Id"                        xml:"id,attr"`
 			Uname              string      `xml:"uname,attr"`
 			InstanceAttributes []Attribute `xml:"instance_attributes>nvpair"`
 		} `xml:"nodes>node"`
@@ -41,7 +41,7 @@ type Root struct {
 		// Schema: https://github.com/ClusterLabs/pacemaker/blob/main/xml/constraints-3.9.rng
 		Constraints struct {
 			RscLocations []struct {
-				ID       string `xml:"id,attr" json:"Id"`
+				ID       string `json:"Id"        xml:"id,attr"`
 				Node     string `xml:"node,attr"`
 				Resource string `xml:"rsc,attr"`
 				Role     string `xml:"role,attr"`
@@ -54,7 +54,7 @@ type Root struct {
 // Attribute is an nvpair element.
 // Schema: https://github.com/ClusterLabs/pacemaker/blob/main/xml/nvset-3.9.rng
 type Attribute struct {
-	ID    string `xml:"id,attr" json:"Id"`
+	ID    string `json:"Id"        xml:"id,attr"`
 	Name  string `xml:"name,attr"`
 	Value string `xml:"value,attr"`
 }
@@ -62,14 +62,14 @@ type Attribute struct {
 // Primitive is a simple (non-grouped, non-cloned) resource or resource template in the CIB.
 // Schema: https://github.com/ClusterLabs/pacemaker/blob/main/xml/resources-3.9.rng
 type Primitive struct {
-	ID                 string      `xml:"id,attr" json:"Id"`
+	ID                 string      `json:"Id"                        xml:"id,attr"`
 	Class              string      `xml:"class,attr"`
 	Type               string      `xml:"type,attr"`
 	Provider           string      `xml:"provider,attr"`
 	InstanceAttributes []Attribute `xml:"instance_attributes>nvpair"`
 	MetaAttributes     []Attribute `xml:"meta_attributes>nvpair"`
 	Operations         []struct {
-		ID   string `xml:"id,attr" json:"Id"`
+		ID   string `json:"Id"       xml:"id,attr"`
 		Name string `xml:"name,attr"`
 		Role string `xml:"role,attr"`
 		// TODO: interval and timeout are time based vars. We should in future parse them correctly instead of string
@@ -82,7 +82,7 @@ type Primitive struct {
 // Pacemaker 3.x recommends <clone> with promotable="true" in meta_attributes instead, but <master> remains valid.
 // Schema: https://github.com/ClusterLabs/pacemaker/blob/main/xml/resources-3.9.rng
 type Clone struct {
-	ID             string      `xml:"id,attr" json:"Id"`
+	ID             string      `json:"Id"                    xml:"id,attr"`
 	MetaAttributes []Attribute `xml:"meta_attributes>nvpair"`
 	Primitive      Primitive   `xml:"primitive"`
 }
@@ -90,6 +90,6 @@ type Clone struct {
 // Group is a set of primitives that start and stop together in order.
 // Schema: https://github.com/ClusterLabs/pacemaker/blob/main/xml/resources-3.9.rng
 type Group struct {
-	ID         string      `xml:"id,attr" json:"Id"`
+	ID         string      `json:"Id"       xml:"id,attr"`
 	Primitives []Primitive `xml:"primitive"`
 }

--- a/internal/core/cluster/cib/parser.go
+++ b/internal/core/cluster/cib/parser.go
@@ -16,7 +16,7 @@ type Parser struct {
 func (p *Parser) Parse() (Root, error) {
 	var CIB Root
 
-	cibXML, err := exec.Command(p.cibAdminPath, "--query", "--local").Output() //nolint:gosec
+	cibXML, err := exec.Command(p.cibAdminPath, "--query", "--local").Output() //nolint:gosec,noctx
 	if err != nil {
 		return CIB, fmt.Errorf("error while executing cibadmin: %w", err)
 	}

--- a/internal/core/cluster/cib/parser_test.go
+++ b/internal/core/cluster/cib/parser_test.go
@@ -19,7 +19,7 @@ func TestParserTestSuite(t *testing.T) {
 	suite.Run(t, new(ParserTestSuite))
 }
 
-// TestParse verifies parsing of the CIB
+// TestParse verifies parsing of the CIB.
 func (suite *ParserTestSuite) TestParse() {
 	p := cib.NewCibAdminParser(helpers.GetFixturePath("discovery/cluster/fake_cibadmin.sh"))
 	data, err := p.Parse()
@@ -81,7 +81,7 @@ func (suite *ParserTestSuite) TestParse() {
 	suite.Equal("ocf", data.Configuration.Resources.Primitives[2].Class)
 	suite.Equal("heartbeat", data.Configuration.Resources.Primitives[2].Provider)
 	suite.Equal("Dummy", data.Configuration.Resources.Primitives[2].Type)
-	suite.Equal(6, len(data.Configuration.CrmConfig.ClusterProperties))
+	suite.Len(data.Configuration.CrmConfig.ClusterProperties, 6)
 	suite.Equal("cib-bootstrap-options-stonith-enabled", data.Configuration.CrmConfig.ClusterProperties[4].ID)
 	suite.Equal("stonith-enabled", data.Configuration.CrmConfig.ClusterProperties[4].Name)
 }
@@ -92,16 +92,16 @@ func (suite *ParserTestSuite) TestParse() {
 func (suite *ParserTestSuite) TestParsePacemaker3() {
 	p := cib.NewCibAdminParser(helpers.GetFixturePath("discovery/cluster/fake_cibadmin_pacemaker3.sh"))
 	data, err := p.Parse()
-	suite.NoError(err)
+	suite.Require().NoError(err)
 	suite.Equal("3.20.5", data.CRMFeatureSet)
-	suite.Equal(7, len(data.Configuration.CrmConfig.ClusterProperties))
+	suite.Len(data.Configuration.CrmConfig.ClusterProperties, 7)
 	suite.Equal("cib-bootstrap-options-stonith-enabled", data.Configuration.CrmConfig.ClusterProperties[4].ID)
 	suite.Equal("stonith-enabled", data.Configuration.CrmConfig.ClusterProperties[4].Name)
 	suite.Equal("cib-bootstrap-options-fencing-enabled", data.Configuration.CrmConfig.ClusterProperties[5].ID)
 	suite.Equal("fencing-enabled", data.Configuration.CrmConfig.ClusterProperties[5].Name)
 
 	// (no separate <master> element), and Role uses the mandatory-since-3.0.0 OCF 1.1 names.
-	suite.Len(data.Configuration.Resources.Masters, 0)
+	suite.Empty(data.Configuration.Resources.Masters)
 	suite.Len(data.Configuration.Resources.Clones, 2)
 	suite.Equal("msl_SAPHana_PRD_HDB00", data.Configuration.Resources.Clones[0].ID)
 	suite.Equal("Promoted", data.Configuration.Resources.Clones[0].Primitive.Operations[3].Role)
@@ -113,13 +113,13 @@ func (suite *ParserTestSuite) TestParsePacemaker3() {
 func (suite *ParserTestSuite) TestParsePacemakerFuture() {
 	p := cib.NewCibAdminParser(helpers.GetFixturePath("discovery/cluster/fake_cibadmin_pacemaker_future.sh"))
 	data, err := p.Parse()
-	suite.NoError(err)
+	suite.Require().NoError(err)
 	suite.Equal("4.0.0", data.CRMFeatureSet)
-	suite.Equal(6, len(data.Configuration.CrmConfig.ClusterProperties))
+	suite.Len(data.Configuration.CrmConfig.ClusterProperties, 6)
 	suite.Equal("cib-bootstrap-options-fencing-enabled", data.Configuration.CrmConfig.ClusterProperties[4].ID)
 	suite.Equal("fencing-enabled", data.Configuration.CrmConfig.ClusterProperties[4].Name)
 
-	suite.Len(data.Configuration.Resources.Masters, 0)
+	suite.Empty(data.Configuration.Resources.Masters)
 	suite.Len(data.Configuration.Resources.Clones, 2)
 	suite.Equal("msl_SAPHana_PRD_HDB00", data.Configuration.Resources.Clones[0].ID)
 	suite.Equal("Promoted", data.Configuration.Resources.Clones[0].Primitive.Operations[3].Role)

--- a/internal/core/cluster/cluster.go
+++ b/internal/core/cluster/cluster.go
@@ -14,9 +14,6 @@ import (
 	"os"
 	"strings"
 
-	// These packages were originally imported from github.com/ClusterLabs/ha_cluster_exporter/collector/pacemaker
-	// Now we maintain our own fork.
-
 	"github.com/trento-project/agent/v3/internal/core/cloud"
 	"github.com/trento-project/agent/v3/internal/core/cluster/cib"
 	"github.com/trento-project/agent/v3/internal/core/cluster/corosync"
@@ -155,7 +152,7 @@ func makeOnlineHostPayload(
 		state = unknownState
 	}
 
-	var cluster = &Cluster{
+	cluster := &Cluster{
 		Cib:      cib.Root{},
 		Crmmon:   crmmon.Root{},
 		SBD:      SBD{},

--- a/internal/core/cluster/corosync/parser_test.go
+++ b/internal/core/cluster/corosync/parser_test.go
@@ -18,6 +18,7 @@ type ParserTestSuite struct {
 func TestParserTestSuite(t *testing.T) {
 	suite.Run(t, new(ParserTestSuite))
 }
+
 func (suite *ParserTestSuite) TestParse() {
 	file := helpers.GetFixturePath("discovery/cluster/corosync.conf")
 

--- a/internal/core/cluster/crmmon/parser.go
+++ b/internal/core/cluster/crmmon/parser.go
@@ -16,7 +16,7 @@ type Parser struct {
 func (c *Parser) Parse() (Root, error) {
 	var crmMon Root
 
-	crmMonXML, err := exec.Command(c.crmMonPath, "-X", "--inactive").Output() //nolint:gosec
+	crmMonXML, err := exec.Command(c.crmMonPath, "-X", "--inactive").Output() //nolint:gosec,noctx
 	if err != nil {
 		return crmMon, fmt.Errorf("error while executing crm_mon: %w", err)
 	}

--- a/internal/core/cluster/crmmon/parser_test.go
+++ b/internal/core/cluster/crmmon/parser_test.go
@@ -96,29 +96,29 @@ func (suite *ParserTestSuite) TestParseClonesPacemaker3AndFuture() {
 func (suite *ParserTestSuite) TestParseFencingAttributesDualEmission() {
 	p := crmmon.NewCrmMonParser(helpers.GetFixturePath("discovery/cluster/fake_crm_mon_pacemaker3.sh"))
 	data, err := p.Parse()
-	suite.NoError(err)
+	suite.Require().NoError(err)
 	suite.True(data.Summary.ClusterOptions.FencingEnabled)
 	suite.True(data.Summary.ClusterOptions.StonithEnabled)
 	suite.True(data.Resources[0].Removed)
 	suite.True(data.Resources[0].Orphaned)
 }
 
-// TestParseFencingAttributesLegacyOnly verifies we parse deprecated params that are only emitted in Pacemaker < 3.0.0
+// TestParseFencingAttributesLegacyOnly verifies we parse deprecated params that are only emitted in Pacemaker < 3.0.0.
 func (suite *ParserTestSuite) TestParseFencingAttributesLegacyOnly() {
 	p := crmmon.NewCrmMonParser(helpers.GetFixturePath("discovery/cluster/fake_crm_mon.sh"))
 	data, err := p.Parse()
-	suite.NoError(err)
+	suite.Require().NoError(err)
 	suite.True(data.Summary.ClusterOptions.StonithEnabled)
 	suite.False(data.Summary.ClusterOptions.FencingEnabled)
 	suite.False(data.Resources[0].Orphaned)
 	suite.False(data.Resources[0].Removed)
 }
 
-// TestParseFencingAttributesNewNameOnly verifies we parse new params that are only emitted a future Pacemaker version
+// TestParseFencingAttributesNewNameOnly verifies we parse new params that are only emitted a future Pacemaker version.
 func (suite *ParserTestSuite) TestParseFencingAttributesNewNameOnly() {
 	p := crmmon.NewCrmMonParser(helpers.GetFixturePath("discovery/cluster/fake_crm_mon_pacemaker_future.sh"))
 	data, err := p.Parse()
-	suite.NoError(err)
+	suite.Require().NoError(err)
 	suite.True(data.Summary.ClusterOptions.FencingEnabled)
 	suite.False(data.Summary.ClusterOptions.StonithEnabled)
 	suite.False(data.Resources[0].Removed)

--- a/internal/core/cluster/sbd.go
+++ b/internal/core/cluster/sbd.go
@@ -4,14 +4,13 @@
 package cluster
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
 	"regexp"
 	"strconv"
 	"strings"
-
-	"errors"
 
 	"github.com/hashicorp/go-envparse"
 	"github.com/trento-project/agent/v3/pkg/utils"
@@ -57,7 +56,7 @@ type SBDNode struct {
 }
 
 func NewSBD(executor utils.CommandExecutor, sbdPath, sbdConfigPath string) (SBD, error) {
-	var s = SBD{
+	s := SBD{
 		Devices: nil, // TODO check me, no slice of pointers needed
 		Config:  map[string]string{},
 	}
@@ -225,7 +224,7 @@ func sbdDump(executor utils.CommandExecutor, sbdPath string, device string) (SBD
 // 0	hana01	clear
 // 1	hana02	clear.
 func sbdList(executor utils.CommandExecutor, sbdPath, device string) ([]*SBDNode, error) {
-	var list = []*SBDNode{}
+	list := []*SBDNode{}
 
 	output, err := executor.Output(sbdPath, "-d", device, "list")
 

--- a/internal/core/hosts/discovered_host.go
+++ b/internal/core/hosts/discovered_host.go
@@ -3,9 +3,11 @@
 
 package hosts
 
-import "time"
+import (
+	"time"
 
-import "github.com/trento-project/agent/v3/internal/core/systemd"
+	"github.com/trento-project/agent/v3/internal/core/systemd"
+)
 
 type UTCTime struct{ time.Time }
 

--- a/internal/core/sapsystem/sapcontrolapi/webservice.go
+++ b/internal/core/sapsystem/sapcontrolapi/webservice.go
@@ -32,11 +32,13 @@ type WebService interface {
 	StopSystemContext(ctx context.Context, request *StopSystem) (*StopSystemResponse, error)
 }
 
-type STATECOLOR string   //nolint:revive
-type STATECOLOR_CODE int //nolint:revive
-type HAVerificationState string
-type HACheckCategory string
-type StartStopOption string
+type (
+	STATECOLOR          string
+	STATECOLOR_CODE     int //nolint:revive
+	HAVerificationState string
+	HACheckCategory     string
+	StartStopOption     string
+)
 
 //nolint:revive
 const (
@@ -68,6 +70,7 @@ const (
 	// NOTE: This was just copy-pasted from sap_host_exporter, not used right now
 	//nolint:lll
 	// see: https://github.com/SUSE/sap_host_exporter/blob/68bbf2f1b490ab0efaa2dd7b878b778f07fba2ab/lib/sapcontrol/webservice.go#L42
+
 	STATECOLOR_CODE_GRAY   STATECOLOR_CODE = 1
 	STATECOLOR_CODE_GREEN  STATECOLOR_CODE = 2
 	STATECOLOR_CODE_YELLOW STATECOLOR_CODE = 3
@@ -150,13 +153,13 @@ type InstanceProperty struct {
 }
 
 type SAPInstance struct {
-	Hostname      string     `xml:"hostname,omitempty" json:"hostname,omitempty"`
-	InstanceNr    int32      `xml:"instanceNr,omitempty" json:"instanceNr"`
-	HttpPort      int32      `xml:"httpPort,omitempty" json:"httpPort,omitempty"`   //nolint:revive
-	HttpsPort     int32      `xml:"httpsPort,omitempty" json:"httpsPort,omitempty"` //nolint:revive
-	StartPriority string     `xml:"startPriority,omitempty" json:"startPriority,omitempty"`
-	Features      string     `xml:"features,omitempty" json:"features,omitempty"`
-	Dispstatus    STATECOLOR `xml:"dispstatus,omitempty" json:"dispstatus,omitempty"`
+	Hostname      string     `json:"hostname,omitempty"      xml:"hostname,omitempty"`
+	InstanceNr    int32      `json:"instanceNr"              xml:"instanceNr,omitempty"`
+	HttpPort      int32      `json:"httpPort,omitempty"      xml:"httpPort,omitempty"`  //nolint:revive
+	HttpsPort     int32      `json:"httpsPort,omitempty"     xml:"httpsPort,omitempty"` //nolint:revive
+	StartPriority string     `json:"startPriority,omitempty" xml:"startPriority,omitempty"`
+	Features      string     `json:"features,omitempty"      xml:"features,omitempty"`
+	Dispstatus    STATECOLOR `json:"dispstatus,omitempty"    xml:"dispstatus,omitempty"`
 	// Added manually as a virtual field to identify if the instance belongs to
 	// the currently discovered instance
 	CurrentInstance bool `json:"currentInstance"`
@@ -183,8 +186,7 @@ type Start struct {
 	Runlevel string   `json:"runlevel,omitempty"  xml:"runlevel,omitempty"`
 }
 
-type StartResponse struct {
-}
+type StartResponse struct{}
 
 type Stop struct {
 	XMLName      xml.Name `xml:"urn:SAPControl Stop"`
@@ -192,8 +194,7 @@ type Stop struct {
 	IsSystemStop int32    `json:"IsSystemStop,omitempty" xml:"IsSystemStop,omitempty"`
 }
 
-type StopResponse struct {
-}
+type StopResponse struct{}
 
 type StartSystem struct {
 	XMLName       xml.Name         `xml:"urn:SAPControl StartSystem"`
@@ -203,8 +204,7 @@ type StartSystem struct {
 	Runlevel      string           `json:"runlevel,omitempty"        xml:"runlevel,omitempty"`
 }
 
-type StartSystemResponse struct {
-}
+type StartSystemResponse struct{}
 
 type StopSystem struct {
 	XMLName       xml.Name         `xml:"urn:SAPControl StopSystem"`
@@ -214,8 +214,7 @@ type StopSystem struct {
 	Waittimeout   int32            `json:"waittimeout,omitempty"    xml:"waittimeout,omitempty"`
 }
 
-type StopSystemResponse struct {
-}
+type StopSystemResponse struct{}
 
 type webService struct {
 	client *soap.Client

--- a/internal/core/sapsystem/sapinstance.go
+++ b/internal/core/sapsystem/sapinstance.go
@@ -23,9 +23,11 @@ var (
 	diagnosticsAgentFeatures = regexp.MustCompile("SMDAGENT")
 )
 
-type SystemReplication map[string]any
-type HostConfiguration map[string]any
-type HdbnsutilSRstate map[string]any
+type (
+	SystemReplication map[string]any
+	HostConfiguration map[string]any
+	HdbnsutilSRstate  map[string]any
+)
 
 type SAPInstance struct {
 	Name       string

--- a/internal/core/sapsystem/sapsystem.go
+++ b/internal/core/sapsystem/sapsystem.go
@@ -18,7 +18,6 @@ import (
 	"strings"
 
 	"github.com/spf13/afero"
-
 	"github.com/trento-project/agent/v3/internal/core/sapsystem/sapcontrolapi"
 	"github.com/trento-project/agent/v3/pkg/utils"
 )
@@ -48,8 +47,10 @@ var (
 	sapProfilePatternCompiled    = regexp.MustCompile(sapProfilePattern)
 )
 
-type SAPSystemsList []*SAPSystem
-type SAPSystemsMap map[string]*SAPSystem
+type (
+	SAPSystemsList []*SAPSystem
+	SAPSystemsMap  map[string]*SAPSystem
+)
 
 // A SAPSystem in this context is a SAP installation under one SID.
 // It will have application or database type, mutually exclusive
@@ -99,7 +100,7 @@ func NewSAPSystemsList(
 	executor utils.CommandExecutor,
 	webService sapcontrolapi.WebServiceConnector,
 ) (SAPSystemsList, error) {
-	var systems = SAPSystemsList{}
+	systems := SAPSystemsList{}
 
 	systemPaths, err := FindSystems(fs)
 	if err != nil {
@@ -217,7 +218,7 @@ func (system *SAPSystem) GetDBAddress() (string, error) {
 		return "", errors.New("SAPDBHOST field not found in the SAP profile")
 	}
 
-	addrList, err := net.LookupIP(sapdbhost)
+	addrList, err := net.LookupIP(sapdbhost) //nolint:noctx
 	if err != nil {
 		return "", fmt.Errorf("could not resolve \"%s\" hostname", sapdbhost)
 	}
@@ -238,7 +239,7 @@ func (system *SAPSystem) GetDBAddress() (string, error) {
 // FindSystems returns the installed SAP systems in the /usr/sap folder
 // It returns the list of found SAP system paths.
 func FindSystems(fs afero.Fs) ([]string, error) {
-	var systems = []string{}
+	systems := []string{}
 
 	exists, _ := afero.DirExists(fs, sapInstallationPath)
 	if !exists {
@@ -265,7 +266,7 @@ func FindSystems(fs afero.Fs) ([]string, error) {
 // FindInstances returns the installed SAP instances in the /usr/sap/${SID} folder
 // It returns a list with [instanceName, instanceNumber] combination.
 func FindInstances(fs afero.Fs, sapPath string) ([][]string, error) {
-	var instances = [][]string{}
+	instances := [][]string{}
 
 	files, err := afero.ReadDir(fs, sapPath)
 	if err != nil {
@@ -284,7 +285,7 @@ func FindInstances(fs afero.Fs, sapPath string) ([][]string, error) {
 
 // FindProfiles returns the latest profile file names in the /sapmnt/${SID}/folder folder.
 func FindProfiles(fs afero.Fs, sid string) ([]string, error) {
-	var profiles = []string{}
+	profiles := []string{}
 
 	files, err := afero.ReadDir(fs, path.Join(sapMntPath, sid, "profile"))
 	if err != nil {
@@ -349,6 +350,7 @@ func parseSAPProfile(r io.Reader) (map[string]string, error) {
 	lineNumber := 0
 	for scanner.Scan() {
 		lineNumber++
+
 		line := strings.TrimSpace(scanner.Text())
 		if line == "" || strings.HasPrefix(line, "#") {
 			continue
@@ -357,25 +359,29 @@ func parseSAPProfile(r io.Reader) (map[string]string, error) {
 		key, value, found := strings.Cut(line, "=")
 		if !found {
 			slog.Warn("Skipping malformed SAP profile line without '=' separator", "line", lineNumber)
+
 			continue
 		}
 
 		key = strings.TrimSpace(key)
 		if key == "" {
 			slog.Warn("Skipping SAP profile line with empty key", "line", lineNumber)
+
 			continue
 		}
 
 		profile[key] = strings.TrimSpace(value)
 	}
 
-	if err := scanner.Err(); err != nil {
+	err := scanner.Err()
+	if err != nil {
 		return nil, err
 	}
 
 	return profile, nil
 }
 
+// GetDatabases returns the list of databases.
 // The content type of the databases.lst looks like
 // # DATABASE:CONTAINER:USER:GROUP:USERID:GROUPID:HOST:SQLPORT:ACTIVE
 // PRD::::::hana02:30015:yes

--- a/internal/core/sapsystem/sapsystem_test.go
+++ b/internal/core/sapsystem/sapsystem_test.go
@@ -87,22 +87,22 @@ func fakeNewWebService(instName string, features string) sapcontrolapi.WebServic
 func mockDEVFileSystem() (afero.Fs, error) {
 	appFS := afero.NewMemMapFs()
 
-	err := appFS.MkdirAll("/usr/sap/DEV/ASCS01", 0755)
+	err := appFS.MkdirAll("/usr/sap/DEV/ASCS01", 0o755)
 	if err != nil {
 		return nil, err
 	}
 
-	err = afero.WriteFile(appFS, "/usr/sap/DEV/SYS/profile/DEFAULT.PFL", []byte{}, 0644)
+	err = afero.WriteFile(appFS, "/usr/sap/DEV/SYS/profile/DEFAULT.PFL", []byte{}, 0o644)
 	if err != nil {
 		return nil, err
 	}
 
-	err = appFS.MkdirAll("/usr/sap/DEV/SYS/global/hdb/custom/config/", 0755)
+	err = appFS.MkdirAll("/usr/sap/DEV/SYS/global/hdb/custom/config/", 0o755)
 	if err != nil {
 		return nil, err
 	}
 
-	err = appFS.MkdirAll("/usr/sap/DEV/SYS/global/sapcontrol", 0755)
+	err = appFS.MkdirAll("/usr/sap/DEV/SYS/global/sapcontrol", 0o755)
 	if err != nil {
 		return nil, err
 	}
@@ -111,7 +111,7 @@ func mockDEVFileSystem() (afero.Fs, error) {
 		appFS,
 		"/usr/sap/DEV/SYS/global/sapcontrol/0.3_50013_50014_0_2_00_host",
 		[]byte("Host:somehost Pid:100"),
-		0644,
+		0o644,
 	)
 	if err != nil {
 		return nil, err
@@ -155,13 +155,13 @@ func mockSappfpar() []byte {
 func (suite *SAPSystemTestSuite) TestNewSAPSystemsList() {
 	ctx := context.TODO()
 	appFS := afero.NewMemMapFs()
-	err := appFS.MkdirAll("/usr/sap/DEV/ASCS01", 0755)
+	err := appFS.MkdirAll("/usr/sap/DEV/ASCS01", 0o755)
 	suite.Require().NoError(err)
-	err = afero.WriteFile(appFS, "/usr/sap/DEV/SYS/profile/DEFAULT.PFL", []byte{}, 0644)
+	err = afero.WriteFile(appFS, "/usr/sap/DEV/SYS/profile/DEFAULT.PFL", []byte{}, 0o644)
 	suite.Require().NoError(err)
-	err = appFS.MkdirAll("/usr/sap/PRD/ERS02", 0755)
+	err = appFS.MkdirAll("/usr/sap/PRD/ERS02", 0o755)
 	suite.Require().NoError(err)
-	err = afero.WriteFile(appFS, "/usr/sap/PRD/SYS/profile/DEFAULT.PFL", []byte{}, 0644)
+	err = afero.WriteFile(appFS, "/usr/sap/PRD/SYS/profile/DEFAULT.PFL", []byte{}, 0o644)
 	suite.Require().NoError(err)
 
 	mockCommand := new(mocks.MockCommandExecutor)
@@ -186,20 +186,20 @@ func (suite *SAPSystemTestSuite) TestNewSAPSystem() {
 	mockWebServiceConnector.On("New", "02").Return(fakeNewWebService("ERS02", ""))
 
 	appFS := afero.NewMemMapFs()
-	err := appFS.MkdirAll("/usr/sap/DEV/ASCS01", 0755)
+	err := appFS.MkdirAll("/usr/sap/DEV/ASCS01", 0o755)
 	suite.Require().NoError(err)
-	err = appFS.MkdirAll("/usr/sap/DEV/ERS02", 0755)
+	err = appFS.MkdirAll("/usr/sap/DEV/ERS02", 0o755)
 	suite.Require().NoError(err)
 
 	profileFile, _ := os.Open(helpers.GetFixturePath("discovery/sap_system/sap_profile_default"))
 	profileContent, _ := io.ReadAll(profileFile)
 
-	err = appFS.MkdirAll("/usr/sap/DEV/SYS/profile", 0755)
+	err = appFS.MkdirAll("/usr/sap/DEV/SYS/profile", 0o755)
 	suite.Require().NoError(err)
-	err = afero.WriteFile(appFS, "/usr/sap/DEV/SYS/profile/DEFAULT.PFL", profileContent, 0644)
+	err = afero.WriteFile(appFS, "/usr/sap/DEV/SYS/profile/DEFAULT.PFL", profileContent, 0o644)
 	suite.Require().NoError(err)
 
-	err = appFS.MkdirAll("/usr/sap/DEV/SYS/global/sapcontrol", 0755)
+	err = appFS.MkdirAll("/usr/sap/DEV/SYS/global/sapcontrol", 0o755)
 	suite.Require().NoError(err)
 
 	expectedProfile := sapsystem.SAPProfile{
@@ -275,7 +275,7 @@ key2 = value2
 
 	err = afero.WriteFile(
 		appFS, "/usr/sap/DEV/SYS/global/hdb/custom/config/nameserver.ini",
-		nameserverContent, 0644)
+		nameserverContent, 0o644)
 	suite.Require().NoError(err)
 
 	mockCommand := new(mocks.MockCommandExecutor)
@@ -326,7 +326,7 @@ func (suite *SAPSystemTestSuite) TestDetectSystemId_Diagnostics() {
 
 	err = afero.WriteFile(
 		appFS, "/etc/machine-id",
-		machineIDContent, 0644)
+		machineIDContent, 0o644)
 	suite.Require().NoError(err)
 
 	mockCommand := new(mocks.MockCommandExecutor)
@@ -360,7 +360,7 @@ func (suite *SAPSystemTestSuite) TestDetectSystemId_Unknown() {
 
 func (suite *SAPSystemTestSuite) TestGetDatabases() {
 	appFS := afero.NewMemMapFs()
-	err := appFS.MkdirAll("/usr/sap/DEV/SYS/global/hdb/mdc/", 0755)
+	err := appFS.MkdirAll("/usr/sap/DEV/SYS/global/hdb/mdc/", 0o755)
 	suite.Require().NoError(err)
 
 	nameserverContent := []byte(`
@@ -373,7 +373,7 @@ ERR:::
 
 	err = afero.WriteFile(
 		appFS, "/usr/sap/DEV/SYS/global/hdb/mdc/databases.lst",
-		nameserverContent, 0644)
+		nameserverContent, 0o644)
 	suite.Require().NoError(err)
 
 	dbs, err := sapsystem.GetDatabases(appFS, "DEV")
@@ -428,20 +428,20 @@ func (suite *SAPSystemTestSuite) TestNewSAPInstanceDatabase() {
 	host, _ := os.Hostname()
 
 	appFS := afero.NewMemMapFs()
-	err := appFS.MkdirAll("/usr/sap/PRD/SYS/global/sapcontrol", 0755)
+	err := appFS.MkdirAll("/usr/sap/PRD/SYS/global/sapcontrol", 0o755)
 	suite.Require().NoError(err)
 	err = afero.WriteFile(
 		appFS,
 		"/usr/sap/PRD/SYS/global/sapcontrol/0.3_50013_50014_0_2_00_host1",
 		[]byte("Host:otherhost Pid:100"),
-		0644,
+		0o644,
 	)
 	suite.Require().NoError(err)
 	err = afero.WriteFile(
 		appFS,
 		"/usr/sap/PRD/SYS/global/sapcontrol/0.3_50113_50114_0_3_01_host2",
 		fmt.Appendf(nil, "Host:%s Pid:100", host),
-		0644,
+		0o644,
 	)
 	suite.Require().NoError(err)
 
@@ -527,9 +527,10 @@ func (suite *SAPSystemTestSuite) TestNewSAPInstanceDatabase() {
 		mockSystemReplicationStatus(), nil,
 	)
 
-	mockCommand.On("Output", "/usr/bin/su", "-lc", "python /usr/sap/PRD/HDB01/exe/python_support/landscapeHostConfiguration.py --sapcontrol=1", "prdadm").Return(
-		mockLandscapeHostConfiguration(), nil,
-	)
+	mockCommand.On("Output", "/usr/bin/su", "-lc", "python /usr/sap/PRD/HDB01/exe/python_support/landscapeHostConfiguration.py --sapcontrol=1", "prdadm").
+		Return(
+			mockLandscapeHostConfiguration(), nil,
+		)
 
 	mockCommand.On("Output", "/usr/bin/su", "-lc", "/usr/sap/PRD/HDB01/exe/hdbnsutil -sr_state -sapcontrol=1", "prdadm").Return(
 		mockHdbnsutilSrstate(), nil,
@@ -710,20 +711,20 @@ func (suite *SAPSystemTestSuite) TestNewSAPInstanceApp() {
 	host, _ := os.Hostname()
 
 	appFS := afero.NewMemMapFs()
-	err := appFS.MkdirAll("/usr/sap/PRD/SYS/global/sapcontrol", 0755)
+	err := appFS.MkdirAll("/usr/sap/PRD/SYS/global/sapcontrol", 0o755)
 	suite.Require().NoError(err)
 	err = afero.WriteFile(
 		appFS,
 		"/usr/sap/PRD/SYS/global/sapcontrol/0.3_50013_50014_0_2_00_host1",
 		fmt.Appendf(nil, "Host:%s Pid:100", host),
-		0644,
+		0o644,
 	)
 	suite.Require().NoError(err)
 	err = afero.WriteFile(
 		appFS,
 		"/usr/sap/PRD/SYS/global/sapcontrol/0.3_50113_50114_0_3_01_host2",
 		[]byte("Host:otherhost Pid:100"),
-		0644,
+		0o644,
 	)
 	suite.Require().NoError(err)
 
@@ -918,10 +919,10 @@ func (suite *SAPSystemTestSuite) TestGetSIDsString() {
 func (suite *SAPSystemTestSuite) TestFindSystemsNotFound() {
 	appFS := afero.NewMemMapFs()
 	// create test files and directories
-	err := appFS.MkdirAll("/usr/sap/", 0755)
+	err := appFS.MkdirAll("/usr/sap/", 0o755)
 	suite.Require().NoError(err)
 
-	err = appFS.MkdirAll("/usr/sap/DEV1/", 0755)
+	err = appFS.MkdirAll("/usr/sap/DEV1/", 0o755)
 	suite.Require().NoError(err)
 
 	systems, err := sapsystem.FindSystems(appFS)
@@ -933,22 +934,22 @@ func (suite *SAPSystemTestSuite) TestFindSystemsNotFound() {
 func (suite *SAPSystemTestSuite) TestFindSystems() {
 	appFS := afero.NewMemMapFs()
 	// create test files and directories
-	err := appFS.MkdirAll("/usr/sap/PRD/HDB00", 0755)
+	err := appFS.MkdirAll("/usr/sap/PRD/HDB00", 0o755)
 	suite.Require().NoError(err)
 
-	err = appFS.MkdirAll("/usr/sap/PRD/HDB01", 0755)
+	err = appFS.MkdirAll("/usr/sap/PRD/HDB01", 0o755)
 	suite.Require().NoError(err)
 
-	err = appFS.MkdirAll("/usr/sap/DEV/ASCS02", 0755)
+	err = appFS.MkdirAll("/usr/sap/DEV/ASCS02", 0o755)
 	suite.Require().NoError(err)
 
-	err = appFS.MkdirAll("/usr/sap/DEV1/ASCS02", 0755)
+	err = appFS.MkdirAll("/usr/sap/DEV1/ASCS02", 0o755)
 	suite.Require().NoError(err)
 
-	err = appFS.MkdirAll("/usr/sap/DEV/SYS/BLA12", 0755)
+	err = appFS.MkdirAll("/usr/sap/DEV/SYS/BLA12", 0o755)
 	suite.Require().NoError(err)
 
-	err = appFS.MkdirAll("/usr/sap/DEV/PRD0", 0755)
+	err = appFS.MkdirAll("/usr/sap/DEV/PRD0", 0o755)
 	suite.Require().NoError(err)
 
 	systems, err := sapsystem.FindSystems(appFS)
@@ -959,7 +960,7 @@ func (suite *SAPSystemTestSuite) TestFindSystems() {
 func (suite *SAPSystemTestSuite) TestFindInstancesNotFound() {
 	appFS := afero.NewMemMapFs()
 	// create test files and directories
-	err := appFS.MkdirAll("/usr/sap/DEV/SYS/BLA12", 0755)
+	err := appFS.MkdirAll("/usr/sap/DEV/SYS/BLA12", 0o755)
 	suite.Require().NoError(err)
 
 	instances, err := sapsystem.FindInstances(appFS, "/usr/sap/DEV")
@@ -971,16 +972,16 @@ func (suite *SAPSystemTestSuite) TestFindInstancesNotFound() {
 func (suite *SAPSystemTestSuite) TestFindInstances() {
 	appFS := afero.NewMemMapFs()
 	// create test files and directories
-	err := appFS.MkdirAll("/usr/sap/DEV/ASCS02", 0755)
+	err := appFS.MkdirAll("/usr/sap/DEV/ASCS02", 0o755)
 	suite.Require().NoError(err)
 
-	err = appFS.MkdirAll("/usr/sap/DEV/SYS/BLA12", 0755)
+	err = appFS.MkdirAll("/usr/sap/DEV/SYS/BLA12", 0o755)
 	suite.Require().NoError(err)
 
-	err = appFS.MkdirAll("/usr/sap/DEV/PRD0", 0755)
+	err = appFS.MkdirAll("/usr/sap/DEV/PRD0", 0o755)
 	suite.Require().NoError(err)
 
-	err = appFS.MkdirAll("/usr/sap/DEV/ERS10", 0755)
+	err = appFS.MkdirAll("/usr/sap/DEV/ERS10", 0o755)
 	suite.Require().NoError(err)
 
 	instances, err := sapsystem.FindInstances(appFS, "/usr/sap/DEV")
@@ -995,9 +996,9 @@ func (suite *SAPSystemTestSuite) TestFindInstances() {
 func (suite *SAPSystemTestSuite) TestFindProfilesNotFound() {
 	appFS := afero.NewMemMapFs()
 	// create test files and directories
-	err := appFS.MkdirAll("/sapmnt/DEV/profile", 0755)
+	err := appFS.MkdirAll("/sapmnt/DEV/profile", 0o755)
 	suite.Require().NoError(err)
-	err = appFS.MkdirAll("/sapmnt/PRD/profile", 0755)
+	err = appFS.MkdirAll("/sapmnt/PRD/profile", 0o755)
 	suite.Require().NoError(err)
 
 	profiles, err := sapsystem.FindProfiles(appFS, "DEV")
@@ -1009,17 +1010,17 @@ func (suite *SAPSystemTestSuite) TestFindProfilesNotFound() {
 func (suite *SAPSystemTestSuite) TestFindProfiles() {
 	appFS := afero.NewMemMapFs()
 	// create test files and directories
-	err := afero.WriteFile(appFS, "/sapmnt/DEV/profile/DEFAULT.1.PFL", []byte{}, 0644)
+	err := afero.WriteFile(appFS, "/sapmnt/DEV/profile/DEFAULT.1.PFL", []byte{}, 0o644)
 	suite.Require().NoError(err)
-	err = afero.WriteFile(appFS, "/sapmnt/DEV/profile/DEFAULT.PFL", []byte{}, 0644)
+	err = afero.WriteFile(appFS, "/sapmnt/DEV/profile/DEFAULT.PFL", []byte{}, 0o644)
 	suite.Require().NoError(err)
-	err = afero.WriteFile(appFS, "/sapmnt/DEV/profile/dev_profile", []byte{}, 0644)
+	err = afero.WriteFile(appFS, "/sapmnt/DEV/profile/dev_profile", []byte{}, 0o644)
 	suite.Require().NoError(err)
-	err = afero.WriteFile(appFS, "/sapmnt/DEV/profile/dev_profile.1", []byte{}, 0644)
+	err = afero.WriteFile(appFS, "/sapmnt/DEV/profile/dev_profile.1", []byte{}, 0o644)
 	suite.Require().NoError(err)
-	err = afero.WriteFile(appFS, "/sapmnt/DEV/profile/dev_profile.bak", []byte{}, 0644)
+	err = afero.WriteFile(appFS, "/sapmnt/DEV/profile/dev_profile.bak", []byte{}, 0o644)
 	suite.Require().NoError(err)
-	err = afero.WriteFile(appFS, "/sapmnt/PRD/profile/prd_profile", []byte{}, 0644)
+	err = afero.WriteFile(appFS, "/sapmnt/PRD/profile/prd_profile", []byte{}, 0o644)
 	suite.Require().NoError(err)
 
 	profiles, err := sapsystem.FindProfiles(appFS, "DEV")
@@ -1094,7 +1095,7 @@ func (suite *SAPSystemTestSuite) TestDetectType() {
 	}
 
 	appFS := afero.NewMemMapFs()
-	err := appFS.MkdirAll("/usr/sap/PRD/SYS/global/sapcontrol", 0755)
+	err := appFS.MkdirAll("/usr/sap/PRD/SYS/global/sapcontrol", 0o755)
 	suite.Require().NoError(err)
 
 	for _, tt := range cases {
@@ -1146,7 +1147,7 @@ func (suite *SAPSystemTestSuite) TestDetectType_Database() {
 	ctx := context.TODO()
 
 	appFS := afero.NewMemMapFs()
-	err := appFS.MkdirAll("/usr/sap/HDB/SYS/global/sapcontrol", 0755)
+	err := appFS.MkdirAll("/usr/sap/HDB/SYS/global/sapcontrol", 0o755)
 	suite.Require().NoError(err)
 
 	mockWebService := new(sapControlMocks.MockWebService)

--- a/internal/core/saptune/saptune.go
+++ b/internal/core/saptune/saptune.go
@@ -10,14 +10,13 @@ import (
 	"strings"
 
 	"github.com/tidwall/gjson"
-	"golang.org/x/mod/semver"
-
 	"github.com/trento-project/agent/v3/pkg/utils"
+	"golang.org/x/mod/semver"
 )
 
 const minimalSaptuneVersion = "v3.1.0"
 
-type Saptune interface {
+type Saptune interface { //nolint:interfacebloat
 	CheckVersionSupport(ctx context.Context) error
 	GetVersion(ctx context.Context) (string, error)
 	GetAppliedSolution(ctx context.Context) (string, error)

--- a/internal/core/saptune/saptune_test.go
+++ b/internal/core/saptune/saptune_test.go
@@ -6,9 +6,8 @@ package saptune_test
 import (
 	"context"
 	"errors"
-	"testing"
-
 	"log/slog"
+	"testing"
 
 	"github.com/stretchr/testify/suite"
 	"github.com/trento-project/agent/v3/internal/core/saptune"

--- a/internal/core/subscription/subscription_test.go
+++ b/internal/core/subscription/subscription_test.go
@@ -4,12 +4,10 @@
 package subscription_test
 
 import (
+	"errors"
 	"testing"
 
-	"errors"
-
 	"github.com/stretchr/testify/suite"
-
 	"github.com/trento-project/agent/v3/internal/core/subscription"
 	"github.com/trento-project/agent/v3/pkg/utils/mocks"
 )

--- a/internal/discovery/cloud.go
+++ b/internal/discovery/cloud.go
@@ -6,18 +6,19 @@ package discovery
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"time"
-
-	"log/slog"
 
 	"github.com/trento-project/agent/v3/internal/core/cloud"
 	"github.com/trento-project/agent/v3/internal/discovery/collector"
 	"github.com/trento-project/agent/v3/pkg/utils"
 )
 
-const CloudDiscoveryID string = "cloud_discovery"
-const CloudDiscoveryMinPeriod time.Duration = 1 * time.Second
+const (
+	CloudDiscoveryID        string        = "cloud_discovery"
+	CloudDiscoveryMinPeriod time.Duration = 1 * time.Second
+)
 
 type CloudDiscovery struct {
 	id              string

--- a/internal/discovery/cluster.go
+++ b/internal/discovery/cluster.go
@@ -6,18 +6,19 @@ package discovery
 import (
 	"context"
 	"fmt"
-	"time"
-
 	"log/slog"
+	"time"
 
 	"github.com/trento-project/agent/v3/internal/core/cluster"
 	"github.com/trento-project/agent/v3/internal/discovery/collector"
 )
 
-const ClusterDiscoveryID string = "ha_cluster_discovery"
-const ClusterDiscoveryMinPeriod time.Duration = 1 * time.Second
+const (
+	ClusterDiscoveryID        string        = "ha_cluster_discovery"
+	ClusterDiscoveryMinPeriod time.Duration = 1 * time.Second
+)
 
-// This Discover handles any Pacemaker Cluster type.
+// ClusterDiscovery handles any Pacemaker Cluster type.
 type ClusterDiscovery struct {
 	id              string
 	collectorClient collector.Client
@@ -40,7 +41,7 @@ func (c ClusterDiscovery) GetInterval() time.Duration {
 	return c.interval
 }
 
-// Execute one iteration of a discovery and publish the results to the collector.
+// Discover executes one iteration of a discovery and publish the results to the collector.
 func (c ClusterDiscovery) Discover(ctx context.Context) (string, error) {
 	cluster, err := cluster.NewCluster(ctx)
 	if err != nil {

--- a/internal/discovery/collector/client.go
+++ b/internal/discovery/collector/client.go
@@ -75,6 +75,7 @@ func (c *Collector) Publish(ctx context.Context, discoveryType string, payload a
 					" Status: %d, Agent: %s, discovery: %s, and the response body could not be read: %w",
 				resp.StatusCode, c.config.AgentID, discoveryType, err)
 		}
+
 		return fmt.Errorf(
 			"something wrong happened while publishing data to the collector. Status: %d, Agent: %s, discovery: %s, body: %q",
 			resp.StatusCode, c.config.AgentID, discoveryType, body)

--- a/internal/discovery/collector/client_test.go
+++ b/internal/discovery/collector/client_test.go
@@ -140,7 +140,7 @@ func (suite *CollectorClientTestSuite) TestCollectorClientPublishingFailureRespo
 
 		err := suite.collectorClient.Publish(ctx, "some_discovery_type", struct{}{})
 
-		suite.Error(err, tt.name)
+		suite.Require().Error(err, tt.name)
 
 		if tt.expectContains != "" {
 			suite.Contains(err.Error(), tt.expectContains, tt.name)
@@ -152,7 +152,7 @@ func (suite *CollectorClientTestSuite) TestCollectorClientPublishingFailureRespo
 		}
 
 		if tt.expectErrorIs != nil {
-			suite.ErrorIs(err, tt.expectErrorIs, tt.name)
+			suite.Require().ErrorIs(err, tt.expectErrorIs, tt.name)
 		}
 	}
 }

--- a/internal/discovery/collector/publishing_test.go
+++ b/internal/discovery/collector/publishing_test.go
@@ -59,7 +59,10 @@ func (suite *PublishingTestSuite) TestCollectorClientPublishingClusterDiscovery(
 	discoveredCluster := mocks.NewDiscoveredClusterMock()
 
 	suite.runDiscoveryScenario(clusterDiscovery, discoveredCluster, func(requestBodyAgainstCollector string) {
-		suite.assertJSONMatchesJSONFileContent(helpers.GetFixturePath("discovery/cluster/expected_published_cluster_discovery.json"), requestBodyAgainstCollector)
+		suite.assertJSONMatchesJSONFileContent(
+			helpers.GetFixturePath("discovery/cluster/expected_published_cluster_discovery.json"),
+			requestBodyAgainstCollector,
+		)
 	})
 }
 
@@ -67,7 +70,10 @@ func (suite *PublishingTestSuite) TestCollectorClientPublishingClusterDiscoveryP
 	discoveredCluster := mocks.NewDiscoveredClusterMockPacemaker3()
 
 	suite.runDiscoveryScenario(clusterDiscovery, discoveredCluster, func(requestBodyAgainstCollector string) {
-		suite.assertJSONMatchesJSONFileContent(helpers.GetFixturePath("discovery/cluster/expected_published_cluster_discovery_pacemaker3.json"), requestBodyAgainstCollector)
+		suite.assertJSONMatchesJSONFileContent(
+			helpers.GetFixturePath("discovery/cluster/expected_published_cluster_discovery_pacemaker3.json"),
+			requestBodyAgainstCollector,
+		)
 	})
 }
 
@@ -75,7 +81,10 @@ func (suite *PublishingTestSuite) TestCollectorClientPublishingClusterDiscoveryP
 	discoveredCluster := mocks.NewDiscoveredClusterMockPacemakerFuture()
 
 	suite.runDiscoveryScenario(clusterDiscovery, discoveredCluster, func(requestBodyAgainstCollector string) {
-		suite.assertJSONMatchesJSONFileContent(helpers.GetFixturePath("discovery/cluster/expected_published_cluster_discovery_pacemaker_future.json"), requestBodyAgainstCollector)
+		suite.assertJSONMatchesJSONFileContent(
+			helpers.GetFixturePath("discovery/cluster/expected_published_cluster_discovery_pacemaker_future.json"),
+			requestBodyAgainstCollector,
+		)
 	})
 }
 
@@ -98,7 +107,10 @@ func (suite *PublishingTestSuite) TestCollectorClientPublishingHostDiscovery() {
 func (suite *PublishingTestSuite) TestCollectorClientPublishingSubscriptionDiscovery() {
 	discoveredSubscriptions := mocks.NewDiscoveredSubscriptionsMock()
 	suite.runDiscoveryScenario(subscriptionDiscovery, discoveredSubscriptions, func(requestBodyAgainstCollector string) {
-		suite.assertJSONMatchesJSONFileContent(helpers.GetFixturePath("discovery/subscriptions/expected_published_subscriptions_discovery.json"), requestBodyAgainstCollector)
+		suite.assertJSONMatchesJSONFileContent(
+			helpers.GetFixturePath("discovery/subscriptions/expected_published_subscriptions_discovery.json"),
+			requestBodyAgainstCollector,
+		)
 	})
 }
 
@@ -106,7 +118,10 @@ func (suite *PublishingTestSuite) TestCollectorClientPublishingSAPSystemDatabase
 	discoveredSAPSystem := mocks.NewDiscoveredSAPSystemDatabaseMock()
 
 	suite.runDiscoveryScenario(sapSystemdiscovery, discoveredSAPSystem, func(requestBodyAgainstCollector string) {
-		suite.assertJSONMatchesJSONFileContent(helpers.GetFixturePath("discovery/sap_system/expected_published_sap_system_discovery_database.json"), requestBodyAgainstCollector)
+		suite.assertJSONMatchesJSONFileContent(
+			helpers.GetFixturePath("discovery/sap_system/expected_published_sap_system_discovery_database.json"),
+			requestBodyAgainstCollector,
+		)
 	})
 }
 
@@ -114,7 +129,10 @@ func (suite *PublishingTestSuite) TestCollectorClientPublishingSAPSystemApplicat
 	discoveredSAPSystem := mocks.NewDiscoveredSAPSystemApplicationMock()
 
 	suite.runDiscoveryScenario(sapSystemdiscovery, discoveredSAPSystem, func(requestBodyAgainstCollector string) {
-		suite.assertJSONMatchesJSONFileContent(helpers.GetFixturePath("discovery/sap_system/expected_published_sap_system_discovery_application.json"), requestBodyAgainstCollector)
+		suite.assertJSONMatchesJSONFileContent(
+			helpers.GetFixturePath("discovery/sap_system/expected_published_sap_system_discovery_application.json"),
+			requestBodyAgainstCollector,
+		)
 	})
 }
 
@@ -122,7 +140,10 @@ func (suite *PublishingTestSuite) TestCollectorClientPublishingSAPSystemDiagnost
 	discoveredSAPSystem := mocks.NewDiscoveredSAPSystemDiagnosticsMock()
 
 	suite.runDiscoveryScenario(sapSystemdiscovery, discoveredSAPSystem, func(requestBodyAgainstCollector string) {
-		suite.assertJSONMatchesJSONFileContent(helpers.GetFixturePath("discovery/sap_system/expected_published_sap_system_discovery_diagnostics.json"), requestBodyAgainstCollector)
+		suite.assertJSONMatchesJSONFileContent(
+			helpers.GetFixturePath("discovery/sap_system/expected_published_sap_system_discovery_diagnostics.json"),
+			requestBodyAgainstCollector,
+		)
 	})
 }
 
@@ -142,7 +163,10 @@ func (suite *PublishingTestSuite) TestCollectorClientPublishingAWSCloudDiscovery
 	}
 
 	suite.runDiscoveryScenario(cloudDiscovery, discoveredCloudInstance, func(requestBodyAgainstCollector string) {
-		suite.assertJSONMatchesJSONFileContent(helpers.GetFixturePath("discovery/aws/collector_payloads/expected_published_cloud_discovery_with_metadata.json"), requestBodyAgainstCollector)
+		suite.assertJSONMatchesJSONFileContent(
+			helpers.GetFixturePath("discovery/aws/collector_payloads/expected_published_cloud_discovery_with_metadata.json"),
+			requestBodyAgainstCollector,
+		)
 	})
 }
 

--- a/internal/discovery/host.go
+++ b/internal/discovery/host.go
@@ -24,11 +24,15 @@ import (
 	"github.com/trento-project/agent/v3/internal/version"
 )
 
-const HostDiscoveryID string = "host_discovery"
-const HostDiscoveryMinPeriod time.Duration = 1 * time.Second
+const (
+	HostDiscoveryID        string        = "host_discovery"
+	HostDiscoveryMinPeriod time.Duration = 1 * time.Second
+)
 
-const DefaultNodeExporterName string = "node_exporter"
-const NodeExporterPort int = 9100
+const (
+	DefaultNodeExporterName string = "node_exporter"
+	NodeExporterPort        int    = 9100
+)
 
 type PrometheusTargets map[string]string
 
@@ -69,7 +73,7 @@ func (d HostDiscovery) GetInterval() time.Duration {
 	return d.interval
 }
 
-// Execute one iteration of a discovery and publish to the collector.
+// Discover executes one iteration of a discovery and publish to the collector.
 func (d HostDiscovery) Discover(ctx context.Context) (string, error) {
 	ipAddresses, netmasks, err := getNetworksData()
 	if err != nil {
@@ -140,7 +144,8 @@ func getNetworksData() ([]string, []int, error) {
 func updatePrometheusTargets(
 	target string,
 	ipAddresses []string,
-	exporterName string) PrometheusTargets {
+	exporterName string,
+) PrometheusTargets {
 	// Return exporter details if they are given by the user
 	if target != "" {
 		return PrometheusTargets{

--- a/internal/discovery/policy.go
+++ b/internal/discovery/policy.go
@@ -10,7 +10,6 @@ import (
 	"slices"
 
 	"github.com/trento-project/agent/v3/internal/messaging"
-
 	"github.com/trento-project/contracts/go/pkg/events"
 )
 

--- a/internal/discovery/policy_integration_test.go
+++ b/internal/discovery/policy_integration_test.go
@@ -43,6 +43,7 @@ func (suite *PolicyIntegrationTestSuite) TestDiscoveryIntegration() {
 	// with a clear error instead of hanging until the outer test timeout.
 	ctx, ctxCancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer ctxCancel()
+
 	g, groupCtx := errgroup.WithContext(ctx)
 
 	testDiscovery := mocks.NewMockDiscovery(suite.T())

--- a/internal/discovery/policy_test.go
+++ b/internal/discovery/policy_test.go
@@ -6,10 +6,9 @@ package discovery_test
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"testing"
 	"time"
-
-	"log/slog"
 
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"

--- a/internal/discovery/sapsystem.go
+++ b/internal/discovery/sapsystem.go
@@ -13,8 +13,10 @@ import (
 	"github.com/trento-project/agent/v3/internal/discovery/collector"
 )
 
-const SAPDiscoveryID string = "sap_system_discovery"
-const SAPDiscoveryMinPeriod time.Duration = 1 * time.Second
+const (
+	SAPDiscoveryID        string        = "sap_system_discovery"
+	SAPDiscoveryMinPeriod time.Duration = 1 * time.Second
+)
 
 type SAPSystemsDiscovery struct {
 	id              string

--- a/internal/discovery/saptune.go
+++ b/internal/discovery/saptune.go
@@ -14,8 +14,10 @@ import (
 	"github.com/trento-project/agent/v3/pkg/utils"
 )
 
-const SaptuneDiscoveryID string = "saptune_discovery"
-const SaptuneDiscoveryMinPeriod time.Duration = 1 * time.Second
+const (
+	SaptuneDiscoveryID        string        = "saptune_discovery"
+	SaptuneDiscoveryMinPeriod time.Duration = 1 * time.Second
+)
 
 type SaptuneDiscovery struct {
 	id              string

--- a/internal/discovery/subscription.go
+++ b/internal/discovery/subscription.go
@@ -14,8 +14,10 @@ import (
 	"github.com/trento-project/agent/v3/pkg/utils"
 )
 
-const SubscriptionDiscoveryID string = "subscription_discovery"
-const SubscriptionDiscoveryMinPeriod time.Duration = 20 * time.Second
+const (
+	SubscriptionDiscoveryID        string        = "subscription_discovery"
+	SubscriptionDiscoveryMinPeriod time.Duration = 20 * time.Second
+)
 
 type SubscriptionDiscovery struct {
 	id              string

--- a/internal/factsengine/factscache/cache.go
+++ b/internal/factsengine/factscache/cache.go
@@ -4,9 +4,8 @@
 package factscache
 
 import (
-	"sync"
-
 	"log/slog"
+	"sync"
 
 	"golang.org/x/sync/singleflight"
 )
@@ -56,6 +55,7 @@ func (c *FactsCache) Entries() []string {
 
 	c.entries.Range(func(key, _ any) bool {
 		keys = append(keys, key.(string)) //nolint:forcetypeassert
+
 		return true
 	})
 
@@ -76,6 +76,7 @@ func (c *FactsCache) GetOrUpdate(
 	loadedEntry, hit := c.entries.Load(entry)
 	if hit {
 		cacheEntry := loadedEntry.(Entry) //nolint:forcetypeassert
+
 		slog.Debug("Value for entry already cached", "entry", entry)
 
 		return cacheEntry.content, cacheEntry.err

--- a/internal/factsengine/factsengine_integration_test.go
+++ b/internal/factsengine/factsengine_integration_test.go
@@ -9,14 +9,13 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/suite"
-	"golang.org/x/sync/errgroup"
-	"google.golang.org/protobuf/types/known/structpb"
-
 	"github.com/trento-project/agent/v3/internal/factsengine"
 	"github.com/trento-project/agent/v3/internal/factsengine/gatherers"
 	"github.com/trento-project/agent/v3/internal/messaging/testsupport"
 	"github.com/trento-project/agent/v3/pkg/factsengine/entities"
 	"github.com/trento-project/contracts/go/pkg/events"
+	"golang.org/x/sync/errgroup"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 type FactsEngineIntegrationTestSuite struct {
@@ -81,6 +80,7 @@ func (suite *FactsEngineIntegrationTestSuite) TestFactsEngineIntegration() {
 	// with a clear error instead of hanging until the outer test timeout.
 	ctx, ctxCancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer ctxCancel()
+
 	g, groupCtx := errgroup.WithContext(ctx)
 
 	g.Go(func() error {

--- a/internal/factsengine/gatherers/ascsers_cluster.go
+++ b/internal/factsengine/gatherers/ascsers_cluster.go
@@ -8,9 +8,8 @@ import (
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
-	"strings"
-
 	"log/slog"
+	"strings"
 
 	"github.com/trento-project/agent/v3/internal/core/cluster/cib"
 	"github.com/trento-project/agent/v3/internal/core/sapsystem/sapcontrolapi"
@@ -69,7 +68,8 @@ func NewDefaultAscsErsClusterGatherer() *AscsErsClusterGatherer {
 }
 
 func NewAscsErsClusterGatherer(executor utils.CommandExecutor, webService sapcontrolapi.WebServiceConnector,
-	cache *factscache.FactsCache) *AscsErsClusterGatherer {
+	cache *factscache.FactsCache,
+) *AscsErsClusterGatherer {
 	return &AscsErsClusterGatherer{
 		executor:   executor,
 		webService: webService,

--- a/internal/factsengine/gatherers/ascsers_cluster_test.go
+++ b/internal/factsengine/gatherers/ascsers_cluster_test.go
@@ -6,7 +6,6 @@ package gatherers_test
 import (
 	"context"
 	"errors"
-	"fmt"
 	"io"
 	"os"
 	"testing"
@@ -316,12 +315,12 @@ func (suite *AscsErsClusterTestSuite) TestAscsErsClusterGatherPacemaker3() {
 	mockWebServicePRDERS10 := new(sapControlMocks.MockWebService)
 	mockWebServicePRDERS10.
 		On("GetProcessListContext", ctx, mock.Anything).
-		Return(nil, fmt.Errorf("some error"))
+		Return(nil, errors.New("some error"))
 
 	mockWebServiceDEVASCS01 := new(sapControlMocks.MockWebService)
 	mockWebServiceDEVASCS01.
 		On("GetProcessListContext", ctx, mock.Anything).
-		Return(nil, fmt.Errorf("some error"))
+		Return(nil, errors.New("some error"))
 
 	mockWebServiceDEVERS10 := new(sapControlMocks.MockWebService)
 	mockWebServiceDEVERS10.
@@ -361,7 +360,6 @@ func (suite *AscsErsClusterTestSuite) TestAscsErsClusterGatherPacemaker3() {
 
 	results, err := p.Gather(context.Background(), factRequests)
 
-	// nolint:dupl
 	expectedFacts := []entities.Fact{
 		{
 			Name:    "ascsers",
@@ -436,7 +434,7 @@ func (suite *AscsErsClusterTestSuite) TestAscsErsClusterGatherPacemaker3() {
 		},
 	}
 
-	suite.NoError(err)
+	suite.Require().NoError(err)
 	suite.ElementsMatch(expectedFacts, results)
 	suite.webService.AssertNumberOfCalls(suite.T(), "New", 4)
 }

--- a/internal/factsengine/gatherers/cibadmin.go
+++ b/internal/factsengine/gatherers/cibadmin.go
@@ -75,9 +75,11 @@ func (g *CibAdminGatherer) Gather(ctx context.Context, factsRequests []entities.
 		return nil, CibAdminDecodingError.Wrap("error casting the command output")
 	}
 
-	elementsToList := map[string]bool{"primitive": true, "clone": true, "master": true, "group": true,
+	elementsToList := map[string]bool{
+		"primitive": true, "clone": true, "master": true, "group": true,
 		"nvpair": true, "op": true, "rsc_location": true, "rsc_order": true,
-		"rsc_colocation": true, "cluster_property_set": true, "meta_attributes": true}
+		"rsc_colocation": true, "cluster_property_set": true, "meta_attributes": true,
+	}
 
 	factValueMap, err := parseXMLToFactValueMap(cibadmin, elementsToList, entities.WithStringConversion())
 	if err != nil {

--- a/internal/factsengine/gatherers/cibadmin_test.go
+++ b/internal/factsengine/gatherers/cibadmin_test.go
@@ -155,7 +155,8 @@ func (suite *CibAdminTestSuite) TestCibAdminGather() {
 			Error: &entities.FactGatheringError{
 				Type: "value-not-found",
 				Message: "error getting value: requested field value not found: " +
-					"cib.not_found.crm_config"},
+					"cib.not_found.crm_config",
+			},
 		},
 		{
 			Name: "primitives",
@@ -278,7 +279,7 @@ func (suite *CibAdminTestSuite) TestCibAdminGatherPacemaker3() {
 	}
 
 	factResults, err := p.Gather(context.Background(), factRequests)
-	suite.NoError(err)
+	suite.Require().NoError(err)
 	suite.ElementsMatch(expectedResults, factResults)
 }
 
@@ -333,7 +334,7 @@ func (suite *CibAdminTestSuite) TestCibAdminGatherPacemakerFuture() {
 	}
 
 	factResults, err := p.Gather(context.Background(), factRequests)
-	suite.NoError(err)
+	suite.Require().NoError(err)
 	suite.ElementsMatch(expectedResults, factResults)
 }
 

--- a/internal/factsengine/gatherers/corosyncconf.go
+++ b/internal/factsengine/gatherers/corosyncconf.go
@@ -125,6 +125,7 @@ func corosyncConfToMap(lines []string, elementsToList map[string]bool) (*entitie
 	)
 
 	for index, line := range lines {
+		//nolint:nestif
 		if start := sectionStartPatternCompiled.FindStringSubmatch(line); start != nil {
 			if sections == 0 {
 				sectionKey := start[1]

--- a/internal/factsengine/gatherers/corosyncconf_test.go
+++ b/internal/factsengine/gatherers/corosyncconf_test.go
@@ -141,7 +141,6 @@ func (suite *CorosyncConfTestSuite) TestCorosyncConfOneNode() {
 	factsGathered, err := c.Gather(context.Background(), factsRequest)
 
 	expectedResults := []entities.Fact{
-
 		{
 			Name: "corosync_nodes",
 			Value: &entities.FactValueList{Value: []entities.FactValue{
@@ -173,7 +172,6 @@ func (suite *CorosyncConfTestSuite) TestCorosyncConfThreeNodes() {
 	factsGathered, err := c.Gather(context.Background(), factsRequest)
 
 	expectedResults := []entities.Fact{
-
 		{
 			Name: "corosync_nodes",
 			Value: &entities.FactValueList{Value: []entities.FactValue{

--- a/internal/factsengine/gatherers/dir_scan.go
+++ b/internal/factsengine/gatherers/dir_scan.go
@@ -9,13 +9,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"strconv"
 	"syscall"
 
-	"log/slog"
-
 	"github.com/spf13/afero"
-
 	"github.com/trento-project/agent/v3/pkg/factsengine/entities"
 )
 

--- a/internal/factsengine/gatherers/dir_scan_test.go
+++ b/internal/factsengine/gatherers/dir_scan_test.go
@@ -13,11 +13,10 @@ import (
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
-	"go.uber.org/goleak"
-
 	"github.com/trento-project/agent/v3/internal/factsengine/gatherers"
 	"github.com/trento-project/agent/v3/internal/factsengine/gatherers/mocks"
 	"github.com/trento-project/agent/v3/pkg/factsengine/entities"
+	"go.uber.org/goleak"
 )
 
 const dirScanTestBasePath = "/var/test"
@@ -42,7 +41,7 @@ func (s *DirScanGathererSuite) SetupSuite() {
 	for i := range 3 {
 		dirPath := fmt.Sprintf("%s/%d/", dirScanTestBasePath, i)
 		filePath := fmt.Sprintf("%s/%d/ASCS%d", dirScanTestBasePath, i, i)
-		_ = tFs.MkdirAll(dirPath, 0777)
+		_ = tFs.MkdirAll(dirPath, 0o777)
 		_, _ = tFs.Create(filePath)
 	}
 

--- a/internal/factsengine/gatherers/dispwork_test.go
+++ b/internal/factsengine/gatherers/dispwork_test.go
@@ -33,13 +33,13 @@ func TestDispWorkGathererSuite(t *testing.T) {
 
 func (suite *DispWorkGathererTestSuite) SetupTest() {
 	fs := afero.NewMemMapFs()
-	err := fs.MkdirAll("/usr/sap/PRD", 0644)
+	err := fs.MkdirAll("/usr/sap/PRD", 0o644)
 	suite.Require().NoError(err)
-	err = fs.MkdirAll("/usr/sap/QAS", 0644)
+	err = fs.MkdirAll("/usr/sap/QAS", 0o644)
 	suite.Require().NoError(err)
-	err = fs.MkdirAll("/usr/sap/QA2", 0644)
+	err = fs.MkdirAll("/usr/sap/QA2", 0o644)
 	suite.Require().NoError(err)
-	err = fs.MkdirAll("/usr/sap/DEV", 0644)
+	err = fs.MkdirAll("/usr/sap/DEV", 0o644)
 	suite.Require().NoError(err)
 
 	suite.fs = fs

--- a/internal/factsengine/gatherers/fs_usage_test.go
+++ b/internal/factsengine/gatherers/fs_usage_test.go
@@ -49,7 +49,10 @@ tmpfs                6134516        68   6134448       1% /run/user/1000
 coolfs auto             1024      1024        -1     101% /run/user/2000
 `)
 
-	s.mockExecutor.On("OutputContext", mock.Anything, "/usr/bin/df", "-k", "-P", "--", "/usr/sap").Return(dfOutputFile, nil).On("OutputContext", mock.Anything, "/usr/bin/df", "-k", "-P", "--").Return(dfOutputAll, nil)
+	s.mockExecutor.On("OutputContext", mock.Anything, "/usr/bin/df", "-k", "-P", "--", "/usr/sap").
+		Return(dfOutputFile, nil).
+		On("OutputContext", mock.Anything, "/usr/bin/df", "-k", "-P", "--").
+		Return(dfOutputAll, nil)
 
 	gatherer := gatherers.NewFSUsageGatherer(s.mockExecutor)
 

--- a/internal/factsengine/gatherers/groups_test.go
+++ b/internal/factsengine/gatherers/groups_test.go
@@ -112,7 +112,8 @@ func (s *GroupsGathererSuite) TestGroupsParsingDecodeErrorInvalidFormat() {
 
 	result, err := gatherer.Gather(context.Background(), fr)
 	s.Nil(result)
-	s.Require().EqualError(err, "fact gathering error: groups-decoding-error - error decoding groups file: could not decode groups file line daemon:x:1, entry are less then 4")
+	s.Require().
+		EqualError(err, "fact gathering error: groups-decoding-error - error decoding groups file: could not decode groups file line daemon:x:1, entry are less then 4")
 }
 
 func (s *GroupsGathererSuite) TestGroupsContextCancelled() {

--- a/internal/factsengine/gatherers/hostsfile.go
+++ b/internal/factsengine/gatherers/hostsfile.go
@@ -27,9 +27,7 @@ const (
 	hostsFileEntryNotFoundMsg = "requested field value not found in /etc/hosts file"
 )
 
-var (
-	hostsEntryCompiled = regexp.MustCompile(hostsParsingRegexp)
-)
+var hostsEntryCompiled = regexp.MustCompile(hostsParsingRegexp)
 
 //nolint:gochecknoglobals
 var (
@@ -136,9 +134,9 @@ func readHostsFileByLines(filePath string) ([]string, error) {
 }
 
 func hostsFileToMap(lines []string) (*entities.FactValueMap, error) {
-	var hostsFileMap = make(map[string]entities.FactValue)
+	hostsFileMap := make(map[string]entities.FactValue)
 
-	var paramsMap = make(map[string]string)
+	paramsMap := make(map[string]string)
 
 	for _, line := range lines {
 		match := hostsEntryCompiled.FindStringSubmatch(line)

--- a/internal/factsengine/gatherers/ini_files_test.go
+++ b/internal/factsengine/gatherers/ini_files_test.go
@@ -70,7 +70,7 @@ func (suite *IniFilesTestSuite) TestIniFilesGathererNoSAPSystemFound() {
 
 func (suite *IniFilesTestSuite) TestIniFilesGathererEmptyGlobalIni() {
 	fs := afero.NewMemMapFs()
-	err := afero.WriteFile(fs, "/usr/sap/S01/SYS/global/hdb/custom/config/global.ini", []byte(""), 0400)
+	err := afero.WriteFile(fs, "/usr/sap/S01/SYS/global/hdb/custom/config/global.ini", []byte(""), 0o400)
 	suite.Require().NoErrorf(err, "error creating content01")
 
 	c := gatherers.NewIniFilesGatherer(fs)
@@ -107,7 +107,7 @@ func (suite *IniFilesTestSuite) TestIniFilesGathererEmptyGlobalIni() {
 
 func (suite *IniFilesTestSuite) TestIniFilesGathererInvalidGlobalIni() {
 	fs := afero.NewMemMapFs()
-	err := afero.WriteFile(fs, "/usr/sap/S01/SYS/global/hdb/custom/config/global.ini", []byte("invalid"), 0400)
+	err := afero.WriteFile(fs, "/usr/sap/S01/SYS/global/hdb/custom/config/global.ini", []byte("invalid"), 0o400)
 	suite.Require().NoErrorf(err, "error creating content01")
 
 	c := gatherers.NewIniFilesGatherer(fs)
@@ -139,7 +139,7 @@ func (suite *IniFilesTestSuite) TestIniFilesGathererGlobalIniParse() {
 	`
 
 	fs := afero.NewMemMapFs()
-	err := afero.WriteFile(fs, "/usr/sap/S01/SYS/global/hdb/custom/config/global.ini", []byte(content), 0400)
+	err := afero.WriteFile(fs, "/usr/sap/S01/SYS/global/hdb/custom/config/global.ini", []byte(content), 0o400)
 	suite.Require().NoErrorf(err, "error creating content01")
 
 	c := gatherers.NewIniFilesGatherer(fs)
@@ -189,9 +189,9 @@ func (suite *IniFilesTestSuite) TestIniFilesGathererGlobalIniParse() {
 
 func (suite *IniFilesTestSuite) TestIniFilesGathererGlobalIniMultiParse() {
 	fs := afero.NewMemMapFs()
-	err := afero.WriteFile(fs, "/usr/sap/S01/SYS/global/hdb/custom/config/global.ini", []byte("key1=value1"), 0400)
+	err := afero.WriteFile(fs, "/usr/sap/S01/SYS/global/hdb/custom/config/global.ini", []byte("key1=value1"), 0o400)
 	suite.Require().NoErrorf(err, "error creating content01")
-	err = afero.WriteFile(fs, "/usr/sap/S02/SYS/global/hdb/custom/config/global.ini", []byte("key2=value2"), 0400)
+	err = afero.WriteFile(fs, "/usr/sap/S02/SYS/global/hdb/custom/config/global.ini", []byte("key2=value2"), 0o400)
 	suite.Require().NoErrorf(err, "error creating content02")
 
 	c := gatherers.NewIniFilesGatherer(fs)
@@ -243,9 +243,9 @@ func (suite *IniFilesTestSuite) TestIniFilesGathererGlobalIniMultiParse() {
 
 func (suite *IniFilesTestSuite) TestIniFilesGathererGlobalIniPartialError() {
 	fs := afero.NewMemMapFs()
-	err := afero.WriteFile(fs, "/usr/sap/S01/SYS/global/hdb/custom/config/global.ini", []byte("key1=value1"), 0400)
+	err := afero.WriteFile(fs, "/usr/sap/S01/SYS/global/hdb/custom/config/global.ini", []byte("key1=value1"), 0o400)
 	suite.Require().NoErrorf(err, "error creating content01")
-	err = afero.WriteFile(fs, "/usr/sap/S02/SYS/global/hdb/custom/config/global.ini", []byte("invalid"), 0400)
+	err = afero.WriteFile(fs, "/usr/sap/S02/SYS/global/hdb/custom/config/global.ini", []byte("invalid"), 0o400)
 	suite.Require().NoErrorf(err, "error creating content02")
 
 	c := gatherers.NewIniFilesGatherer(fs)
@@ -270,7 +270,7 @@ func (suite *IniFilesTestSuite) TestIniFilesGathererContextCancelled() {
 	cancel()
 
 	fs := afero.NewMemMapFs()
-	err := afero.WriteFile(fs, "/usr/sap/S01/SYS/global/hdb/custom/config/global.ini", []byte("key1=value1"), 0400)
+	err := afero.WriteFile(fs, "/usr/sap/S01/SYS/global/hdb/custom/config/global.ini", []byte("key1=value1"), 0o400)
 	suite.Require().NoErrorf(err, "error creating content01")
 
 	c := gatherers.NewIniFilesGatherer(fs)

--- a/internal/factsengine/gatherers/mountinfo.go
+++ b/internal/factsengine/gatherers/mountinfo.go
@@ -90,9 +90,10 @@ func (g *MountInfoGatherer) Gather(ctx context.Context, factsRequests []entities
 			continue
 		}
 
-		var foundMountInfoResult = MountInfoResult{}
+		foundMountInfoResult := MountInfoResult{}
 
 		for _, mount := range mounts {
+			//nolint:nestif
 			if mount.Mountpoint == requestedFact.Argument {
 				foundMountInfoResult = MountInfoResult{
 					MountPoint: mount.Mountpoint,

--- a/internal/factsengine/gatherers/mountinfo_test.go
+++ b/internal/factsengine/gatherers/mountinfo_test.go
@@ -223,7 +223,8 @@ func (suite *MountInfoTestSuite) TestMountInfoParsingGathererContextCancelled() 
 
 	c := gatherers.NewSapHostCtrlGatherer(utils.Executor{})
 	factRequests := []entities.FactRequest{
-		{Name: "shared",
+		{
+			Name:     "shared",
 			Gatherer: "mount_info",
 			CheckID:  "check1",
 			Argument: "/sapmnt",

--- a/internal/factsengine/gatherers/packageversion_test.go
+++ b/internal/factsengine/gatherers/packageversion_test.go
@@ -85,12 +85,12 @@ func (suite *PackageVersionTestSuite) TestPackageVersionGathererNoArgumentProvid
 
 func (suite *PackageVersionTestSuite) TestPackageVersionGather() {
 	exit11Sh := helpers.GetFixturePath("gatherers/exit11.sh")
-	exit11Cmd := exec.Command(exit11Sh)
+	exit11Cmd := exec.Command(exit11Sh) //nolint:noctx
 	cmdErr := exit11Cmd.Run()
 	suite.Require().Error(cmdErr)
 
 	exit12Sh := helpers.GetFixturePath("gatherers/exit12.sh")
-	exit12Cmd := exec.Command(exit12Sh)
+	exit12Cmd := exec.Command(exit12Sh) //nolint:noctx
 	cmdErr = exit12Cmd.Run()
 	suite.Require().Error(cmdErr)
 
@@ -104,14 +104,12 @@ func (suite *PackageVersionTestSuite) TestPackageVersionGather() {
 	suite.mockExecutor.On("OutputContext", mock.Anything, "/usr/bin/rpm", "-q", "--qf", packageVersionQueryFormat, "pacemaker").
 		Return(pacemakerVersionMockOutput, nil)
 
-	multiversionsMockOutputFile, _ :=
-		os.Open(helpers.GetFixturePath("gatherers/rpm-query-multi-versions.variant-1.output"))
+	multiversionsMockOutputFile, _ := os.Open(helpers.GetFixturePath("gatherers/rpm-query-multi-versions.variant-1.output"))
 	multiversionsVersionMockOutput, _ := io.ReadAll(multiversionsMockOutputFile)
 	suite.mockExecutor.On("OutputContext", mock.Anything, "/usr/bin/rpm", "-q", "--qf", packageVersionQueryFormat, "sbd").
 		Return(multiversionsVersionMockOutput, nil)
 
-	multiversionsVariantMockOutputFile, _ :=
-		os.Open(helpers.GetFixturePath("gatherers/rpm-query-multi-versions.variant-2.output"))
+	multiversionsVariantMockOutputFile, _ := os.Open(helpers.GetFixturePath("gatherers/rpm-query-multi-versions.variant-2.output"))
 	multiversionsVariantVersionMockOutput, _ := io.ReadAll(multiversionsVariantMockOutputFile)
 	suite.mockExecutor.On("OutputContext", mock.Anything, "/usr/bin/rpm", "-q", "--qf", packageVersionQueryFormat, "awk").
 		Return(multiversionsVariantVersionMockOutput, nil)
@@ -123,8 +121,7 @@ func (suite *PackageVersionTestSuite) TestPackageVersionGather() {
 	suite.mockExecutor.On("OutputContext", mock.Anything, "/usr/bin/zypper", "--terse", "versioncmp", "2.4.6", "2.4.5").Return(
 		[]byte("1\n"), &exec.ExitError{ProcessState: exit12Cmd.ProcessState})
 
-	versionComparisonOutputWithWarningFile, _ :=
-		os.Open(helpers.GetFixturePath("gatherers/versioncmp-with-warning.output"))
+	versionComparisonOutputWithWarningFile, _ := os.Open(helpers.GetFixturePath("gatherers/versioncmp-with-warning.output"))
 	versionComparisonOutputWithWarning, _ := io.ReadAll(versionComparisonOutputWithWarningFile)
 	suite.mockExecutor.On("OutputContext", mock.Anything, "/usr/bin/zypper", "--terse", "versioncmp", "1.5.2", "1.5.2").Return(
 		versionComparisonOutputWithWarning, nil)
@@ -274,7 +271,7 @@ func (suite *PackageVersionTestSuite) TestPackageVersionGather() {
 }
 
 func (suite *PackageVersionTestSuite) TestPackageVersionGatherErrors() {
-	exitCmd := exec.Command("exit")
+	exitCmd := exec.Command("exit") //nolint:noctx
 	cmdErr := exitCmd.Run()
 	suite.Require().Error(cmdErr)
 
@@ -359,7 +356,7 @@ func (suite *PackageVersionTestSuite) TestPackageVersionGatherErrors() {
 			Name:  "corosync_compare",
 			Value: nil,
 			Error: &entities.FactGatheringError{
-				Message: "error while executing zypper: zypper: command not found",
+				Message: "error while executing zypper: command not found",
 				Type:    "package-version-zypper-cmd-error",
 			},
 			CheckID: "check3",

--- a/internal/factsengine/gatherers/packageversion_test.go
+++ b/internal/factsengine/gatherers/packageversion_test.go
@@ -356,7 +356,7 @@ func (suite *PackageVersionTestSuite) TestPackageVersionGatherErrors() {
 			Name:  "corosync_compare",
 			Value: nil,
 			Error: &entities.FactGatheringError{
-				Message: "error while executing zypper: command not found",
+				Message: "error while executing zypper: zypper: command not found",
 				Type:    "package-version-zypper-cmd-error",
 			},
 			CheckID: "check3",

--- a/internal/factsengine/gatherers/products_test.go
+++ b/internal/factsengine/gatherers/products_test.go
@@ -53,7 +53,7 @@ func (s *ProductsGathererSuite) TestProductsGathererReadingError() {
 	<name>Leap</name>
 	<version>15.3</version>
 	<release>2</releas
-`), 0777)
+`), 0o777)
 
 	s.Require().NoError(err)
 
@@ -88,7 +88,7 @@ func (s *ProductsGathererSuite) TestProductsGathererSuccess() {
 		<url name="releasenotes">http://doc.opensuse.org/release-notes-openSUSE.rpm</url>
 	</urls>
 </product>
-`), 0777)
+`), 0o777)
 	s.Require().NoError(err)
 
 	err = afero.WriteFile(fs, path.Join(testProductsPath, "otherproduct"), []byte(`
@@ -99,7 +99,7 @@ func (s *ProductsGathererSuite) TestProductsGathererSuccess() {
 	<version>15.5</version>
 	<release>1</release>
 </product>
-`), 0777)
+`), 0o777)
 	s.Require().NoError(err)
 
 	fr := []entities.FactRequest{

--- a/internal/factsengine/gatherers/registry.go
+++ b/internal/factsengine/gatherers/registry.go
@@ -18,7 +18,7 @@ func (e *GathererNotFoundError) Error() string {
 	return fmt.Sprintf("gatherer %s not found", e.Name)
 }
 
-// map[gathererName]map[GathererVersion]FactGatherer.
+// FactGatherersTree is map[gathererName]map[GathererVersion]FactGatherer.
 type FactGatherersTree map[string]map[string]FactGatherer
 
 func extractVersionAndGathererName(gathererName string) (string, string, error) {
@@ -89,7 +89,7 @@ func (m *Registry) AvailableGatherers() []string {
 	return gatherersList
 }
 
-// This is not safe, please not use concurrently.
+// AddGatherers is not safe, please not use concurrently.
 func (m *Registry) AddGatherers(gatherers FactGatherersTree) {
 	gatherersMap := []FactGatherersTree{m.gatherers, gatherers}
 	result := make(FactGatherersTree)

--- a/internal/factsengine/gatherers/registry.go
+++ b/internal/factsengine/gatherers/registry.go
@@ -89,7 +89,7 @@ func (m *Registry) AvailableGatherers() []string {
 	return gatherersList
 }
 
-// AddGatherers is not safe, please not use concurrently.
+// AddGatherers is not safe; please do not use it concurrently.
 func (m *Registry) AddGatherers(gatherers FactGatherersTree) {
 	gatherersMap := []FactGatherersTree{m.gatherers, gatherers}
 	result := make(FactGatherersTree)

--- a/internal/factsengine/gatherers/rpc_plugin.go
+++ b/internal/factsengine/gatherers/rpc_plugin.go
@@ -30,7 +30,7 @@ func (l *RPCPluginLoader) Load(pluginPath string) (FactGatherer, error) {
 	client := goplugin.NewClient(&goplugin.ClientConfig{
 		HandshakeConfig: handshakeConfig,
 		Plugins:         pluginMap,
-		Cmd:             exec.Command(pluginPath),
+		Cmd:             exec.Command(pluginPath), //nolint:noctx
 		Managed:         true,
 		AllowedProtocols: []goplugin.Protocol{
 			goplugin.ProtocolNetRPC,

--- a/internal/factsengine/gatherers/sapcontrol.go
+++ b/internal/factsengine/gatherers/sapcontrol.go
@@ -7,10 +7,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"path/filepath"
 	"regexp"
-
-	"log/slog"
 
 	"github.com/spf13/afero"
 	"github.com/trento-project/agent/v3/internal/core/sapsystem"
@@ -111,7 +110,8 @@ func NewDefaultSapControlGatherer() *SapControlGatherer {
 func NewSapControlGatherer(
 	webService sapcontrolapi.WebServiceConnector,
 	fs afero.Fs,
-	cache *factscache.FactsCache) *SapControlGatherer {
+	cache *factscache.FactsCache,
+) *SapControlGatherer {
 	return &SapControlGatherer{
 		webService: webService,
 		fs:         fs,

--- a/internal/factsengine/gatherers/sapcontrol_test.go
+++ b/internal/factsengine/gatherers/sapcontrol_test.go
@@ -11,12 +11,11 @@ import (
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
+	sapcontrol "github.com/trento-project/agent/v3/internal/core/sapsystem/sapcontrolapi"
+	sapControlMocks "github.com/trento-project/agent/v3/internal/core/sapsystem/sapcontrolapi/mocks"
 	"github.com/trento-project/agent/v3/internal/factsengine/factscache"
 	"github.com/trento-project/agent/v3/internal/factsengine/gatherers"
 	"github.com/trento-project/agent/v3/pkg/factsengine/entities"
-
-	sapcontrol "github.com/trento-project/agent/v3/internal/core/sapsystem/sapcontrolapi"
-	sapControlMocks "github.com/trento-project/agent/v3/internal/core/sapsystem/sapcontrolapi/mocks"
 )
 
 type SapControlGathererSuite struct {
@@ -33,7 +32,7 @@ func TestSapControlGathererSuite(t *testing.T) {
 
 func (suite *SapControlGathererSuite) SetupSuite() {
 	testFS := afero.NewMemMapFs()
-	err := testFS.MkdirAll("/usr/sap/PRD/ASCS00", 0644)
+	err := testFS.MkdirAll("/usr/sap/PRD/ASCS00", 0o644)
 	suite.Require().NoError(err)
 
 	suite.testFS = testFS
@@ -230,13 +229,13 @@ func (suite *SapControlGathererSuite) TestSapControlGathererCacheHit() {
 func (suite *SapControlGathererSuite) TestSapControlGathererMultipleInstances() {
 	ctx := context.Background()
 	testFS := afero.NewMemMapFs()
-	err := testFS.MkdirAll("/usr/sap/PRD/ASCS00", 0644)
+	err := testFS.MkdirAll("/usr/sap/PRD/ASCS00", 0o644)
 	suite.Require().NoError(err)
-	err = testFS.MkdirAll("/usr/sap/PRD/ERS10", 0644)
+	err = testFS.MkdirAll("/usr/sap/PRD/ERS10", 0o644)
 	suite.Require().NoError(err)
-	err = testFS.MkdirAll("/usr/sap/QAS/D01", 0644)
+	err = testFS.MkdirAll("/usr/sap/QAS/D01", 0o644)
 	suite.Require().NoError(err)
-	err = testFS.MkdirAll("/usr/sap/QAS/D02", 0644)
+	err = testFS.MkdirAll("/usr/sap/QAS/D02", 0o644)
 	suite.Require().NoError(err)
 
 	mockWebService := new(sapControlMocks.MockWebService)

--- a/internal/factsengine/gatherers/sapinstancehostnameresolver.go
+++ b/internal/factsengine/gatherers/sapinstancehostnameresolver.go
@@ -67,7 +67,7 @@ type Resolver struct{}
 type Pinger struct{}
 
 func (r *Resolver) LookupHost(host string) ([]string, error) {
-	return net.LookupHost(host)
+	return net.LookupHost(host) //nolint:noctx
 }
 
 func (p *Pinger) Ping(host string) bool {
@@ -99,7 +99,8 @@ func NewDefaultSapInstanceHostnameResolverGatherer() *SapInstanceHostnameResolve
 func NewSapInstanceHostnameResolverGatherer(
 	fs afero.Fs,
 	hr HostnameResolver,
-	hp HostPinger) *SapInstanceHostnameResolverGatherer {
+	hp HostPinger,
+) *SapInstanceHostnameResolverGatherer {
 	return &SapInstanceHostnameResolverGatherer{fs: fs, hr: hr, hp: hp}
 }
 

--- a/internal/factsengine/gatherers/sapinstancehostnameresolver_test.go
+++ b/internal/factsengine/gatherers/sapinstancehostnameresolver_test.go
@@ -34,16 +34,16 @@ func (suite *SapInstanceHostnameResolverTestSuite) SetupTest() {
 func (suite *SapInstanceHostnameResolverTestSuite) TestSapInstanceHostnameResolverSuccess() {
 	appFS := afero.NewMemMapFs()
 
-	err := appFS.MkdirAll("/usr/sap/QAS", 0644)
+	err := appFS.MkdirAll("/usr/sap/QAS", 0o644)
 	suite.Require().NoError(err)
-	err = appFS.MkdirAll("/usr/sap/NWP", 0644)
+	err = appFS.MkdirAll("/usr/sap/NWP", 0o644)
 	suite.Require().NoError(err)
 
-	err = afero.WriteFile(appFS, "/sapmnt/QAS/profile/QAS_ASCS00_sapqasas", []byte{}, 0644)
+	err = afero.WriteFile(appFS, "/sapmnt/QAS/profile/QAS_ASCS00_sapqasas", []byte{}, 0o644)
 	suite.Require().NoError(err)
-	err = afero.WriteFile(appFS, "/sapmnt/QAS/profile/QAS_ERS10_sapqaser", []byte{}, 0644)
+	err = afero.WriteFile(appFS, "/sapmnt/QAS/profile/QAS_ERS10_sapqaser", []byte{}, 0o644)
 	suite.Require().NoError(err)
-	err = afero.WriteFile(appFS, "/sapmnt/NWP/profile/NWP_ERS10_sapnwper", []byte{}, 0644)
+	err = afero.WriteFile(appFS, "/sapmnt/NWP/profile/NWP_ERS10_sapnwper", []byte{}, 0o644)
 	suite.Require().NoError(err)
 
 	suite.mockResolver.On("LookupHost", "sapqasas").Return([]string{"10.1.1.5"}, nil)
@@ -125,7 +125,7 @@ func (suite *SapInstanceHostnameResolverTestSuite) TestSapInstanceHostnameResolv
 func (suite *SapInstanceHostnameResolverTestSuite) TestSapInstanceHostnameResolverNoProfiles() {
 	appFS := afero.NewMemMapFs()
 
-	err := appFS.MkdirAll("/usr/sap/QAS", 0644)
+	err := appFS.MkdirAll("/usr/sap/QAS", 0o644)
 	suite.Require().NoError(err)
 
 	g := gatherers.NewSapInstanceHostnameResolverGatherer(appFS, suite.mockResolver, suite.mockPinger)
@@ -138,19 +138,21 @@ func (suite *SapInstanceHostnameResolverTestSuite) TestSapInstanceHostnameResolv
 
 	factResults, err := g.Gather(context.Background(), factRequests)
 	suite.Nil(factResults)
-	suite.Require().EqualError(err, "fact gathering error: sapinstance-hostname-resolver-details-error - error gathering details: open /sapmnt/QAS/profile: file does not exist")
+	suite.Require().
+		EqualError(err, "fact gathering error: sapinstance-hostname-resolver-details-error - error gathering details: open /sapmnt/QAS/profile: file does not exist")
 }
 
 func (suite *SapInstanceHostnameResolverTestSuite) TestSapInstanceHostnameResolverLookupHostError() {
 	appFS := afero.NewMemMapFs()
 
-	err := appFS.MkdirAll("/usr/sap/QAS", 0644)
+	err := appFS.MkdirAll("/usr/sap/QAS", 0o644)
 	suite.Require().NoError(err)
 
-	err = afero.WriteFile(appFS, "/sapmnt/QAS/profile/QAS_ASCS00_sapqasas", []byte{}, 0644)
+	err = afero.WriteFile(appFS, "/sapmnt/QAS/profile/QAS_ASCS00_sapqasas", []byte{}, 0o644)
 	suite.Require().NoError(err)
 
-	suite.mockResolver.On("LookupHost", "sapqasas").Return([]string{}, errors.New("lookup sapqasas on 169.254.169.254:53: dial udp 169.254.169.254:53: connect: no route to host"))
+	suite.mockResolver.On("LookupHost", "sapqasas").
+		Return([]string{}, errors.New("lookup sapqasas on 169.254.169.254:53: dial udp 169.254.169.254:53: connect: no route to host"))
 	suite.mockPinger.On("Ping", "sapqasas").Return(false, nil)
 
 	g := gatherers.NewSapInstanceHostnameResolverGatherer(appFS, suite.mockResolver, suite.mockPinger)

--- a/internal/factsengine/gatherers/sapprofiles_test.go
+++ b/internal/factsengine/gatherers/sapprofiles_test.go
@@ -27,30 +27,30 @@ func TestSapProfilesTestSuite(t *testing.T) {
 func (suite *SapProfilesTestSuite) TestSapProfilesSuccess() {
 	appFS := afero.NewMemMapFs()
 
-	err := appFS.MkdirAll("/usr/sap/PRD", 0644)
+	err := appFS.MkdirAll("/usr/sap/PRD", 0o644)
 	suite.Require().NoError(err)
-	err = appFS.MkdirAll("/usr/sap/QAS", 0644)
+	err = appFS.MkdirAll("/usr/sap/QAS", 0o644)
 	suite.Require().NoError(err)
 
 	defaultProfileFile, _ := os.Open(helpers.GetFixturePath("gatherers/sap_profile.default"))
 	defaultProfileContent, _ := io.ReadAll(defaultProfileFile)
-	err = afero.WriteFile(appFS, "/sapmnt/PRD/profile/DEFAULT.PFL", defaultProfileContent, 0644)
+	err = afero.WriteFile(appFS, "/sapmnt/PRD/profile/DEFAULT.PFL", defaultProfileContent, 0o644)
 	suite.Require().NoError(err)
-	err = afero.WriteFile(appFS, "/sapmnt/PRD/profile/DEFAULT.1.PFL", []byte{}, 0644)
+	err = afero.WriteFile(appFS, "/sapmnt/PRD/profile/DEFAULT.1.PFL", []byte{}, 0o644)
 	suite.Require().NoError(err)
 
 	ascsProfileFile, _ := os.Open(helpers.GetFixturePath("gatherers/sap_profile.ascs"))
 	ascsProfileContent, _ := io.ReadAll(ascsProfileFile)
-	err = afero.WriteFile(appFS, "/sapmnt/QAS/profile/QAS_ASCS00_sapqasas", ascsProfileContent, 0644)
+	err = afero.WriteFile(appFS, "/sapmnt/QAS/profile/QAS_ASCS00_sapqasas", ascsProfileContent, 0o644)
 	suite.Require().NoError(err)
-	err = afero.WriteFile(appFS, "/sapmnt/QAS/profile/QAS_ASCS00_sapqasas.1", []byte{}, 0644)
+	err = afero.WriteFile(appFS, "/sapmnt/QAS/profile/QAS_ASCS00_sapqasas.1", []byte{}, 0o644)
 	suite.Require().NoError(err)
-	err = afero.WriteFile(appFS, "/sapmnt/QAS/profile/QAS_ASCS00_sapqasas.bak", []byte{}, 0644)
+	err = afero.WriteFile(appFS, "/sapmnt/QAS/profile/QAS_ASCS00_sapqasas.bak", []byte{}, 0o644)
 	suite.Require().NoError(err)
 
 	minimalProfileFile, _ := os.Open(helpers.GetFixturePath("gatherers/sap_profile.minimal"))
 	minimalProfileContent, _ := io.ReadAll(minimalProfileFile)
-	err = afero.WriteFile(appFS, "/sapmnt/QAS/profile/DEFAULT.PFL", minimalProfileContent, 0644)
+	err = afero.WriteFile(appFS, "/sapmnt/QAS/profile/DEFAULT.PFL", minimalProfileContent, 0o644)
 	suite.Require().NoError(err)
 
 	gatherer := gatherers.NewSapProfilesGatherer(appFS)
@@ -342,10 +342,10 @@ func (suite *SapProfilesTestSuite) TestSapProfilesSuccess() {
 func (suite *SapProfilesTestSuite) TestSapProfilesNoProfiles() {
 	appFS := afero.NewMemMapFs()
 
-	err := appFS.MkdirAll("/usr/sap/PRD", 0644)
+	err := appFS.MkdirAll("/usr/sap/PRD", 0o644)
 	suite.Require().NoError(err)
 
-	err = appFS.MkdirAll("/sapmnt/PRD/profile", 0755)
+	err = appFS.MkdirAll("/sapmnt/PRD/profile", 0o755)
 	suite.Require().NoError(err)
 
 	gatherer := gatherers.NewSapProfilesGatherer(appFS)
@@ -382,12 +382,12 @@ func (suite *SapProfilesTestSuite) TestSapProfilesNoProfiles() {
 func (suite *SapProfilesTestSuite) TestSapProfilesMalformedProfile() {
 	appFS := afero.NewMemMapFs()
 
-	err := appFS.MkdirAll("/usr/sap/PRD", 0644)
+	err := appFS.MkdirAll("/usr/sap/PRD", 0o644)
 	suite.Require().NoError(err)
 
 	// Lines without a '=' separator are ignored on a best-effort basis, so a
 	// malformed profile yields an empty content map rather than an error.
-	err = afero.WriteFile(appFS, "/sapmnt/PRD/profile/DEFAULT.PFL", []byte("invalid"), 0644)
+	err = afero.WriteFile(appFS, "/sapmnt/PRD/profile/DEFAULT.PFL", []byte("invalid"), 0o644)
 	suite.Require().NoError(err)
 
 	gatherer := gatherers.NewSapProfilesGatherer(appFS)
@@ -431,7 +431,7 @@ func (suite *SapProfilesTestSuite) TestSapProfilesMalformedProfile() {
 	}
 
 	results, err := gatherer.Gather(context.Background(), fr)
-	suite.NoError(err)
+	suite.Require().NoError(err)
 	suite.Equal(expectedFacts, results)
 }
 

--- a/internal/factsengine/gatherers/sapservices.go
+++ b/internal/factsengine/gatherers/sapservices.go
@@ -7,10 +7,9 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"log/slog"
 	"regexp"
 	"strings"
-
-	"log/slog"
 
 	"github.com/spf13/afero"
 	"github.com/trento-project/agent/v3/pkg/factsengine/entities"

--- a/internal/factsengine/gatherers/sapservices_test.go
+++ b/internal/factsengine/gatherers/sapservices_test.go
@@ -35,7 +35,8 @@ func (s *SapServicesGathererSuite) TestSapServicesGathererFileNotFound() {
 
 	result, err := g.Gather(context.Background(), fr)
 	s.Nil(result)
-	s.Require().EqualError(err, "fact gathering error: sap-services-reading-error - error reading the sapservices file: open /usr/sap/sapservices: file does not exist")
+	s.Require().
+		EqualError(err, "fact gathering error: sap-services-reading-error - error reading the sapservices file: open /usr/sap/sapservices: file does not exist")
 }
 
 func (s *SapServicesGathererSuite) TestSapServicesGathererInstanceNotIdentifiedSystemd() {
@@ -45,7 +46,7 @@ func (s *SapServicesGathererSuite) TestSapServicesGathererInstanceNotIdentifiedS
 limit.descriptors=1048576
 systemctl --no-ask-password start SAPS41_0 
 systemctl --no-ask-password start SAPS41_1
-`), 0777)
+`), 0o777)
 
 	fr := []entities.FactRequest{
 		{
@@ -58,8 +59,10 @@ systemctl --no-ask-password start SAPS41_1
 	g := gatherers.NewSapServicesGatherer("/usr/sap/sapservices", tFs)
 	result, err := g.Gather(context.Background(), fr)
 	s.Nil(result)
-	s.Require().EqualError(err, "fact gathering error: sap-services-parsing-error - error parsing the sapservices file: could not extract values from systemd SAP services entry: systemctl --no-ask-password start SAPS41_0 ")
+	s.Require().
+		EqualError(err, "fact gathering error: sap-services-parsing-error - error parsing the sapservices file: could not extract values from systemd SAP services entry: systemctl --no-ask-password start SAPS41_0 ")
 }
+
 func (s *SapServicesGathererSuite) TestSapServicesGathererSIDNotIdentifiedSystemd() {
 	tFs := afero.NewMemMapFs()
 	_ = afero.WriteFile(tFs, "/usr/sap/sapservices", []byte(`
@@ -67,7 +70,7 @@ func (s *SapServicesGathererSuite) TestSapServicesGathererSIDNotIdentifiedSystem
 limit.descriptors=1048576
 systemctl --no-ask-password start SAPS41_40 
 systemctl --no-ask-password start SADS41_41
-`), 0777)
+`), 0o777)
 
 	fr := []entities.FactRequest{
 		{
@@ -80,7 +83,8 @@ systemctl --no-ask-password start SADS41_41
 	g := gatherers.NewSapServicesGatherer("/usr/sap/sapservices", tFs)
 	result, err := g.Gather(context.Background(), fr)
 	s.Nil(result)
-	s.Require().EqualError(err, "fact gathering error: sap-services-parsing-error - error parsing the sapservices file: could not extract values from systemd SAP services entry: systemctl --no-ask-password start SADS41_41")
+	s.Require().
+		EqualError(err, "fact gathering error: sap-services-parsing-error - error parsing the sapservices file: could not extract values from systemd SAP services entry: systemctl --no-ask-password start SADS41_41")
 }
 
 func (s *SapServicesGathererSuite) TestSapServicesGathererSIDNotIdentifiedSapstart() {
@@ -91,7 +95,7 @@ limit.descriptors=1048576
 LD_LIBRARY_PATH=/usr/sap/HS1/HDB11/exe:$LD_LIBRARY_PATH;export LD_LIBRARY_PATH;/usr/sap/HS1/HDB11/exe/sapstartsrv pf=/usr/sap/HS1/SYS/profile/HS1HDB11_s41db -D -u hs1adm
 LD_LIBRARY_PATH=/usr/sap/S41/ASCS41/exe:$LD_LIBRARY_PATH; export LD_LIBRARY_PATH; /usr/sap/S41/ASCS41/exe/sapstartsrv pf=/usr/sap/S41/SYS/profile/S41_ASCS41_s41app -D -u s41adm
 LD_LIBRARY_PATH=/usr/sap/S41/D40/exe:$LD_LIBRARY_PATH; export LD_LIBRARY_PATH; /usr/sap/S41/D40/exe/sapstartsrv pf=/usr/sap/S41/SYS/profile/S41_D40_s41app -D -u s41adm
-`), 0777)
+`), 0o777)
 
 	fr := []entities.FactRequest{
 		{
@@ -104,7 +108,8 @@ LD_LIBRARY_PATH=/usr/sap/S41/D40/exe:$LD_LIBRARY_PATH; export LD_LIBRARY_PATH; /
 	g := gatherers.NewSapServicesGatherer("/usr/sap/sapservices", tFs)
 	result, err := g.Gather(context.Background(), fr)
 	s.Nil(result)
-	s.Require().EqualError(err, "fact gathering error: sap-services-parsing-error - error parsing the sapservices file: could not extract values from sapstartsrv SAP services entry: LD_LIBRARY_PATH=/usr/sap/HS1/HDB11/exe:$LD_LIBRARY_PATH;export LD_LIBRARY_PATH;/usr/sap/HS1/HDB11/exe/sapstartsrv pf=/usr/sap/HS1/SYS/profile/HS1HDB11_s41db -D -u hs1adm")
+	s.Require().
+		EqualError(err, "fact gathering error: sap-services-parsing-error - error parsing the sapservices file: could not extract values from sapstartsrv SAP services entry: LD_LIBRARY_PATH=/usr/sap/HS1/HDB11/exe:$LD_LIBRARY_PATH;export LD_LIBRARY_PATH;/usr/sap/HS1/HDB11/exe/sapstartsrv pf=/usr/sap/HS1/SYS/profile/HS1HDB11_s41db -D -u hs1adm")
 }
 
 func (s *SapServicesGathererSuite) TestSapServicesGathererInstanceNotIdentifiedSapstart() {
@@ -115,7 +120,7 @@ limit.descriptors=1048576
 LD_LIBRARY_PATH=/usr/sap/HS1/HDB11/exe:$LD_LIBRARY_PATH;export LD_LIBRARY_PATH;/usr/sap/HS1/HDB11/exe/sapstartsrv pf=/usr/sap/HS1/SYS/profile/HS1_HDB1_s41db -D -u hs1adm
 LD_LIBRARY_PATH=/usr/sap/S41/ASCS41/exe:$LD_LIBRARY_PATH; export LD_LIBRARY_PATH; /usr/sap/S41/ASCS41/exe/sapstartsrv pf=/usr/sap/S41/SYS/profile/S41_ASCS41_s41app -D -u s41adm
 LD_LIBRARY_PATH=/usr/sap/S41/D40/exe:$LD_LIBRARY_PATH; export LD_LIBRARY_PATH; /usr/sap/S41/D40/exe/sapstartsrv pf=/usr/sap/S41/SYS/profile/S41_D40_s41app -D -u s41adm
-`), 0777)
+`), 0o777)
 
 	fr := []entities.FactRequest{
 		{
@@ -128,7 +133,8 @@ LD_LIBRARY_PATH=/usr/sap/S41/D40/exe:$LD_LIBRARY_PATH; export LD_LIBRARY_PATH; /
 	g := gatherers.NewSapServicesGatherer("/usr/sap/sapservices", tFs)
 	result, err := g.Gather(context.Background(), fr)
 	s.Nil(result)
-	s.Require().EqualError(err, "fact gathering error: sap-services-parsing-error - error parsing the sapservices file: could not extract values from sapstartsrv SAP services entry: LD_LIBRARY_PATH=/usr/sap/HS1/HDB11/exe:$LD_LIBRARY_PATH;export LD_LIBRARY_PATH;/usr/sap/HS1/HDB11/exe/sapstartsrv pf=/usr/sap/HS1/SYS/profile/HS1_HDB1_s41db -D -u hs1adm")
+	s.Require().
+		EqualError(err, "fact gathering error: sap-services-parsing-error - error parsing the sapservices file: could not extract values from sapstartsrv SAP services entry: LD_LIBRARY_PATH=/usr/sap/HS1/HDB11/exe:$LD_LIBRARY_PATH;export LD_LIBRARY_PATH;/usr/sap/HS1/HDB11/exe/sapstartsrv pf=/usr/sap/HS1/SYS/profile/HS1_HDB1_s41db -D -u hs1adm")
 }
 
 func (s *SapServicesGathererSuite) TestSapServicesGathererSuccessSapstart() {
@@ -138,7 +144,7 @@ func (s *SapServicesGathererSuite) TestSapServicesGathererSuccessSapstart() {
 limit.descriptors=1048576
 LD_LIBRARY_PATH=/usr/sap/HS1/HDB11/exe:$LD_LIBRARY_PATH;export LD_LIBRARY_PATH;/usr/sap/HS1/HDB11/exe/sapstartsrv pf=/usr/sap/HS1/SYS/profile/HS1_HDB11_s41db -D -u hs1adm
 LD_LIBRARY_PATH=/usr/sap/S41/ASCS41/exe:$LD_LIBRARY_PATH; export LD_LIBRARY_PATH; /usr/sap/S41/ASCS41/exe/sapstartsrv pf=/usr/sap/S41/SYS/profile/S41_ASCS41_s41app -D -u s41adm
-`), 0777)
+`), 0o777)
 
 	fr := []entities.FactRequest{
 		{
@@ -159,7 +165,9 @@ LD_LIBRARY_PATH=/usr/sap/S41/ASCS41/exe:$LD_LIBRARY_PATH; export LD_LIBRARY_PATH
 							"sid":         &entities.FactValueString{Value: "HS1"},
 							"kind":        &entities.FactValueString{Value: "sapstartsrv"},
 							"instance_nr": &entities.FactValueString{Value: "11"},
-							"content":     &entities.FactValueString{Value: "LD_LIBRARY_PATH=/usr/sap/HS1/HDB11/exe:$LD_LIBRARY_PATH;export LD_LIBRARY_PATH;/usr/sap/HS1/HDB11/exe/sapstartsrv pf=/usr/sap/HS1/SYS/profile/HS1_HDB11_s41db -D -u hs1adm"},
+							"content": &entities.FactValueString{
+								Value: "LD_LIBRARY_PATH=/usr/sap/HS1/HDB11/exe:$LD_LIBRARY_PATH;export LD_LIBRARY_PATH;/usr/sap/HS1/HDB11/exe/sapstartsrv pf=/usr/sap/HS1/SYS/profile/HS1_HDB11_s41db -D -u hs1adm",
+							},
 						},
 					},
 					&entities.FactValueMap{
@@ -167,7 +175,9 @@ LD_LIBRARY_PATH=/usr/sap/S41/ASCS41/exe:$LD_LIBRARY_PATH; export LD_LIBRARY_PATH
 							"sid":         &entities.FactValueString{Value: "S41"},
 							"kind":        &entities.FactValueString{Value: "sapstartsrv"},
 							"instance_nr": &entities.FactValueString{Value: "41"},
-							"content":     &entities.FactValueString{Value: "LD_LIBRARY_PATH=/usr/sap/S41/ASCS41/exe:$LD_LIBRARY_PATH; export LD_LIBRARY_PATH; /usr/sap/S41/ASCS41/exe/sapstartsrv pf=/usr/sap/S41/SYS/profile/S41_ASCS41_s41app -D -u s41adm"},
+							"content": &entities.FactValueString{
+								Value: "LD_LIBRARY_PATH=/usr/sap/S41/ASCS41/exe:$LD_LIBRARY_PATH; export LD_LIBRARY_PATH; /usr/sap/S41/ASCS41/exe/sapstartsrv pf=/usr/sap/S41/SYS/profile/S41_ASCS41_s41app -D -u s41adm",
+							},
 						},
 					},
 				},
@@ -187,7 +197,7 @@ func (s *SapServicesGathererSuite) TestSapServicesGathererSuccessSystemd() {
 limit.descriptors=1048576
 systemctl --no-ask-password start SAPS41_40
 systemctl --no-ask-password start SAPS42_41
-`), 0777)
+`), 0o777)
 
 	fr := []entities.FactRequest{
 		{
@@ -236,7 +246,7 @@ func (s *SapServicesGathererSuite) TestSapServicesGathererSuccessWithAMiddleComm
 limit.descriptors=1048576
 systemctl --no-ask-password start SAPHA1_10 # sapstartsrv pf=/usr/sap/HA1/SYS/profile/HA1_ERS10_sapha1er
 systemctl --no-ask-password start SAPS42_41
-`), 0777)
+`), 0o777)
 
 	fr := []entities.FactRequest{
 		{

--- a/internal/factsengine/gatherers/saptune_test.go
+++ b/internal/factsengine/gatherers/saptune_test.go
@@ -610,15 +610,21 @@ func (suite *SaptuneTestSuite) TestSaptuneGathererCheck() {
 									},
 									&entities.FactValueMap{
 										Value: map[string]entities.FactValue{
-											"type":        &entities.FactValueString{Value: "WARN"},
-											"text":        &entities.FactValueString{Value: "systemd reports status \"degraded\". Failed units: systemd-vconsole-setup.service "},
-											"remediation": &entities.FactValueString{Value: "Check the cause and reset the state with 'systemctl reset-failed'!"},
+											"type": &entities.FactValueString{Value: "WARN"},
+											"text": &entities.FactValueString{
+												Value: "systemd reports status \"degraded\". Failed units: systemd-vconsole-setup.service ",
+											},
+											"remediation": &entities.FactValueString{
+												Value: "Check the cause and reset the state with 'systemctl reset-failed'!",
+											},
 										},
 									},
 									&entities.FactValueMap{
 										Value: map[string]entities.FactValue{
 											"type": &entities.FactValueString{Value: "NOTE"},
-											"text": &entities.FactValueString{Value: "A degraded systemd system status means, that one or more systemd units failed. The system is still operational! Tuning might not be affected, please run 'saptune verify' for detailed information."},
+											"text": &entities.FactValueString{
+												Value: "A degraded systemd system status means, that one or more systemd units failed. The system is still operational! Tuning might not be affected, please run 'saptune verify' for detailed information.",
+											},
 										},
 									},
 									&entities.FactValueMap{

--- a/internal/factsengine/gatherers/sbddump.go
+++ b/internal/factsengine/gatherers/sbddump.go
@@ -7,10 +7,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"regexp"
 	"strings"
-
-	"log/slog"
 
 	"github.com/trento-project/agent/v3/internal/core/cluster"
 	"github.com/trento-project/agent/v3/pkg/factsengine/entities"
@@ -110,8 +109,9 @@ func loadDevices(sbdConfigFile string) ([]string, error) {
 func getSBDDevicesDumps(
 	ctx context.Context,
 	executor utils.CommandExecutor,
-	configuredDevices []string) (*entities.FactValueMap, error) {
-	var devicesDumps = make(map[string]entities.FactValue)
+	configuredDevices []string,
+) (*entities.FactValueMap, error) {
+	devicesDumps := make(map[string]entities.FactValue)
 
 	for _, device := range configuredDevices {
 		SBDDumpMap, err := getSBDDumpFactValueMap(ctx, executor, device)
@@ -130,7 +130,8 @@ func getSBDDevicesDumps(
 func getSBDDumpFactValueMap(
 	ctx context.Context,
 	executor utils.CommandExecutor,
-	device string) (*entities.FactValueMap, error) {
+	device string,
+) (*entities.FactValueMap, error) {
 	SBDDump, err := executor.OutputContext(ctx, "/usr/sbin/sbd", "-d", device, "dump")
 	if err != nil {
 		return nil, fmt.Errorf("Error while dumping information for device %s: %w", device, err)
@@ -138,7 +139,7 @@ func getSBDDumpFactValueMap(
 
 	SBDDumpMap := utils.FindMatches(`(?m)^(\S+(?: \S+)*)\s*:\s(\S*)$`, SBDDump)
 
-	var deviceDump = make(map[string]entities.FactValue)
+	deviceDump := make(map[string]entities.FactValue)
 
 	for key, value := range SBDDumpMap {
 		key = undesiredParenthesesRegexp.ReplaceAllString(key, "")

--- a/internal/factsengine/gatherers/status.go
+++ b/internal/factsengine/gatherers/status.go
@@ -5,7 +5,6 @@ package gatherers
 
 import (
 	"context"
-
 	"log/slog"
 
 	"github.com/trento-project/agent/v3/internal/version"

--- a/internal/factsengine/gatherers/sudoers.go
+++ b/internal/factsengine/gatherers/sudoers.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 
 	"github.com/spf13/afero"
-
 	"github.com/trento-project/agent/v3/internal/core/sapsystem"
 	"github.com/trento-project/agent/v3/pkg/factsengine/entities"
 	"github.com/trento-project/agent/v3/pkg/utils"

--- a/internal/factsengine/gatherers/sudoers_test.go
+++ b/internal/factsengine/gatherers/sudoers_test.go
@@ -67,7 +67,8 @@ User foo_user may run the following commands on host:
 						"run_as_group": &entities.FactValueString{Value: ""},
 						"no_password":  &entities.FactValueBool{Value: false},
 						"command":      &entities.FactValueString{Value: "ALL"},
-					}},
+					},
+				},
 				&entities.FactValueMap{
 					Value: map[string]entities.FactValue{
 						"user":         &entities.FactValueString{Value: "foo_user"},
@@ -75,7 +76,8 @@ User foo_user may run the following commands on host:
 						"run_as_group": &entities.FactValueString{Value: ""},
 						"no_password":  &entities.FactValueBool{Value: true},
 						"command":      &entities.FactValueString{Value: "/usr/sbin/cmd1 --flag"},
-					}},
+					},
+				},
 				&entities.FactValueMap{
 					Value: map[string]entities.FactValue{
 						"user":         &entities.FactValueString{Value: "foo_user"},
@@ -83,7 +85,8 @@ User foo_user may run the following commands on host:
 						"run_as_group": &entities.FactValueString{Value: ""},
 						"no_password":  &entities.FactValueBool{Value: true},
 						"command":      &entities.FactValueString{Value: "/usr/sbin/cmd2"},
-					}},
+					},
+				},
 				&entities.FactValueMap{
 					Value: map[string]entities.FactValue{
 						"user":         &entities.FactValueString{Value: "foo_user"},
@@ -91,7 +94,8 @@ User foo_user may run the following commands on host:
 						"run_as_group": &entities.FactValueString{Value: "ALL"},
 						"no_password":  &entities.FactValueBool{Value: false},
 						"command":      &entities.FactValueString{Value: "ALL"},
-					}},
+					},
+				},
 			},
 		},
 		factResults[0].Value,
@@ -133,7 +137,8 @@ User foo_user may run the following commands on host:
 						"run_as_group": &entities.FactValueString{Value: ""},
 						"no_password":  &entities.FactValueBool{Value: true},
 						"command":      &entities.FactValueString{Value: "/usr/sbin/cmd1"},
-					}},
+					},
+				},
 			},
 		},
 		factResults[0].Value,
@@ -162,9 +167,9 @@ User baradm may run the following commands on host:
 		Once()
 
 	fs := afero.NewMemMapFs()
-	err := afero.WriteFile(fs, "/usr/sap/FOO/SYS/global/hdb/custom/config/global.ini", []byte("key1=value1"), 0400)
+	err := afero.WriteFile(fs, "/usr/sap/FOO/SYS/global/hdb/custom/config/global.ini", []byte("key1=value1"), 0o400)
 	suite.Require().NoErrorf(err, "error creating content01")
-	err = afero.WriteFile(fs, "/usr/sap/BAR/SYS/global/hdb/custom/config/global.ini", []byte("key1=value1"), 0400)
+	err = afero.WriteFile(fs, "/usr/sap/BAR/SYS/global/hdb/custom/config/global.ini", []byte("key1=value1"), 0o400)
 	suite.Require().NoErrorf(err, "error creating content02")
 
 	c := gatherers.NewSudoersGatherer(suite.mockExecutor, fs)
@@ -192,7 +197,8 @@ User baradm may run the following commands on host:
 						"run_as_group": &entities.FactValueString{Value: ""},
 						"no_password":  &entities.FactValueBool{Value: true},
 						"command":      &entities.FactValueString{Value: "/usr/sbin/cmd1 --flagbar"},
-					}},
+					},
+				},
 				&entities.FactValueMap{
 					Value: map[string]entities.FactValue{
 						"user":         &entities.FactValueString{Value: "baradm"},
@@ -200,7 +206,8 @@ User baradm may run the following commands on host:
 						"run_as_group": &entities.FactValueString{Value: ""},
 						"no_password":  &entities.FactValueBool{Value: true},
 						"command":      &entities.FactValueString{Value: "/usr/sbin/cmd2"},
-					}},
+					},
+				},
 				// expected for user fooadm
 				&entities.FactValueMap{
 					Value: map[string]entities.FactValue{
@@ -209,7 +216,8 @@ User baradm may run the following commands on host:
 						"run_as_group": &entities.FactValueString{Value: ""},
 						"no_password":  &entities.FactValueBool{Value: true},
 						"command":      &entities.FactValueString{Value: "/usr/sbin/cmd1 --flagfoo"},
-					}},
+					},
+				},
 			},
 		},
 		factResults[0].Value,
@@ -261,9 +269,9 @@ User baradm may run the following commands on host:
 		Once()
 
 	fs := afero.NewMemMapFs()
-	err := afero.WriteFile(fs, "/usr/sap/FOO/SYS/global/hdb/custom/config/global.ini", []byte("key1=value1"), 0400)
+	err := afero.WriteFile(fs, "/usr/sap/FOO/SYS/global/hdb/custom/config/global.ini", []byte("key1=value1"), 0o400)
 	suite.Require().NoErrorf(err, "error creating content01")
-	err = afero.WriteFile(fs, "/usr/sap/BAR/SYS/global/hdb/custom/config/global.ini", []byte("key1=value1"), 0400)
+	err = afero.WriteFile(fs, "/usr/sap/BAR/SYS/global/hdb/custom/config/global.ini", []byte("key1=value1"), 0o400)
 	suite.Require().NoErrorf(err, "error creating content02")
 
 	c := gatherers.NewSudoersGatherer(suite.mockExecutor, fs)
@@ -291,7 +299,8 @@ User baradm may run the following commands on host:
 						"run_as_group": &entities.FactValueString{Value: ""},
 						"no_password":  &entities.FactValueBool{Value: true},
 						"command":      &entities.FactValueString{Value: "/usr/sbin/cmd1 --flagbar"},
-					}},
+					},
+				},
 			},
 		},
 		factResults[0].Value,

--- a/internal/factsengine/gatherers/systemd_test.go
+++ b/internal/factsengine/gatherers/systemd_test.go
@@ -12,10 +12,9 @@ import (
 	"github.com/coreos/go-systemd/v22/dbus"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
-	"github.com/trento-project/agent/v3/pkg/factsengine/entities"
-
 	"github.com/trento-project/agent/v3/internal/core/dbus/mocks"
 	"github.com/trento-project/agent/v3/internal/factsengine/gatherers"
+	"github.com/trento-project/agent/v3/pkg/factsengine/entities"
 )
 
 type SystemDTestSuite struct {
@@ -27,6 +26,7 @@ type SystemDTestSuite struct {
 func TestSystemDTestSuite(t *testing.T) {
 	suite.Run(t, new(SystemDTestSuite))
 }
+
 func (suite *SystemDTestSuite) SetupTest() {
 	suite.mockConnector = mocks.NewMockConnector(suite.T())
 }
@@ -197,7 +197,8 @@ func (suite *SystemDTestSuite) TestSystemDContextCancelled() {
 			Name:     "no_argument_fact",
 			Gatherer: "systemd",
 			CheckID:  "check1",
-		}}
+		},
+	}
 
 	factResults, err := gatherer.Gather(ctx, factsRequest)
 
@@ -220,7 +221,8 @@ func (suite *SystemDTestSuite) TestSystemDContextCancelledLongRunning() {
 			Name:     "no_argument_fact",
 			Gatherer: "systemd",
 			CheckID:  "check1",
-		}}
+		},
+	}
 
 	go func() {
 		time.Sleep(1 * time.Millisecond)

--- a/internal/factsengine/gatherers/systemd_v2_test.go
+++ b/internal/factsengine/gatherers/systemd_v2_test.go
@@ -11,10 +11,9 @@ import (
 
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
-	"github.com/trento-project/agent/v3/pkg/factsengine/entities"
-
 	"github.com/trento-project/agent/v3/internal/core/dbus/mocks"
 	"github.com/trento-project/agent/v3/internal/factsengine/gatherers"
+	"github.com/trento-project/agent/v3/pkg/factsengine/entities"
 )
 
 type SystemDV2TestSuite struct {
@@ -225,7 +224,8 @@ func (suite *SystemDTestSuite) TestSystemDV2ContextCancelled() {
 			Name:     "no_argument_fact",
 			Gatherer: "systemd",
 			CheckID:  "check1",
-		}}
+		},
+	}
 
 	factResults, err := gatherer.Gather(ctx, factsRequest)
 
@@ -249,7 +249,8 @@ func (suite *SystemDTestSuite) TestSystemDV2ContextCancelledLongRunning() {
 			Gatherer: "systemd@v2",
 			Argument: "corosync.service",
 			CheckID:  "check1",
-		}}
+		},
+	}
 
 	go func() {
 		time.Sleep(1 * time.Second)

--- a/internal/factsengine/gatherers/verifypassword.go
+++ b/internal/factsengine/gatherers/verifypassword.go
@@ -75,9 +75,7 @@ func NewVerifyPasswordGatherer(executor utils.CommandExecutor) *VerifyPasswordGa
 	}
 }
 
-/*
-This gatherer expects only the username for which the password will be verified.
-*/
+// Gather for VerifyPasswordGatherer expects only the username for which the password will be verified.
 func (g *VerifyPasswordGatherer) Gather(
 	ctx context.Context,
 	factsRequests []entities.FactRequest,

--- a/internal/factsengine/gatherers/xml.go
+++ b/internal/factsengine/gatherers/xml.go
@@ -20,7 +20,8 @@ func init() {
 func parseXMLToFactValueMap(
 	xmlContent []byte,
 	elementsToList map[string]bool,
-	factValueOpts ...entities.FactValueOption) (*entities.FactValueMap, error) {
+	factValueOpts ...entities.FactValueOption,
+) (*entities.FactValueMap, error) {
 	mv, err := mxj.NewMapXml(xmlContent)
 	if err != nil {
 		return nil, err

--- a/internal/factsengine/gathering.go
+++ b/internal/factsengine/gathering.go
@@ -94,7 +94,8 @@ func gatherFacts(
 
 // Group the received facts by gatherer type, so they are executed in the same moment with the same source of truth.
 func groupFactsRequestByGatherer(
-	factsRequest *entities.FactsGatheringRequestedTarget) entities.GroupedByGathererRequestedTarget {
+	factsRequest *entities.FactsGatheringRequestedTarget,
+) entities.GroupedByGathererRequestedTarget {
 	groupedFactsRequest := entities.GroupedByGathererRequestedTarget{
 		FactRequests: make(map[string][]entities.FactRequest),
 	}

--- a/internal/factsengine/mapper_test.go
+++ b/internal/factsengine/mapper_test.go
@@ -8,11 +8,10 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/suite"
-	"google.golang.org/protobuf/types/known/structpb"
-
 	"github.com/trento-project/agent/v3/internal/factsengine"
 	"github.com/trento-project/agent/v3/pkg/factsengine/entities"
 	"github.com/trento-project/contracts/go/pkg/events"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 type MapperTestSuite struct {

--- a/internal/factsengine/policy.go
+++ b/internal/factsengine/policy.go
@@ -83,7 +83,8 @@ func HandleEvent(
 
 func getAgentFacts(
 	agentID string,
-	factsRequest *entities.FactsGatheringRequested) *entities.FactsGatheringRequestedTarget {
+	factsRequest *entities.FactsGatheringRequested,
+) *entities.FactsGatheringRequestedTarget {
 	for _, agentRequests := range factsRequest.Targets {
 		if agentRequests.AgentID == agentID {
 			return &agentRequests

--- a/internal/factsengine/policy_test.go
+++ b/internal/factsengine/policy_test.go
@@ -10,14 +10,13 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
+	"github.com/trento-project/agent/v3/internal/factsengine"
 	"github.com/trento-project/agent/v3/internal/factsengine/gatherers"
 	gathererMocks "github.com/trento-project/agent/v3/internal/factsengine/gatherers/mocks"
 	"github.com/trento-project/agent/v3/internal/messaging/mocks"
 	"github.com/trento-project/agent/v3/pkg/factsengine/entities"
 	"github.com/trento-project/contracts/go/pkg/events"
 	"google.golang.org/protobuf/types/known/structpb"
-
-	"github.com/trento-project/agent/v3/internal/factsengine"
 )
 
 type PolicyTestSuite struct {

--- a/internal/messaging/testsupport/testsupport.go
+++ b/internal/messaging/testsupport/testsupport.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/suite"
-
 	"github.com/trento-project/agent/v3/internal/messaging"
 )
 
@@ -67,7 +66,8 @@ func (s *RabbitMQIntegrationSuite) TearDownTest() {
 		return
 	}
 
-	if err := s.RabbitMQAdapter.Unsubscribe(); err != nil {
+	err := s.RabbitMQAdapter.Unsubscribe()
+	if err != nil {
 		panic(err)
 	}
 }
@@ -90,7 +90,8 @@ func PublishUntilDone(
 	defer ticker.Stop()
 
 	for ctx.Err() == nil {
-		if err := adapter.Publish(routingKey, "", event); err != nil {
+		err := adapter.Publish(routingKey, "", event)
+		if err != nil {
 			slog.Warn(warnMsg, "error", err)
 		}
 

--- a/internal/operations/engine_integration_test.go
+++ b/internal/operations/engine_integration_test.go
@@ -10,13 +10,12 @@ import (
 
 	"github.com/stretchr/testify/suite"
 	"github.com/trento-project/agent/v3/internal/messaging/testsupport"
+	"github.com/trento-project/agent/v3/internal/operations"
 	"github.com/trento-project/agent/v3/internal/operations/operator"
 	operatorMocks "github.com/trento-project/agent/v3/internal/operations/operator/mocks"
 	"github.com/trento-project/contracts/go/pkg/events"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/protobuf/types/known/structpb"
-
-	"github.com/trento-project/agent/v3/internal/operations"
 )
 
 type OperationsIntegrationTestSuite struct {
@@ -62,6 +61,7 @@ func (suite *OperationsIntegrationTestSuite) TestFactsEngineIntegration() {
 	// with a clear error instead of hanging until the outer test timeout.
 	ctx, ctxCancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer ctxCancel()
+
 	g, groupCtx := errgroup.WithContext(ctx)
 
 	mockOperator.On(

--- a/internal/operations/mapper.go
+++ b/internal/operations/mapper.go
@@ -8,10 +8,9 @@ import (
 	"fmt"
 
 	"github.com/google/uuid"
-	"google.golang.org/protobuf/types/known/structpb"
-
 	"github.com/trento-project/agent/v3/internal/operations/operator"
 	"github.com/trento-project/contracts/go/pkg/events"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 const (
@@ -90,6 +89,7 @@ func OperatorExecutionCompletedToEvent(
 		AgentId:     agentID,
 	}
 
+	//nolint:nestif
 	if report.Success != nil {
 		before, beforeFound := report.Success.Diff["before"]
 		if !beforeFound {

--- a/internal/operations/mapper_test.go
+++ b/internal/operations/mapper_test.go
@@ -8,11 +8,10 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/suite"
-	"google.golang.org/protobuf/types/known/structpb"
-
 	"github.com/trento-project/agent/v3/internal/operations"
 	"github.com/trento-project/agent/v3/internal/operations/operator"
 	"github.com/trento-project/contracts/go/pkg/events"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 type MapperTestSuite struct {

--- a/internal/operations/operator/crmclusterstart_v1.go
+++ b/internal/operations/operator/crmclusterstart_v1.go
@@ -74,7 +74,8 @@ func WithCustomRetry(maxRetries int, initialDelay, maxDelay time.Duration, facto
 
 func NewCrmClusterStart(arguments Arguments,
 	operationID string,
-	options Options[CrmClusterStart]) *Executor {
+	options Options[CrmClusterStart],
+) *Executor {
 	crmClusterStart := &CrmClusterStart{
 		baseOperator: newBaseOperator(
 			CrmClusterStartOperatorName, operationID, arguments, options.BaseOperatorOptions...,

--- a/internal/operations/operator/crmclusterstop_v1.go
+++ b/internal/operations/operator/crmclusterstop_v1.go
@@ -74,7 +74,8 @@ func WithCustomRetryStop(maxRetries int, initialDelay, maxDelay time.Duration, f
 
 func NewCrmClusterStop(arguments Arguments,
 	operationID string,
-	options Options[CrmClusterStop]) *Executor {
+	options Options[CrmClusterStop],
+) *Executor {
 	crmClusterStop := &CrmClusterStop{
 		baseOperator: newBaseOperator(
 			CrmClusterStopOperatorName, operationID, arguments, options.BaseOperatorOptions...,

--- a/internal/operations/operator/hostreboot_v1.go
+++ b/internal/operations/operator/hostreboot_v1.go
@@ -84,7 +84,8 @@ func defaultDbusConstructor(ctx context.Context) (dbus.Connector, error) {
 
 func NewHostReboot(arguments Arguments,
 	operationID string,
-	options Options[HostReboot]) *Executor {
+	options Options[HostReboot],
+) *Executor {
 	hostReboot := &HostReboot{
 		baseOperator: newBaseOperator(
 			HostRebootOperatorName, operationID, arguments, options.BaseOperatorOptions...,

--- a/internal/operations/operator/hostreboot_v1_test.go
+++ b/internal/operations/operator/hostreboot_v1_test.go
@@ -9,14 +9,13 @@ import (
 	"log/slog"
 	"testing"
 
+	baseDbus "github.com/coreos/go-systemd/v22/dbus"
 	"github.com/stretchr/testify/suite"
 	"github.com/trento-project/agent/v3/internal/core/dbus"
 	dbusMocks "github.com/trento-project/agent/v3/internal/core/dbus/mocks"
 	"github.com/trento-project/agent/v3/internal/operations/operator"
 	"github.com/trento-project/agent/v3/pkg/utils"
 	utilsMocks "github.com/trento-project/agent/v3/pkg/utils/mocks"
-
-	baseDbus "github.com/coreos/go-systemd/v22/dbus"
 )
 
 type HostRebootOperatorTestSuite struct {

--- a/internal/operations/operator/operator.go
+++ b/internal/operations/operator/operator.go
@@ -9,8 +9,10 @@ import (
 
 type PhaseName string
 
-type Arguments map[string]any
-type Option[T any] func(*T)
+type (
+	Arguments     map[string]any
+	Option[T any] func(*T)
+)
 
 const (
 	PLAN     PhaseName = "PLAN"

--- a/internal/operations/operator/registry.go
+++ b/internal/operations/operator/registry.go
@@ -19,7 +19,7 @@ func (e *NotFoundError) Error() string {
 
 type Builder func(operationID string, arguments Arguments) Operator
 
-// map[operatorName]map[operatorVersion]OperatorBuilder.
+// BuildersTree is map[operatorName]map[operatorVersion]OperatorBuilder.
 type BuildersTree map[string]map[string]Builder
 
 func extractOperatorNameAndVersion(operatorName string) (string, string, error) {

--- a/internal/operations/operator/servicedisable_v1_test.go
+++ b/internal/operations/operator/servicedisable_v1_test.go
@@ -215,7 +215,10 @@ func (suite *ServiceDisableOperatorTestSuite) TestServiceDisableOperatorVerifyEr
 
 	suite.Nil(report.Success)
 	suite.Equal(operator.ROLLBACK, report.Error.ErrorPhase)
-	suite.Equal("verify: failed to check if service pacemaker.service is enabled: error verifying is disabled; rollback: systemd enable error", report.Error.Message)
+	suite.Equal(
+		"verify: failed to check if service pacemaker.service is enabled: error verifying is disabled; rollback: systemd enable error",
+		report.Error.Message,
+	)
 }
 
 func (suite *ServiceDisableOperatorTestSuite) TestServiceDisableOperatorVerifyErrorIsDisabledSuccessfulRollback() {

--- a/internal/operations/operator/serviceenable_v1_test.go
+++ b/internal/operations/operator/serviceenable_v1_test.go
@@ -215,7 +215,10 @@ func (suite *ServiceEnableOperatorTestSuite) TestServiceEnableOperatorVerifyErro
 
 	suite.Nil(report.Success)
 	suite.Equal(operator.ROLLBACK, report.Error.ErrorPhase)
-	suite.Equal("verify: failed to check if service pacemaker.service is enabled: error verifying is enabled; rollback: systemd disable error", report.Error.Message)
+	suite.Equal(
+		"verify: failed to check if service pacemaker.service is enabled: error verifying is enabled; rollback: systemd disable error",
+		report.Error.Message,
+	)
 }
 
 func (suite *ServiceEnableOperatorTestSuite) TestServiceEnableOperatorVerifyErrorIsEnabledSuccessfulRollback() {

--- a/internal/operations/policy.go
+++ b/internal/operations/policy.go
@@ -9,7 +9,6 @@ import (
 	"log/slog"
 
 	"github.com/trento-project/agent/v3/internal/messaging"
-
 	"github.com/trento-project/agent/v3/internal/operations/operator"
 	"github.com/trento-project/contracts/go/pkg/events"
 )

--- a/internal/operations/policy_test.go
+++ b/internal/operations/policy_test.go
@@ -13,12 +13,11 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 	"github.com/trento-project/agent/v3/internal/messaging/mocks"
+	"github.com/trento-project/agent/v3/internal/operations"
 	"github.com/trento-project/agent/v3/internal/operations/operator"
 	operatorMocks "github.com/trento-project/agent/v3/internal/operations/operator/mocks"
 	"github.com/trento-project/contracts/go/pkg/events"
 	"google.golang.org/protobuf/types/known/structpb"
-
-	"github.com/trento-project/agent/v3/internal/operations"
 )
 
 type PolicyTestSuite struct {

--- a/pkg/factsengine/entities/fact_value.go
+++ b/pkg/factsengine/entities/fact_value.go
@@ -225,7 +225,7 @@ func (v *FactValueList) AsInterface() any {
 	return result
 }
 
-// AsInterface converts a FactValueList internal value to an any.
+// AppendValue appends a FactValue to the FactValueList.
 func (v *FactValueList) AppendValue(value FactValue) {
 	v.Value = append(v.Value, value)
 }

--- a/pkg/factsengine/entities/fact_value_test.go
+++ b/pkg/factsengine/entities/fact_value_test.go
@@ -71,11 +71,13 @@ func (suite *FactValueTestSuite) TestNewFactValueWithStringConversion() {
 							&entities.FactValueList{Value: []entities.FactValue{
 								&entities.FactValueFloat{Value: 1.5},
 							}},
-						}},
+						},
+					},
 					"map": &entities.FactValueMap{Value: map[string]entities.FactValue{
 						"int": &entities.FactValueInt{Value: 5},
 					}},
-				}},
+				},
+			},
 			err: nil,
 		},
 		{
@@ -140,11 +142,13 @@ func (suite *FactValueTestSuite) TestNewFactValueWithSnakeCaseKeys() {
 					&entities.FactValueList{Value: []entities.FactValue{
 						&entities.FactValueString{Value: "1.5"},
 					}},
-				}},
+				},
+			},
 			"map": &entities.FactValueMap{Value: map[string]entities.FactValue{
 				"int": &entities.FactValueInt{Value: 5},
 			}},
-		}}
+		},
+	}
 
 	suite.Equal(expected, factValue)
 	suite.Require().NoError(err)
@@ -180,14 +184,18 @@ func (suite *FactValueTestSuite) TestFactValueAsInterface() {
 			description: "FactValueMap AsInterface",
 			factValue: &entities.FactValueMap{
 				Value: map[string]entities.FactValue{
-					"test": &entities.FactValueString{Value: "test"}}},
+					"test": &entities.FactValueString{Value: "test"},
+				},
+			},
 			expected: map[string]any{"test": "test"},
 		},
 		{
 			description: "FactValueList AsInterface",
 			factValue: &entities.FactValueList{
 				Value: []entities.FactValue{
-					&entities.FactValueString{Value: "test"}}},
+					&entities.FactValueString{Value: "test"},
+				},
+			},
 			expected: []any{"test"},
 		},
 	}

--- a/pkg/factsengine/entities/facts_gathered_test.go
+++ b/pkg/factsengine/entities/facts_gathered_test.go
@@ -29,11 +29,13 @@ func (suite *FactsGatheredTestSuite) TestFactPrettify() {
 					&entities.FactValueList{Value: []entities.FactValue{
 						&entities.FactValueFloat{Value: 1.5},
 					}},
-				}},
+				},
+			},
 			"map": &entities.FactValueMap{Value: map[string]entities.FactValue{
 				"int": &entities.FactValueInt{Value: 5},
 			}},
-		}}
+		},
+	}
 
 	fact := entities.Fact{
 		Name:    "fact",
@@ -44,5 +46,8 @@ func (suite *FactsGatheredTestSuite) TestFactPrettify() {
 
 	prettyPrintedOutput, _ := fact.Prettify()
 
-	suite.Equal("Name: fact\nCheck ID: 12345\n\nValue:\n\n#{\n  \"basic\": \"basic\",\n  \"list\": [\n    \"string\",\n    2,\n    [\n      1.5\n    ]\n  ],\n  \"map\": #{\n    \"int\": 5\n  }\n}", prettyPrintedOutput)
+	suite.Equal(
+		"Name: fact\nCheck ID: 12345\n\nValue:\n\n#{\n  \"basic\": \"basic\",\n  \"list\": [\n    \"string\",\n    2,\n    [\n      1.5\n    ]\n  ],\n  \"map\": #{\n    \"int\": 5\n  }\n}",
+		prettyPrintedOutput,
+	)
 }

--- a/pkg/factsengine/plugininterface/interface.go
+++ b/pkg/factsengine/plugininterface/interface.go
@@ -30,8 +30,8 @@ type Gatherer interface {
 	Gather(context context.Context, factsRequests []entities.FactRequest) ([]entities.Fact, error)
 }
 
-// This is the implementation of plugin.Plugin.
-type GathererPlugin struct {
+// GathererPlugin is the implementation of plugin.Plugin.
+type GathererPlugin struct { //nolint:recvcheck
 	// Impl Injection
 	Impl Gatherer
 }

--- a/pkg/factsengine/plugininterface/rpc.go
+++ b/pkg/factsengine/plugininterface/rpc.go
@@ -88,6 +88,7 @@ func (s *GathererRPCServer) ServeGathering(args GatheringArgs, resp *[]entities.
 
 func (s *GathererRPCServer) Cancel(requestID string, _ *[]entities.Fact) (_ error) {
 	s.mu.Lock()
+
 	cancel, ok := s.cancelMap[requestID]
 	if ok {
 		delete(s.cancelMap, requestID)

--- a/pkg/factsengine/plugininterface/rpc_internal_test.go
+++ b/pkg/factsengine/plugininterface/rpc_internal_test.go
@@ -13,9 +13,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"go.uber.org/goleak"
-
 	"github.com/trento-project/agent/v3/pkg/factsengine/entities"
+	"go.uber.org/goleak"
 )
 
 // slowGatherer blocks until its context is cancelled, mimicking a long-running gathering
@@ -29,6 +28,7 @@ func (slowGatherer) Gather(ctx context.Context, _ []entities.FactRequest) ([]ent
 	case <-ctx.Done():
 	case <-time.After(500 * time.Millisecond):
 	}
+
 	return nil, ctx.Err()
 }
 
@@ -43,6 +43,7 @@ func TestRequestGatheringCancellationDoesNotLeakGoroutine(t *testing.T) {
 	require.NoError(t, server.RegisterName("Plugin", &GathererRPCServer{Impl: slowGatherer{}}))
 
 	serverDone := make(chan struct{})
+
 	go func() {
 		server.ServeConn(serverConn)
 		close(serverDone)
@@ -52,6 +53,7 @@ func TestRequestGatheringCancellationDoesNotLeakGoroutine(t *testing.T) {
 	g := &GathererRPC{client: rpcClient}
 
 	ctx, cancel := context.WithCancel(context.Background())
+
 	go func() {
 		time.Sleep(50 * time.Millisecond)
 		cancel()
@@ -72,13 +74,15 @@ func TestRequestGatheringCancellationDoesNotLeakGoroutine(t *testing.T) {
 	// goroutine (e.g. via require.Eventually) would make that polling goroutine itself show up
 	// as "unexpected", so retry it directly in this goroutine instead.
 	var leakErr error
-	for i := 0; i < 20; i++ {
+	for range 20 {
 		leakErr = goleak.Find()
 		if leakErr == nil {
 			break
 		}
+
 		time.Sleep(50 * time.Millisecond)
 	}
+
 	require.NoError(t, leakErr, "background RPC call goroutine leaked after context cancellation")
 }
 
@@ -90,22 +94,29 @@ func TestGathererRPCServerCancelMapConcurrentAccessIsSynchronized(t *testing.T) 
 	server := &GathererRPCServer{Impl: slowGatherer{}}
 
 	const requests = 50
+
 	var wg sync.WaitGroup
+
 	wg.Add(requests * 2)
 
-	for i := 0; i < requests; i++ {
+	for i := range requests {
 		requestID := fmt.Sprintf("req-%d", i)
 
 		go func() {
 			defer wg.Done()
+
 			var resp []entities.Fact
+
 			_ = server.ServeGathering(GatheringArgs{RequestID: requestID}, &resp)
 		}()
 
 		go func() {
 			defer wg.Done()
+
 			time.Sleep(time.Millisecond)
+
 			var resp []entities.Fact
+
 			_ = server.Cancel(requestID, &resp)
 		}()
 	}

--- a/pkg/utils/commandexecutor.go
+++ b/pkg/utils/commandexecutor.go
@@ -22,7 +22,7 @@ type CommandExecutor interface {
 type Executor struct{}
 
 func (e Executor) Output(name string, arg ...string) ([]byte, error) {
-	cmd := exec.Command(name, arg...)
+	cmd := exec.Command(name, arg...) //nolint:noctx
 	cmd.Env = os.Environ()
 	cmd.Env = append(cmd.Env, "LC_ALL=C")
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -22,12 +22,13 @@ func FindMatches(pattern string, text []byte) map[string]any {
 
 	values := r.FindAllStringSubmatch(string(text), -1)
 	for _, match := range values {
-		key := strings.Replace(match[1], " ", "_", -1) //nolint:gocritic
+		key := strings.ReplaceAll(match[1], " ", "_")
 		if _, ok := configMap[key]; ok {
 			switch configMap[key].(type) { //nolint:gocritic
 			case string:
 				configMap[key] = []any{configMap[key]}
 			}
+
 			configMap[key] = append(configMap[key].([]any), match[2]) //nolint:forcetypeassert
 		} else {
 			configMap[key] = match[2]

--- a/plugin_examples/dummy/dummy.go
+++ b/plugin_examples/dummy/dummy.go
@@ -18,8 +18,7 @@ import (
 	"github.com/trento-project/agent/v3/pkg/factsengine/plugininterface"
 )
 
-type dummyGatherer struct {
-}
+type dummyGatherer struct{}
 
 func (s dummyGatherer) Gather(_ context.Context, factsRequests []entities.FactRequest) ([]entities.Fact, error) {
 	facts := make([]entities.Fact, 0, len(factsRequests))
@@ -54,7 +53,7 @@ func main() {
 		MagicCookieValue: "gatherer",
 	}
 
-	var pluginMap = map[string]plugin.Plugin{
+	pluginMap := map[string]plugin.Plugin{
 		"gatherer": &plugininterface.GathererPlugin{Impl: d},
 	}
 

--- a/plugin_examples/sleep/sleep.go
+++ b/plugin_examples/sleep/sleep.go
@@ -7,18 +7,16 @@ package main
 
 import (
 	"context"
+	"log/slog"
 	"os/exec"
 	"sync"
-
-	"log/slog"
 
 	"github.com/hashicorp/go-plugin"
 	"github.com/trento-project/agent/v3/pkg/factsengine/entities"
 	"github.com/trento-project/agent/v3/pkg/factsengine/plugininterface"
 )
 
-type sleepGatherer struct {
-}
+type sleepGatherer struct{}
 
 func (s sleepGatherer) Gather(ctx context.Context, factsRequests []entities.FactRequest) ([]entities.Fact, error) {
 	facts := make([]entities.Fact, 0, len(factsRequests))
@@ -64,7 +62,7 @@ func main() {
 		MagicCookieValue: "gatherer",
 	}
 
-	var pluginMap = map[string]plugin.Plugin{
+	pluginMap := map[string]plugin.Plugin{
 		"gatherer": &plugininterface.GathererPlugin{Impl: d},
 	}
 

--- a/test/helpers/filesystem.go
+++ b/test/helpers/filesystem.go
@@ -18,7 +18,7 @@ const (
 func MockMachineIDFile() afero.Fs {
 	fileSystem := afero.NewMemMapFs()
 
-	err := afero.WriteFile(fileSystem, machineIDPath, []byte(DummyMachineID), 0644)
+	err := afero.WriteFile(fileSystem, machineIDPath, []byte(DummyMachineID), 0o644)
 	if err != nil {
 		panic(err)
 	}

--- a/test/helpers/http.go
+++ b/test/helpers/http.go
@@ -23,7 +23,7 @@ import "net/http"
 //	}
 type RoundTripFunc func(req *http.Request) *http.Response
 
-// RoundTrip for RoundTripFunc implements the RoundTripper interface.
+// RoundTrip implements the http.RoundTripper interface for RoundTripFunc.
 func (f RoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return f(req), nil
 }

--- a/test/helpers/http.go
+++ b/test/helpers/http.go
@@ -23,7 +23,7 @@ import "net/http"
 //	}
 type RoundTripFunc func(req *http.Request) *http.Response
 
-// RoundTripFunc implements the RoundTripper interface.
+// RoundTrip for RoundTripFunc implements the RoundTripper interface.
 func (f RoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return f(req), nil
 }


### PR DESCRIPTION
### Description

This pull request runs the linter (with `--fix`) with stricter rules. It also tries to fix minor issues during the merge process of the previous PRs fixing linter issues.

* Updated test assertions in multiple test files to use `suite.Require().NoError(err)` and more expressive assertion methods like `suite.Len` and `suite.Empty` for improved test clarity and failure messages.
* Reordered struct tags in `internal/core/cluster/cib/data.go` to place the `json` tag before the `xml` tag for consistency and clarity. 
* Minor variable declaration style changes (e.g., changing `var x = ...` to `x := ...`) for idiomatic Go code.
* Added or moved `nolint` comments for context and security linting, and improved import ordering for clarity. 
* Added blank lines for readability and consistency in signal handling setup in command files. [[
* Improved formatting of multi-line `fmt.Printf` calls for better readability. 
* Clarified and updated comments in test files.
* Improved error handling by separating variable assignment from conditional checks.

These changes collectively enhance code maintainability, readability, and test reliability.

Related [TRNT-4574](https://jira.suse.com/browse/TRNT-4574)

### How was this tested?

UT

### Documentation changes

No

### Additional information
