### PR TITLE
Improve support for ppc64le

### DIFF
--- a/internal/core/cloud/metadata.go
+++ b/internal/core/cloud/metadata.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os/exec"
 	"regexp"
 	"strings"
@@ -166,7 +167,7 @@ func (i *Identifier) IdentifyCloudProvider() (string, error) {
 	for _, provider := range providers {
 		result, err := provider.identifyFn()
 		if err != nil {
-			if errors.Is(err, exec.ErrNotFound) {
+			if errors.Is(err, exec.ErrNotFound) || errors.Is(err, fs.ErrNotExist) {
 				slog.Debug("Provider identification tool not available, skipping", "provider", provider.name, "error", err)
 			} else {
 				slog.Warn("Could not run provider identification, skipping", "provider", provider.name, "error", err)

--- a/internal/core/cloud/metadata.go
+++ b/internal/core/cloud/metadata.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"log/slog"
 	"os/exec"
 	"regexp"
 	"strings"

--- a/internal/core/cloud/metadata.go
+++ b/internal/core/cloud/metadata.go
@@ -5,6 +5,9 @@ package cloud
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"os/exec"
 	"regexp"
 	"strings"
 
@@ -158,10 +161,19 @@ func (i *Identifier) IdentifyCloudProvider() (string, error) {
 		{identifyFn: i.identifyVMware, name: VMware},
 	}
 
+	var unexpectedErrs []error
+
 	for _, provider := range providers {
 		result, err := provider.identifyFn()
 		if err != nil {
-			return "", err
+			if errors.Is(err, exec.ErrNotFound) {
+				slog.Debug("Provider identification tool not available, skipping", "provider", provider.name, "error", err)
+			} else {
+				slog.Warn("Could not run provider identification, skipping", "provider", provider.name, "error", err)
+				unexpectedErrs = append(unexpectedErrs, fmt.Errorf("%s: %w", provider.name, err))
+			}
+
+			continue
 		}
 
 		if result {
@@ -172,6 +184,10 @@ func (i *Identifier) IdentifyCloudProvider() (string, error) {
 	}
 
 	slog.Info("The system is not running in any recognized cloud provider")
+
+	if len(unexpectedErrs) > 0 {
+		return "", errors.Join(unexpectedErrs...)
+	}
 
 	return "", nil
 }

--- a/internal/core/cloud/metadata_test.go
+++ b/internal/core/cloud/metadata_test.go
@@ -7,8 +7,8 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"io/fs"
 	"net/http"
-	"os/exec"
 	"testing"
 
 	"errors"
@@ -100,18 +100,22 @@ func (suite *CloudMetadataTestSuite) TestIdentifyCloudProviderErr() {
 	suite.Require().ErrorContains(err, "permission denied")
 }
 
+func notExistErr(path string) error {
+	return &fs.PathError{Op: "fork/exec", Path: path, Err: fs.ErrNotExist}
+}
+
 func (suite *CloudMetadataTestSuite) TestIdentifyCloudProviderMissingDmidecode() {
 	suite.mockExecutor.
 		On("Output", "/usr/sbin/dmidecode", "-s", "chassis-asset-tag").
-		Return(nil, &exec.Error{Name: "dmidecode", Err: exec.ErrNotFound}).
+		Return(nil, notExistErr("/usr/sbin/dmidecode")).
 		On("Output", "/usr/sbin/dmidecode", "-s", "system-version").
-		Return(nil, &exec.Error{Name: "dmidecode", Err: exec.ErrNotFound}).
+		Return(nil, notExistErr("/usr/sbin/dmidecode")).
 		On("Output", "/usr/sbin/dmidecode", "-s", "system-manufacturer").
-		Return(nil, &exec.Error{Name: "dmidecode", Err: exec.ErrNotFound}).
+		Return(nil, notExistErr("/usr/sbin/dmidecode")).
 		On("Output", "/usr/sbin/dmidecode", "-s", "bios-vendor").
-		Return(nil, &exec.Error{Name: "dmidecode", Err: exec.ErrNotFound}).
+		Return(nil, notExistErr("/usr/sbin/dmidecode")).
 		On("Output", "/usr/sbin/dmidecode").
-		Return(nil, &exec.Error{Name: "dmidecode", Err: exec.ErrNotFound}).
+		Return(nil, notExistErr("/usr/sbin/dmidecode")).
 		On("Output", "/usr/bin/systemd-detect-virt").
 		Return(systemdDetectVirtKVM(), nil)
 

--- a/internal/core/cloud/metadata_test.go
+++ b/internal/core/cloud/metadata_test.go
@@ -100,22 +100,18 @@ func (suite *CloudMetadataTestSuite) TestIdentifyCloudProviderErr() {
 	suite.Require().ErrorContains(err, "permission denied")
 }
 
-func notExistErr(path string) error {
-	return &fs.PathError{Op: "fork/exec", Path: path, Err: fs.ErrNotExist}
-}
-
 func (suite *CloudMetadataTestSuite) TestIdentifyCloudProviderMissingDmidecode() {
 	suite.mockExecutor.
 		On("Output", "/usr/sbin/dmidecode", "-s", "chassis-asset-tag").
-		Return(nil, notExistErr("/usr/sbin/dmidecode")).
+		Return(nil, &fs.PathError{Op: "fork/exec", Path: "/usr/sbin/dmidecode", Err: fs.ErrNotExist}).
 		On("Output", "/usr/sbin/dmidecode", "-s", "system-version").
-		Return(nil, notExistErr("/usr/sbin/dmidecode")).
+		Return(nil, &fs.PathError{Op: "fork/exec", Path: "/usr/sbin/dmidecode", Err: fs.ErrNotExist}).
 		On("Output", "/usr/sbin/dmidecode", "-s", "system-manufacturer").
-		Return(nil, notExistErr("/usr/sbin/dmidecode")).
+		Return(nil, &fs.PathError{Op: "fork/exec", Path: "/usr/sbin/dmidecode", Err: fs.ErrNotExist}).
 		On("Output", "/usr/sbin/dmidecode", "-s", "bios-vendor").
-		Return(nil, notExistErr("/usr/sbin/dmidecode")).
+		Return(nil, &fs.PathError{Op: "fork/exec", Path: "/usr/sbin/dmidecode", Err: fs.ErrNotExist}).
 		On("Output", "/usr/sbin/dmidecode").
-		Return(nil, notExistErr("/usr/sbin/dmidecode")).
+		Return(nil, &fs.PathError{Op: "fork/exec", Path: "/usr/sbin/dmidecode", Err: fs.ErrNotExist}).
 		On("Output", "/usr/bin/systemd-detect-virt").
 		Return(systemdDetectVirtKVM(), nil)
 

--- a/internal/core/cloud/metadata_test.go
+++ b/internal/core/cloud/metadata_test.go
@@ -8,9 +8,11 @@ import (
 	"context"
 	"io"
 	"net/http"
+	"os/exec"
 	"testing"
 
 	"errors"
+
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 	"github.com/trento-project/agent/v3/internal/core/cloud"
@@ -78,14 +80,47 @@ func dmidecodeEmpty() []byte {
 func (suite *CloudMetadataTestSuite) TestIdentifyCloudProviderErr() {
 	suite.mockExecutor.
 		On("Output", "/usr/sbin/dmidecode", "-s", "chassis-asset-tag").
-		Return(nil, errors.New("error"))
+		Return(nil, errors.New("exit status 1: permission denied")).
+		On("Output", "/usr/sbin/dmidecode", "-s", "system-version").
+		Return(dmidecodeEmpty(), nil).
+		On("Output", "/usr/sbin/dmidecode", "-s", "system-manufacturer").
+		Return(dmidecodeEmpty(), nil).
+		On("Output", "/usr/sbin/dmidecode", "-s", "bios-vendor").
+		Return(dmidecodeEmpty(), nil).
+		On("Output", "/usr/sbin/dmidecode").
+		Return(dmidecodeEmpty(), nil).
+		On("Output", "/usr/bin/systemd-detect-virt").
+		Return(systemdDetectVirtEmpty(), nil)
 
 	cIdentifier := cloud.NewIdentifier(suite.mockExecutor)
 
 	provider, err := cIdentifier.IdentifyCloudProvider()
 
 	suite.Empty(provider)
-	suite.Require().EqualError(err, "error")
+	suite.Require().ErrorContains(err, "permission denied")
+}
+
+func (suite *CloudMetadataTestSuite) TestIdentifyCloudProviderMissingDmidecode() {
+	suite.mockExecutor.
+		On("Output", "/usr/sbin/dmidecode", "-s", "chassis-asset-tag").
+		Return(nil, &exec.Error{Name: "dmidecode", Err: exec.ErrNotFound}).
+		On("Output", "/usr/sbin/dmidecode", "-s", "system-version").
+		Return(nil, &exec.Error{Name: "dmidecode", Err: exec.ErrNotFound}).
+		On("Output", "/usr/sbin/dmidecode", "-s", "system-manufacturer").
+		Return(nil, &exec.Error{Name: "dmidecode", Err: exec.ErrNotFound}).
+		On("Output", "/usr/sbin/dmidecode", "-s", "bios-vendor").
+		Return(nil, &exec.Error{Name: "dmidecode", Err: exec.ErrNotFound}).
+		On("Output", "/usr/sbin/dmidecode").
+		Return(nil, &exec.Error{Name: "dmidecode", Err: exec.ErrNotFound}).
+		On("Output", "/usr/bin/systemd-detect-virt").
+		Return(systemdDetectVirtKVM(), nil)
+
+	cIdentifier := cloud.NewIdentifier(suite.mockExecutor)
+
+	provider, err := cIdentifier.IdentifyCloudProvider()
+
+	suite.Equal("kvm", provider)
+	suite.Require().NoError(err)
 }
 
 func (suite *CloudMetadataTestSuite) TestIdentifyCloudProviderAzure() {

--- a/internal/discovery/host.go
+++ b/internal/discovery/host.go
@@ -217,12 +217,18 @@ func getLogicalCPUs() int {
 	return logical
 }
 
-var cpuInfo = cpu.Info
+var cpuInfo = cpu.Info //nolint:gochecknoglobals
 
 func getCPUSocketCount() int {
 	info, err := cpuInfo()
 	if err != nil {
 		slog.Error("Error while getting CPU info", "error", err)
+
+		return 0
+	}
+
+	if len(info) == 0 {
+		slog.Error("No CPU info retrieved")
 
 		return 0
 	}

--- a/internal/discovery/host.go
+++ b/internal/discovery/host.go
@@ -217,8 +217,10 @@ func getLogicalCPUs() int {
 	return logical
 }
 
+var cpuInfo = cpu.Info
+
 func getCPUSocketCount() int {
-	info, err := cpu.Info()
+	info, err := cpuInfo()
 	if err != nil {
 		slog.Error("Error while getting CPU info", "error", err)
 
@@ -227,6 +229,13 @@ func getCPUSocketCount() int {
 
 	// Get the last CPU info and get the physical ID of it
 	lastCPUInfo := info[len(info)-1]
+
+	if lastCPUInfo.PhysicalID == "" {
+		// Some platforms (e.g. ppc64le) don't report a physical id in /proc/cpuinfo
+		slog.Debug("CPU socket count not reported by this platform")
+
+		return 0
+	}
 
 	physicalID, err := strconv.Atoi(lastCPUInfo.PhysicalID)
 	if err != nil {

--- a/internal/discovery/host_internal_test.go
+++ b/internal/discovery/host_internal_test.go
@@ -4,8 +4,10 @@
 package discovery
 
 import (
+	"errors"
 	"testing"
 
+	"github.com/shirou/gopsutil/cpu"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -54,4 +56,34 @@ func (suite *HostInternalTestSuite) TestHostLastBootTime() {
 	lastBootTimestamp := getLastBootTimestamp()
 	suite.NotNil(lastBootTimestamp)
 	suite.Less(lastBootTimestamp.Unix(), int64(9999999999))
+}
+
+func (suite *HostInternalTestSuite) TestGetCPUSocketCount() {
+	cpuInfo = func() ([]cpu.InfoStat, error) {
+		return []cpu.InfoStat{{PhysicalID: "0"}, {PhysicalID: "1"}}, nil
+	}
+
+	suite.Equal(2, getCPUSocketCount())
+}
+
+// TestGetCPUSocketCountMissingPhysicalID covers platforms such as ppc64le,
+// whose /proc/cpuinfo does not report a "physical id" field.
+func (suite *HostInternalTestSuite) TestGetCPUSocketCountMissingPhysicalID() {
+	cpuInfo = func() ([]cpu.InfoStat, error) {
+		return []cpu.InfoStat{{PhysicalID: ""}}, nil
+	}
+
+	suite.Equal(0, getCPUSocketCount())
+}
+
+func (suite *HostInternalTestSuite) TestGetCPUSocketCountError() {
+	cpuInfo = func() ([]cpu.InfoStat, error) {
+		return nil, errors.New("boom")
+	}
+
+	suite.Equal(0, getCPUSocketCount())
+}
+
+func (suite *HostInternalTestSuite) TearDownTest() {
+	cpuInfo = cpu.Info
 }


### PR DESCRIPTION
### Description

This pull request improves error handling in the cloud provider identification logic and the CPU socket count detection, specifically for PowerPC architectures, where some binaries (like `dmidecode` are not found).

For instance, in #402, dmidecode (used for cloud/hypervisor detection) and the physical id field in /proc/cpuinfo (used for CPU socket count) are both x86/SMBIOS-specific and don't exist on Power hardware. The agent wasn't handling either gracefully.

So, `IdentifyCloudProvider()` was aborting the entire provider-detection loop the moment any single check (e.g. Azure via `dmidecode`) errored... and it never even let KVM/VMware detection (which uses `systemd-detect-virt`, unaffected by this) run.

Besides, `getCPUSocketCount()` was logging an error because ppc64le's `/proc/cpuinfo` has no physical id field, so `strconv.Atoi("") `always failed.

The main changes are:

* The `IdentifyCloudProvider` function in `metadata.go` now distinguishes between missing identification tools (like `dmidecode`) and other errors, skipping providers when the tool is missing and aggregating unexpected errors to return at the end.
* Logging has been added to clarify when a provider is skipped due to a missing tool or an error.
* The CPU socket count logic in `host.go` now handles platforms where the `PhysicalID` field is missing (such as ppc64le), returning 0 and logging a debug message instead of failing.

Fixes  #402 
Fixes #TRNT-4373

### How was this tested?

UT, ~I'd like to test it IRL, though.~ I did a quick test on a real machine and it worked.

### Documentation changes

No

### Additional information

N/A